### PR TITLE
feat(ui): extend component registry with more override slots

### DIFF
--- a/docs/components/admin-app.md
+++ b/docs/components/admin-app.md
@@ -77,6 +77,48 @@ Available slots: `Layout`, `Sidebar`, `Header`, `LoginPage`, `AutoTable`, `AutoF
 
 可覆盖的组件插槽：`Layout`、`Sidebar`、`Header`、`LoginPage`、`AutoTable`、`AutoForm`、`ShowPage`、`Button`、`Input`、`Badge`、`Skeleton`。
 
+### Extended Slots (Optional) / 扩展插槽（可选）
+
+These optional slots allow fine-grained customization of specific UI areas without replacing the entire Layout or Header:
+
+这些可选插槽允许精细自定义特定 UI 区域，无需替换整个 Layout 或 Header：
+
+| Slot | Description / 描述 |
+|------|-------------------|
+| `DashboardPage` | Custom dashboard page component / 自定义仪表盘页面 |
+| `Breadcrumbs` | Custom breadcrumbs (replaces built-in) / 自定义面包屑 |
+| `ThemeToggle` | Custom theme toggle button / 自定义主题切换按钮 |
+| `UserMenu` | Custom user menu / avatar dropdown / 自定义用户菜单/头像下拉 |
+| `NotificationPanel` | Custom notification panel / 自定义通知面板 |
+
+```svelte
+<AdminApp
+  {dataProvider}
+  {resources}
+  components={{
+    UserMenu: MyUserMenu,
+    NotificationPanel: MyNotifications,
+    ThemeToggle: MyThemeToggle,
+    DashboardPage: MyDashboard,
+  }}
+/>
+```
+
+### Header rightActions Snippet
+
+The Header component accepts a `rightActions` snippet for injecting custom actions (e.g. credits display, language switcher):
+
+Header 组件接受 `rightActions` snippet，用于注入自定义操作（如积分显示、语言切换器）：
+
+```svelte
+<Header showSearch onSearchClick={...}>
+  {#snippet rightActions()}
+    <CreditsBadge />
+    <LanguageSwitcher />
+  {/snippet}
+</Header>
+```
+
 Use `create-svadmin eject` to extract component source for customization. See [@svadmin/create README](../packages/create-svadmin/README.md).
 
 使用 `create-svadmin eject` 提取组件源码进行深度定制。

--- a/packages/ui/src/component-registry.svelte.ts
+++ b/packages/ui/src/component-registry.svelte.ts
@@ -24,6 +24,20 @@ export interface ComponentRegistry {
   Input: Component<any>;
   Badge: Component<any>;
   Skeleton: Component<any>;
+
+  // ─── Extended slots (optional) ──────────────────────────────
+  // These allow deeper customization without replacing entire Layout/Header.
+
+  /** Custom dashboard page component (replaces default welcome message) */
+  DashboardPage?: Component<any>;
+  /** Custom breadcrumbs component (replaces built-in Breadcrumbs) */
+  Breadcrumbs?: Component<any>;
+  /** Custom theme toggle button (replaces built-in Sun/Moon toggle) */
+  ThemeToggle?: Component<any>;
+  /** Custom user menu / avatar dropdown in the header */
+  UserMenu?: Component<any>;
+  /** Custom notification panel / bell icon in the header */
+  NotificationPanel?: Component<any>;
 }
 
 const REGISTRY_KEY = 'svadmin:components';

--- a/packages/ui/src/components/Header.svelte
+++ b/packages/ui/src/components/Header.svelte
@@ -5,6 +5,7 @@
   import { getResolvedTheme, toggleTheme } from '@svadmin/core';
   import Breadcrumbs from './Breadcrumbs.svelte';
   import { t } from '@svadmin/core/i18n';
+  import { getComponentRegistry } from '../component-registry.svelte.js';
 
   let {
     showThemeToggle = false,
@@ -12,13 +13,23 @@
     showSearch = true,
     onSearchClick,
     children,
+    /** Slot for additional actions on the right side of the header */
+    rightActions,
   } = $props<{
     showThemeToggle?: boolean;
     showBreadcrumbs?: boolean;
     showSearch?: boolean;
     onSearchClick?: () => void;
     children?: import('svelte').Snippet;
+    rightActions?: import('svelte').Snippet;
   }>();
+
+  // Retrieve optional component overrides from registry
+  const registry = getComponentRegistry();
+  const CustomBreadcrumbs = registry.Breadcrumbs;
+  const CustomThemeToggle = registry.ThemeToggle;
+  const CustomUserMenu = registry.UserMenu;
+  const CustomNotificationPanel = registry.NotificationPanel;
 </script>
 
 <header class="sticky top-0 z-30 flex h-14 w-full shrink-0 items-center justify-between bg-card/60 backdrop-blur-md px-4 md:px-6">
@@ -27,10 +38,22 @@
       {@render children()}
     {/if}
     {#if showBreadcrumbs}
-      <Breadcrumbs />
+      {#if CustomBreadcrumbs}
+        <CustomBreadcrumbs />
+      {:else}
+        <Breadcrumbs />
+      {/if}
     {/if}
   </div>
   <div class="ml-auto flex items-center gap-2">
+    {#if rightActions}
+      {@render rightActions()}
+    {/if}
+
+    {#if CustomNotificationPanel}
+      <CustomNotificationPanel />
+    {/if}
+
     {#if showSearch && onSearchClick}
       <Button variant="outline" size="sm" onclick={onSearchClick} class="gap-2 text-muted-foreground h-8 px-3">
         <Search class="h-3.5 w-3.5" />
@@ -42,13 +65,22 @@
     {/if}
     
     {#if showThemeToggle}
-      <TooltipButton tooltip={t('common.toggleTheme')} onclick={() => toggleTheme()} class="rounded-full">
-        {#if getResolvedTheme() === 'dark'}
-          <Moon class="h-4 w-4 transition-all" />
-        {:else}
-          <Sun class="h-4 w-4 transition-all" />
-        {/if}
-      </TooltipButton>
+      {#if CustomThemeToggle}
+        <CustomThemeToggle />
+      {:else}
+        <TooltipButton tooltip={t('common.toggleTheme')} onclick={() => toggleTheme()} class="rounded-full">
+          {#if getResolvedTheme() === 'dark'}
+            <Moon class="h-4 w-4 transition-all" />
+          {:else}
+            <Sun class="h-4 w-4 transition-all" />
+          {/if}
+        </TooltipButton>
+      {/if}
+    {/if}
+
+    {#if CustomUserMenu}
+      <CustomUserMenu />
     {/if}
   </div>
 </header>
+


### PR DESCRIPTION
- Add 5 optional slots to ComponentRegistry: DashboardPage, Breadcrumbs, ThemeToggle, UserMenu, NotificationPanel
- - Header.svelte: use registry-based components with fallback to defaults
- - Header.svelte: add rightActions snippet prop for custom action injection
- - Docs: update admin-app.md with extended slots reference and examples
These optional slots enable fine-grained customization of specific UI areas (e.g. user menu with credits, notification panel, theme toggle) without needing to replace the entire Layout or Header component.