### PR TITLE
fix(ui): add global border-color reset to app.css

### DIFF
--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -8,6 +8,14 @@
  */
 
 @layer base {
+  /* Global border-color reset — ensures Tailwind border utilities
+   * (border-r, border-t, etc.) use the theme color instead of currentColor */
+  *,
+  ::after,
+  ::before {
+    border-color: var(--border);
+  }
+
   :root {
     --radius: 0.5rem;
     --background: oklch(0.98 0.002 264);


### PR DESCRIPTION
Without this reset, Tailwind's border utilities (border-r, border-t, etc.) default to currentColor (black) instead of the theme's --border variable.

This causes visible black line borders on sidebar separators, card dividers, and any element using border-* utilities without an explicit color class.

The fix adds the standard Shadcn/Tailwind border-color reset inside the existing @layer base block.