### PR TITLE
feat(core): support dark-first theme mode and custom CSS token 

### DIFF
--- a/docs/components/admin-app.md
+++ b/docs/components/admin-app.md
@@ -48,6 +48,7 @@ import { AdminApp } from '@svadmin/ui';
 | `resources` | `ResourceDefinition[]` | ✅ | — | Resource definitions / 资源定义 |
 | `title` | `string` | — | `'Admin'` | App title (shown in sidebar) / 应用标题 |
 | `defaultTheme` | `'light' \| 'dark' \| 'system'` | — | `'system'` | Initial theme / 初始主题 |
+| `themeConfig` | `ThemeConfig` | — | — | Theme config (strategy, CSS overrides) / 主题配置 |
 | `locale` | `string` | — | auto-detect | Override locale / 覆盖语言 |
 | `dashboard` | `Snippet` | — | — | Custom dashboard page / 自定义仪表盘 |
 | `loginPage` | `Snippet` | — | — | Custom login page / 自定义登录页 |

--- a/docs/components/theming.md
+++ b/docs/components/theming.md
@@ -17,6 +17,76 @@ AdminApp `defaultTheme` prop sets the initial mode. Persisted to `localStorage`.
 
 AdminApp 的 `defaultTheme` 属性设定初始模式，自动持久化到 `localStorage`。
 
+## Theme Strategy / 主题策略
+
+By default, svadmin uses **standard** strategy: light-first with a `.dark` CSS class for dark mode. For apps that default to dark mode (e.g. dashboards, creative tools), use **dark-first** strategy:
+
+默认使用 **standard** 策略：默认亮色，通过 `.dark` CSS 类切换暗色。对于默认暗色的应用（如仪表盘、创意工具），使用 **dark-first** 策略：
+
+```typescript
+import { configureTheme } from '@svadmin/core';
+import type { ThemeConfig } from '@svadmin/core';
+
+// Standard (default): adds .dark class for dark mode
+configureTheme({ strategy: 'standard' });
+
+// Dark-first: adds .light class for light mode (dark is default)
+configureTheme({ strategy: 'dark-first' });
+```
+
+Or via `AdminApp` prop:
+
+```svelte
+<AdminApp
+  {dataProvider}
+  {resources}
+  themeConfig={{ strategy: 'dark-first' }}
+  defaultTheme="dark"
+/>
+```
+
+| Strategy | Default Mode | CSS Class | Use Case / 使用场景 |
+|----------|-------------|-----------|--------------------|
+| `standard` | Light | `.dark` added for dark | General admin panels / 通用管理面板 |
+| `dark-first` | Dark | `.light` added for light | Dark dashboards, creative tools / 暗色仪表盘、创意工具 |
+
+## CSS Variable Overrides / CSS 变量覆盖
+
+Override design tokens programmatically via `configureTheme`:
+
+通过 `configureTheme` 编程式覆盖 design tokens：
+
+```typescript
+import { configureTheme, clearCssOverrides } from '@svadmin/core';
+
+configureTheme({
+  strategy: 'dark-first',
+  cssOverrides: {
+    '--primary': 'rgb(108, 124, 255)',
+    '--background': 'rgb(5, 8, 17)',
+    '--radius': '0.8rem',
+  },
+});
+
+// Remove all overrides later
+clearCssOverrides();
+
+// Remove specific overrides
+clearCssOverrides(['--primary']);
+```
+
+This injects CSS variables directly onto `<html>`, taking highest priority over `app.css` defaults.
+
+这会将 CSS 变量直接注入 `<html>`，优先级高于 `app.css` 的默认值。
+
+### ThemeConfig Reference / 配置参考
+
+| Property | Type | Default | Description / 描述 |
+|----------|------|---------|-------------------|
+| `strategy` | `'standard' \| 'dark-first'` | `'standard'` | Class toggle strategy / 类名切换策略 |
+| `cssOverrides` | `Record<string, string>` | — | CSS variables to inject on `<html>` / 注入到 `<html>` 的 CSS 变量 |
+| `disableColorScheme` | `boolean` | `false` | Skip setting `color-scheme` attribute / 跳过 `color-scheme` 属性 |
+
 ## Color Themes / 多色主题
 
 6 built-in color palettes, switchable via sidebar picker or API:
@@ -78,13 +148,23 @@ The built-in sidebar provides:
 | `--info` | `bg-info` | `217 91% 60%` | `217 91% 60%` | Informational / 信息状态 |
 | `--info-foreground` | `text-info-foreground` | `0 0% 100%` | `0 0% 100%` | Text on info / 信息文本 |
 
-Override in your `app.css`:
+Override in your `app.css` or via `configureTheme({ cssOverrides })` API:
 
-在你的 `app.css` 中覆盖：
+在你的 `app.css` 中覆盖或通过 `configureTheme({ cssOverrides })` API：
 
 ```css
 :root {
   --success: 160 84% 39%;          /* Teal instead of green */
   --warning: 25 95% 53%;           /* Orange instead of amber */
 }
+```
+
+```typescript
+// Or programmatically / 或编程式覆盖
+configureTheme({
+  cssOverrides: {
+    '--success': 'oklch(0.65 0.2 160)',
+    '--warning': 'oklch(0.8 0.15 55)',
+  },
+});
 ```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,8 +37,8 @@ export { audit, setAuditHandler, setAuditLogProvider, getAuditLogProvider } from
 export type { AuditLogProvider } from './audit';
 export { setChatProvider, getChatProvider, setChatContext, getChatContext } from './chatProvider.svelte';
 export type { ChatProvider, ChatMessage, ChatContext, ChatAction } from './chatProvider.svelte';
-export { getTheme, setTheme, toggleTheme, getResolvedTheme, getColorTheme, setColorTheme, colorThemes } from './theme.svelte';
-export type { ThemeMode, ColorTheme } from './theme.svelte';
+export { getTheme, setTheme, toggleTheme, getResolvedTheme, getColorTheme, setColorTheme, colorThemes, configureTheme, getThemeConfig, clearCssOverrides } from './theme.svelte';
+export type { ThemeMode, ColorTheme, ThemeStrategy, ThemeConfig } from './theme.svelte';
 export { setUnsavedChanges, getUnsavedChanges, initUnsavedChangesNotifier } from './unsaved-changes.svelte';
 export { setAdminOptions, getAdminOptions, getTextTransformers } from './options';
 export type { AdminOptions, TextTransformers, OvertimeConfig } from './options';

--- a/packages/core/src/theme.svelte.ts
+++ b/packages/core/src/theme.svelte.ts
@@ -1,10 +1,74 @@
 // Theme — dark/light/system mode + color theme management (Svelte 5 runes)
+//
+// Supports two class strategies:
+//   - 'standard' (default): adds 'dark' class for dark mode (light-first)
+//   - 'dark-first': adds 'light' class for light mode (dark-first, e.g. Elygate-style)
 
 export type ThemeMode = 'light' | 'dark' | 'system';
 export type ColorTheme = 'blue' | 'green' | 'rose' | 'orange' | 'violet' | 'zinc';
 
+/** Controls how the theme class is applied to <html> */
+export type ThemeStrategy = 'standard' | 'dark-first';
+
+export interface ThemeConfig {
+  /** Class strategy: 'standard' toggles '.dark', 'dark-first' toggles '.light' */
+  strategy?: ThemeStrategy;
+  /** Custom CSS variables to inject as overrides on <html> */
+  cssOverrides?: Record<string, string>;
+  /** Whether to disable the built-in color-scheme attribute */
+  disableColorScheme?: boolean;
+}
+
 const STORAGE_KEY = 'svadmin-theme';
 const COLOR_STORAGE_KEY = 'svadmin-color-theme';
+
+// ── Theme configuration ──────────────────────────────────
+let themeConfig: ThemeConfig = {};
+
+/**
+ * Configure the theme system. Must be called before setTheme() or
+ * automatically via AdminApp's themeConfig prop.
+ */
+export function configureTheme(config: ThemeConfig): void {
+  themeConfig = { ...config };
+  // Re-apply the current theme with new strategy
+  applyTheme(mode);
+  // Apply CSS overrides
+  if (config.cssOverrides) {
+    applyCssOverrides(config.cssOverrides);
+  }
+}
+
+/** Get current theme configuration */
+export function getThemeConfig(): ThemeConfig {
+  return { ...themeConfig };
+}
+
+function applyCssOverrides(overrides: Record<string, string>): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  for (const [key, value] of Object.entries(overrides)) {
+    const cssVar = key.startsWith('--') ? key : `--${key}`;
+    root.style.setProperty(cssVar, value);
+  }
+}
+
+/** Remove previously applied CSS overrides */
+export function clearCssOverrides(keys?: string[]): void {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  if (keys) {
+    for (const key of keys) {
+      const cssVar = key.startsWith('--') ? key : `--${key}`;
+      root.style.removeProperty(cssVar);
+    }
+  } else if (themeConfig.cssOverrides) {
+    for (const key of Object.keys(themeConfig.cssOverrides)) {
+      const cssVar = key.startsWith('--') ? key : `--${key}`;
+      root.style.removeProperty(cssVar);
+    }
+  }
+}
 
 // ── Color themes (display metadata) ──────────────────────
 export const colorThemes: { id: ColorTheme; label: string; color: string }[] = [
@@ -32,8 +96,24 @@ let mode = $state<ThemeMode>(getStoredTheme());
 
 function applyTheme(m: ThemeMode): void {
   const resolved = m === 'system' ? getSystemPreference() : m;
-  if (typeof document !== 'undefined') {
-    document.documentElement.classList.toggle('dark', resolved === 'dark');
+  if (typeof document === 'undefined') return;
+
+  const strategy = themeConfig.strategy ?? 'standard';
+  const el = document.documentElement;
+
+  if (strategy === 'dark-first') {
+    // Dark-first: default is dark, add 'light' class for light mode
+    el.classList.toggle('light', resolved === 'light');
+    el.classList.remove('dark'); // ensure no conflict
+  } else {
+    // Standard: default is light, add 'dark' class for dark mode
+    el.classList.toggle('dark', resolved === 'dark');
+    el.classList.remove('light'); // ensure no conflict
+  }
+
+  // Set color-scheme attribute unless disabled
+  if (!themeConfig.disableColorScheme) {
+    el.style.colorScheme = resolved;
   }
 }
 

--- a/packages/core/tests/theme-config.test.ts
+++ b/packages/core/tests/theme-config.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+
+/**
+ * Unit tests for theme strategy logic.
+ * Since theme.svelte.ts uses Svelte 5 runes ($state), we test the pure
+ * strategy logic here without importing the module directly.
+ */
+
+// ── Replicate the pure applyTheme logic ──────────────────────
+
+type ThemeMode = 'light' | 'dark' | 'system';
+type ThemeStrategy = 'standard' | 'dark-first';
+
+interface ThemeConfig {
+  strategy?: ThemeStrategy;
+  cssOverrides?: Record<string, string>;
+  disableColorScheme?: boolean;
+}
+
+// Simulate DOM state
+let classes: Set<string>;
+let cssVars: Map<string, string>;
+let colorScheme: string;
+
+function resetMocks() {
+  classes = new Set();
+  cssVars = new Map();
+  colorScheme = '';
+}
+
+/** Pure version of applyTheme logic extracted from theme.svelte.ts */
+function applyTheme(mode: ThemeMode, config: ThemeConfig, systemPreference: 'light' | 'dark' = 'light') {
+  const resolved = mode === 'system' ? systemPreference : mode;
+  const strategy = config.strategy ?? 'standard';
+
+  if (strategy === 'dark-first') {
+    if (resolved === 'light') classes.add('light');
+    else classes.delete('light');
+    classes.delete('dark');
+  } else {
+    if (resolved === 'dark') classes.add('dark');
+    else classes.delete('dark');
+    classes.delete('light');
+  }
+
+  if (!config.disableColorScheme) {
+    colorScheme = resolved;
+  }
+}
+
+function applyCssOverrides(overrides: Record<string, string>) {
+  for (const [key, value] of Object.entries(overrides)) {
+    const cssVar = key.startsWith('--') ? key : `--${key}`;
+    cssVars.set(cssVar, value);
+  }
+}
+
+function clearCssOverrides(config: ThemeConfig, keys?: string[]) {
+  if (keys) {
+    for (const key of keys) {
+      const cssVar = key.startsWith('--') ? key : `--${key}`;
+      cssVars.delete(cssVar);
+    }
+  } else if (config.cssOverrides) {
+    for (const key of Object.keys(config.cssOverrides)) {
+      const cssVar = key.startsWith('--') ? key : `--${key}`;
+      cssVars.delete(cssVar);
+    }
+  }
+}
+
+describe('Theme Strategy — standard (light-first)', () => {
+  beforeEach(resetMocks);
+
+  test('dark mode adds "dark" class', () => {
+    applyTheme('dark', { strategy: 'standard' });
+    expect(classes.has('dark')).toBe(true);
+    expect(classes.has('light')).toBe(false);
+  });
+
+  test('light mode has no mode class', () => {
+    applyTheme('light', { strategy: 'standard' });
+    expect(classes.has('dark')).toBe(false);
+    expect(classes.has('light')).toBe(false);
+  });
+
+  test('system mode resolves to system preference', () => {
+    applyTheme('system', { strategy: 'standard' }, 'dark');
+    expect(classes.has('dark')).toBe(true);
+  });
+
+  test('sets color-scheme by default', () => {
+    applyTheme('dark', { strategy: 'standard' });
+    expect(colorScheme).toBe('dark');
+  });
+});
+
+describe('Theme Strategy — dark-first', () => {
+  beforeEach(resetMocks);
+
+  test('light mode adds "light" class', () => {
+    applyTheme('light', { strategy: 'dark-first' });
+    expect(classes.has('light')).toBe(true);
+    expect(classes.has('dark')).toBe(false);
+  });
+
+  test('dark mode has no mode class', () => {
+    applyTheme('dark', { strategy: 'dark-first' });
+    expect(classes.has('light')).toBe(false);
+    expect(classes.has('dark')).toBe(false);
+  });
+
+  test('system mode resolves correctly', () => {
+    applyTheme('system', { strategy: 'dark-first' }, 'light');
+    expect(classes.has('light')).toBe(true);
+  });
+
+  test('disableColorScheme prevents color-scheme change', () => {
+    applyTheme('dark', { strategy: 'dark-first', disableColorScheme: true });
+    expect(colorScheme).toBe('');
+  });
+});
+
+describe('CSS Overrides', () => {
+  beforeEach(resetMocks);
+
+  test('applies CSS variables with -- prefix', () => {
+    applyCssOverrides({
+      '--primary': 'rgb(108, 124, 255)',
+      '--background': '5, 8, 17',
+    });
+    expect(cssVars.get('--primary')).toBe('rgb(108, 124, 255)');
+    expect(cssVars.get('--background')).toBe('5, 8, 17');
+  });
+
+  test('auto-prefixes keys without --', () => {
+    applyCssOverrides({ 'primary': 'red' });
+    expect(cssVars.get('--primary')).toBe('red');
+  });
+
+  test('clearCssOverrides removes all', () => {
+    const config: ThemeConfig = {
+      cssOverrides: { '--a': '1', '--b': '2' },
+    };
+    applyCssOverrides(config.cssOverrides!);
+    expect(cssVars.size).toBe(2);
+
+    clearCssOverrides(config);
+    expect(cssVars.size).toBe(0);
+  });
+
+  test('clearCssOverrides with specific keys', () => {
+    const config: ThemeConfig = {
+      cssOverrides: { '--a': '1', '--b': '2' },
+    };
+    applyCssOverrides(config.cssOverrides!);
+    clearCssOverrides(config, ['--a']);
+    expect(cssVars.has('--a')).toBe(false);
+    expect(cssVars.has('--b')).toBe(true);
+  });
+});

--- a/packages/ui/src/components/AdminApp.svelte
+++ b/packages/ui/src/components/AdminApp.svelte
@@ -2,8 +2,8 @@
   // Auto-inject design tokens so consumers don't need to manually import
   import '../app.css';
   import type { Snippet } from 'svelte';
-  import type { DataProvider, AuthProvider, ResourceDefinition, ThemeMode, RouterProvider } from '@svadmin/core';
-  import { setDataProvider, setAuthProvider, setResources, setLocale, setTheme, setRouterProvider, getAuthProvider, createHashRouterProvider } from '@svadmin/core';
+  import type { DataProvider, AuthProvider, ResourceDefinition, ThemeMode, RouterProvider, ThemeConfig } from '@svadmin/core';
+  import { setDataProvider, setAuthProvider, setResources, setLocale, setTheme, setRouterProvider, getAuthProvider, createHashRouterProvider, configureTheme } from '@svadmin/core';
   import { t } from '@svadmin/core/i18n';
   import { navigate } from '@svadmin/core/router';
   import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
@@ -35,6 +35,8 @@
     locale?: string;
     title?: string;
     defaultTheme?: ThemeMode;
+    /** Theme configuration for dark-first mode, CSS overrides, etc. */
+    themeConfig?: ThemeConfig;
     dashboard?: Snippet;
     loginPage?: Snippet;
     /** Override default components via DI */
@@ -49,6 +51,7 @@
     locale,
     title = 'Admin',
     defaultTheme,
+    themeConfig: userThemeConfig,
     dashboard,
     loginPage,
     components: userComponents,
@@ -77,6 +80,7 @@
     setResources(resources);
     setRouterProvider(resolvedRouter);
     if (locale) setLocale(locale);
+    if (userThemeConfig) configureTheme(userThemeConfig);
     if (defaultTheme) setTheme(defaultTheme);
   });
 


### PR DESCRIPTION
- Add ThemeStrategy type ('standard' | 'dark-first')
- Add ThemeConfig interface with strategy, cssOverrides, disableColorScheme
- Add configureTheme(), getThemeConfig(), clearCssOverrides() APIs
- Dark-first mode: uses '.light' class instead of '.dark' (for dark-default apps)
- CSS overrides: inject custom CSS variables on <html> element
- AdminApp: add themeConfig prop for easy configuration## Summary
Adds support for **dark-first** theme mode and **custom CSS variable overrides**, enabling apps that default to dark mode (like Elygate/VEO AI dashboards) to integrate with svadmin while preserving their existing styling.

## Changes## Summary

Adds support for **dark-first** theme mode and **custom CSS variable overrides**, enabling apps that default to dark mode (like Elygate/VEO AI dashboards) to integrate with svadmin while preserving their existing styling.

## Changes

### @svadmin/core

**theme.svelte.ts**:
- New ThemeStrategy type: 'standard' (default, adds .dark class) | 'dark-first' (adds .light class)
- - New ThemeConfig interface: { strategy, cssOverrides, disableColorScheme }
- - configureTheme(config) -- configure the theme system
- - getThemeConfig() -- get current config
- - clearCssOverrides(keys?) -- remove applied CSS variable overrides## Summary

Adds support for **dark-first** theme mode and **custom CSS variable overrides**, enabling apps that default to dark mode (like Elygate/VEO AI dashboards) to integrate with svadmin while preserving their existing styling.

## Ch- - Dark-first mode removes .dark class conflicts and uses .light toggle
**index.ts**: Exports new types and functions
feat(core): support dark-first theme mode and custom CSS token override### @svadmin/ui

**AdminApp.svelte**: New themeConfig prop for easy configuration:
```svelte
<AdminApp
  {dataProvider}
  {resources}
  themeConfig={{ strategy: 'dark-first', cssOverrides: { '--primary': 'rgb(108, 124, 255)' } }}
  defaultTheme="dark"
/>
```

### Tests

- 12 new unit tests covering standard/dark-first strategy logic and CSS overrides
- - All existing tests continue to pass
## Motivation

Many apps use a dark-first design (dark background by default, .light class for light mode) rather than svadmin's default light-first approach. This PR enables those apps to use svadmin without rewriting their CSS token system.
### `@svadmin/core`

**`theme.svelte.ts`**:
- New `ThemeStrategy` type: `'standard'` (default, adds `.dark` class) | `'dark-first'` (adds `.light` class)
- - New `ThemeConfig` interface: `{ strategy, cssOverrides, disableColorScheme }`
- - `configureTheme(config)` 
- Export new types and functions from @svadmin/core
- Add 12 unit tests covering strategy logic and CSS overrides