### PR TITLE
fix(ui): highlight.js ESM compat + Tailwind CSS v4 integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,31 +63,31 @@
 
 ### Core / 核心
 
-| Package | Description / 描述 |
-|---------|-------------------|
-| `@svadmin/core` | Hooks, providers, types, utilities, Resource Type Registry |
-| `@svadmin/ui` | Pre-built admin components / 预构建管理组件（shadcn-svelte） |
-| `@svadmin/create` | CLI scaffolding tool / CLI 脚手架工具 |
+| Package           | Description / 描述                                           |
+| ----------------- | ------------------------------------------------------------ |
+| `@svadmin/core`   | Hooks, providers, types, utilities, Resource Type Registry   |
+| `@svadmin/ui`     | Pre-built admin components / 预构建管理组件（shadcn-svelte） |
+| `@svadmin/create` | CLI scaffolding tool / CLI 脚手架工具                        |
 
 ### Data Providers / 数据适配器
 
-| Package | Backend |
-|---------|---------|
-| `@svadmin/simple-rest` | REST API (zero deps, JWT/Cookie auth) |
-| `@svadmin/supabase` | Supabase (data + auth + live) |
-| `@svadmin/pocketbase` | PocketBase (data + auth + live) |
-| `@svadmin/appwrite` | Appwrite (data + auth + live) |
-| `@svadmin/graphql` | GraphQL |
-| `@svadmin/elysia` | Elysia (auto type inference via Eden Treaty) |
-| `@svadmin/strapi` | Strapi CMS |
-| `@svadmin/directus` | Directus |
-| `@svadmin/firebase` | Firebase / Firestore |
-| `@svadmin/hasura` | Hasura GraphQL |
-| `@svadmin/sanity` | Sanity.io |
-| `@svadmin/airtable` | Airtable |
-| `@svadmin/medusa` | Medusa Commerce |
-| `@svadmin/nestjs-query` | NestJS GraphQL |
-| `@svadmin/nestjsx-crud` | NestJS CRUD |
+| Package                 | Backend                                      |
+| ----------------------- | -------------------------------------------- |
+| `@svadmin/simple-rest`  | REST API (zero deps, JWT/Cookie auth)        |
+| `@svadmin/supabase`     | Supabase (data + auth + live)                |
+| `@svadmin/pocketbase`   | PocketBase (data + auth + live)              |
+| `@svadmin/appwrite`     | Appwrite (data + auth + live)                |
+| `@svadmin/graphql`      | GraphQL                                      |
+| `@svadmin/elysia`       | Elysia (auto type inference via Eden Treaty) |
+| `@svadmin/strapi`       | Strapi CMS                                   |
+| `@svadmin/directus`     | Directus                                     |
+| `@svadmin/firebase`     | Firebase / Firestore                         |
+| `@svadmin/hasura`       | Hasura GraphQL                               |
+| `@svadmin/sanity`       | Sanity.io                                    |
+| `@svadmin/airtable`     | Airtable                                     |
+| `@svadmin/medusa`       | Medusa Commerce                              |
+| `@svadmin/nestjs-query` | NestJS GraphQL                               |
+| `@svadmin/nestjsx-crud` | NestJS CRUD                                  |
 
 ## 🚀 Quick Start / 快速开始
 
@@ -115,20 +115,31 @@ bun add @svadmin/core @svadmin/ui @svadmin/simple-rest
 ### Define Resources / 定义资源
 
 ```typescript
-import type { ResourceDefinition } from '@svadmin/core';
+import type { ResourceDefinition } from "@svadmin/core";
 
 export const resources: ResourceDefinition[] = [
   {
-    name: 'products',
-    label: 'Products',
+    name: "products",
+    label: "Products",
     fields: [
-      { key: 'id', label: 'ID', type: 'number', showInForm: false },
-      { key: 'name', label: 'Name', type: 'text', required: true, searchable: true },
-      { key: 'price', label: 'Price', type: 'number', required: true },
-      { key: 'status', label: 'Status', type: 'select', options: [
-        { label: 'Active', value: 'active' },
-        { label: 'Draft', value: 'draft' },
-      ]},
+      { key: "id", label: "ID", type: "number", showInForm: false },
+      {
+        key: "name",
+        label: "Name",
+        type: "text",
+        required: true,
+        searchable: true,
+      },
+      { key: "price", label: "Price", type: "number", required: true },
+      {
+        key: "status",
+        label: "Status",
+        type: "select",
+        options: [
+          { label: "Active", value: "active" },
+          { label: "Draft", value: "draft" },
+        ],
+      },
     ],
   },
 ];
@@ -164,38 +175,84 @@ export const resources: ResourceDefinition[] = [
 
 ```typescript
 // Server: export your Elysia app type
-import { Elysia } from 'elysia';
-const app = new Elysia().get('/posts', () => db.posts.findMany());
+import { Elysia } from "elysia";
+const app = new Elysia().get("/posts", () => db.posts.findMany());
 export type App = typeof app;
 
 // Client: auto-infer resource types
-import { createElysiaDataProvider } from '@svadmin/elysia';
-import type { InferResourceMap } from '@svadmin/elysia';
-import type { App } from './server';
+import { createElysiaDataProvider } from "@svadmin/elysia";
+import type { InferResourceMap } from "@svadmin/elysia";
+import type { App } from "./server";
 
 // ResourceTypeMap auto-derived from Elysia routes
-declare module '@svadmin/core' {
+declare module "@svadmin/core" {
   interface ResourceTypeMap extends InferResourceMap<App> {}
 }
 
-const dataProvider = createElysiaDataProvider<App>('http://localhost:3000');
+const dataProvider = createElysiaDataProvider<App>("http://localhost:3000");
+```
+
+### Tailwind CSS v4 Integration / Tailwind CSS v4 集成
+
+> **Important / 重要**: Tailwind CSS v4 does not scan `node_modules` by default. You **must** add `@source` directives so that utility classes used by `@svadmin/ui` components are generated.
+>
+> Tailwind CSS v4 默认不扫描 `node_modules`。你**必须**添加 `@source` 指令，否则 `@svadmin/ui` 组件使用的工具类不会被生成，导致布局完全错乱。
+
+**1. Add `@source` to your CSS entry file / 在 CSS 入口文件中添加 `@source`:**
+
+```css
+/* app.css */
+@import "tailwindcss";
+
+/* Required: tell Tailwind v4 to scan svadmin component sources */
+@source "../node_modules/@svadmin/ui/src";
+@source "../node_modules/@svadmin/core/src";
+```
+
+**2. Configure Vite `optimizeDeps` / 配置 Vite `optimizeDeps`:**
+
+Since `@svadmin/ui` ships raw `.svelte` source files (not pre-built), exclude the svadmin packages from pre-bundling and explicitly include their CJS peer dependencies:
+
+由于 `@svadmin/ui` 提供的是原始 `.svelte` 源码文件（非预构建），需要将 svadmin 包排除在预打包之外，并显式包含其 CJS 对等依赖：
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ["@svadmin/core", "@svadmin/ui", "@svadmin/supabase"],
+    include: [
+      "@svadmin/core > @tanstack/svelte-query",
+      "@svadmin/ui > svelte-sonner",
+      "@svadmin/ui > vaul-svelte",
+      "@svadmin/ui > cmdk-sv",
+      "@svadmin/ui > bits-ui",
+      "@svadmin/ui > @tanstack/svelte-table",
+      "@svadmin/ui > lucide-svelte",
+      "@svadmin/ui > @lucide/svelte",
+      "highlight.js",
+      "marked",
+      "marked-highlight",
+      "isomorphic-dompurify",
+    ],
+  },
+});
 ```
 
 ## 🏗️ `<AdminApp>` Props
 
-| Prop | Type | Required | Default | Description |
-|------|------|----------|---------|-------------|
-| `dataProvider` | `DataProvider` | ✅ | — | Data source adapter / 数据源适配器 |
-| `authProvider` | `AuthProvider` | — | — | Auth adapter / 认证适配器 |
-| `routerProvider` | `RouterProvider` | — | hash | Custom router / 自定义路由提供者 |
-| `resources` | `ResourceDefinition[]` | ✅ | — | Resource definitions / 资源定义 |
-| `title` | `string` | — | `'Admin'` | App title / 应用标题 |
-| `defaultTheme` | `'light' \| 'dark' \| 'system'` | — | `'system'` | Initial theme / 初始主题 |
-| `themeConfig` | `ThemeConfig` | — | — | Theme config (strategy, overrides) / 主题配置 |
-| `locale` | `string` | — | auto | Override locale / 覆盖语言 |
-| `dashboard` | `Snippet` | — | — | Custom dashboard / 自定义仪表盘 |
-| `loginPage` | `Snippet` | — | — | Custom login page / 自定义登录页 |
-| `components` | `Partial<ComponentRegistry>`| — | — | Override default UI components / 覆盖默认组件 |
+| Prop             | Type                            | Required | Default    | Description                                   |
+| ---------------- | ------------------------------- | -------- | ---------- | --------------------------------------------- |
+| `dataProvider`   | `DataProvider`                  | ✅       | —          | Data source adapter / 数据源适配器            |
+| `authProvider`   | `AuthProvider`                  | —        | —          | Auth adapter / 认证适配器                     |
+| `routerProvider` | `RouterProvider`                | —        | hash       | Custom router / 自定义路由提供者              |
+| `resources`      | `ResourceDefinition[]`          | ✅       | —          | Resource definitions / 资源定义               |
+| `title`          | `string`                        | —        | `'Admin'`  | App title / 应用标题                          |
+| `defaultTheme`   | `'light' \| 'dark' \| 'system'` | —        | `'system'` | Initial theme / 初始主题                      |
+| `themeConfig`    | `ThemeConfig`                   | —        | —          | Theme config (strategy, overrides) / 主题配置 |
+| `locale`         | `string`                        | —        | auto       | Override locale / 覆盖语言                    |
+| `dashboard`      | `Snippet`                       | —        | —          | Custom dashboard / 自定义仪表盘               |
+| `loginPage`      | `Snippet`                       | —        | —          | Custom login page / 自定义登录页              |
+| `components`     | `Partial<ComponentRegistry>`    | —        | —          | Override default UI components / 覆盖默认组件 |
 
 ## 🌓 Dark Mode / 暗色模式
 
@@ -217,12 +274,17 @@ Dark mode works out of the box. Use `defaultTheme` prop or the Sidebar toggle:
 Programmatic control / 编程式控制:
 
 ```typescript
-import { setTheme, toggleTheme, getTheme, getResolvedTheme } from '@svadmin/core';
+import {
+  setTheme,
+  toggleTheme,
+  getTheme,
+  getResolvedTheme,
+} from "@svadmin/core";
 
-setTheme('dark');     // 'light' | 'dark' | 'system'
-toggleTheme();        // toggle between light/dark
-getTheme();           // current setting
-getResolvedTheme();   // resolved to 'light' or 'dark'
+setTheme("dark"); // 'light' | 'dark' | 'system'
+toggleTheme(); // toggle between light/dark
+getTheme(); // current setting
+getResolvedTheme(); // resolved to 'light' or 'dark'
 ```
 
 ## 🎨 Color Themes / 多色主题
@@ -232,11 +294,11 @@ Switch between 6 color palettes via sidebar picker or programmatically:
 通过侧边栏选色器或编程式切换 6 种配色：
 
 ```typescript
-import { getColorTheme, setColorTheme, colorThemes } from '@svadmin/core';
-import type { ColorTheme } from '@svadmin/core';
+import { getColorTheme, setColorTheme, colorThemes } from "@svadmin/core";
+import type { ColorTheme } from "@svadmin/core";
 
-setColorTheme('rose');   // 'blue' | 'green' | 'rose' | 'orange' | 'violet' | 'zinc'
-getColorTheme();         // current color theme
+setColorTheme("rose"); // 'blue' | 'green' | 'rose' | 'orange' | 'violet' | 'zinc'
+getColorTheme(); // current color theme
 console.log(colorThemes); // [{ id: 'blue', label: 'Blue', color: '#3b82f6' }, ...]
 ```
 
@@ -250,7 +312,7 @@ For end-to-end type safety, register your resource types:
 
 ```typescript
 // Extend the ResourceTypeMap interface (declaration merging)
-declare module '@svadmin/core' {
+declare module "@svadmin/core" {
   interface ResourceTypeMap {
     posts: { id: number; title: string; body: string };
     users: { id: number; name: string; email: string };
@@ -258,8 +320,8 @@ declare module '@svadmin/core' {
 }
 
 // Now all hooks get compile-time checking:
-useList({ resource: 'posts' });  // ✅ OK
-useList({ resource: 'postz' });  // ❌ Compile error — typo caught!
+useList({ resource: "posts" }); // ✅ OK
+useList({ resource: "postz" }); // ❌ Compile error — typo caught!
 ```
 
 ## 🔌 Custom DataProvider / 自定义数据源
@@ -269,15 +331,25 @@ Implement the `DataProvider` interface to connect any backend:
 实现 `DataProvider` 接口即可接入任意后端：
 
 ```typescript
-import type { DataProvider, BaseRecord } from '@svadmin/core';
+import type { DataProvider, BaseRecord } from "@svadmin/core";
 
 const myProvider: DataProvider = {
-  getApiUrl: () => 'https://api.example.com',
-  getList: async ({ resource, pagination, sorters, filters }) => { /* ... */ },
-  getOne: async ({ resource, id }) => { /* ... */ },
-  create: async ({ resource, variables }) => { /* ... */ },
-  update: async ({ resource, id, variables }) => { /* ... */ },
-  deleteOne: async ({ resource, id }) => { /* ... */ },
+  getApiUrl: () => "https://api.example.com",
+  getList: async ({ resource, pagination, sorters, filters }) => {
+    /* ... */
+  },
+  getOne: async ({ resource, id }) => {
+    /* ... */
+  },
+  create: async ({ resource, variables }) => {
+    /* ... */
+  },
+  update: async ({ resource, id, variables }) => {
+    /* ... */
+  },
+  deleteOne: async ({ resource, id }) => {
+    /* ... */
+  },
 };
 ```
 

--- a/packages/ui/src/components/MarkdownRenderer.svelte
+++ b/packages/ui/src/components/MarkdownRenderer.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   // @ts-expect-error - missing types
-  import { Marked } from 'marked';
+  import { Marked } from "marked";
   // @ts-expect-error - missing types
-  import { markedHighlight } from 'marked-highlight';
+  import { markedHighlight } from "marked-highlight";
   // @ts-expect-error - missing types
-  import hljs from 'highlight.js';
-  import 'highlight.js/styles/github-dark.css'; // or your preferred theme
+  import * as hljsModule from "highlight.js";
+  const hljs = "default" in hljsModule ? hljsModule.default : hljsModule;
+  import "highlight.js/styles/github-dark.css"; // or your preferred theme
   // @ts-expect-error - missing types
-  import DOMPurify from 'isomorphic-dompurify';
-  import { Check, Copy } from 'lucide-svelte';
-  import { Button } from './ui/button/index.js';
+  import DOMPurify from "isomorphic-dompurify";
+  import { Check, Copy } from "lucide-svelte";
+  import { Button } from "./ui/button/index.js";
 
   interface Props {
     /** The raw markdown string to render */
@@ -20,39 +21,41 @@
     class?: string;
   }
 
-  let { content, streaming = false, class: className = '' }: Props = $props();
+  let { content, streaming = false, class: className = "" }: Props = $props();
 
   // Configure marked with syntax highlighting
   const marked = new Marked(
     markedHighlight({
-      langPrefix: 'hljs language-',
+      langPrefix: "hljs language-",
       highlight(code: string, lang: string) {
-        const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+        const language = hljs.getLanguage(lang) ? lang : "plaintext";
         return hljs.highlight(code, { language }).value;
-      }
-    })
+      },
+    }),
   );
 
   // Render HTML safely
-  const html = $derived(DOMPurify.sanitize(marked.parse(content || '') as string));
+  const html = $derived(
+    DOMPurify.sanitize(marked.parse(content || "") as string),
+  );
 
   // Handle copy code blocks
   let copiedBlock = $state<string | null>(null);
 
   function handleCopy(event: MouseEvent) {
     const target = event.target as HTMLElement;
-    const button = target.closest('.copy-btn');
+    const button = target.closest(".copy-btn");
     if (!button) return;
 
-    const pre = button.closest('.code-block-wrapper')?.querySelector('pre');
+    const pre = button.closest(".code-block-wrapper")?.querySelector("pre");
     if (!pre) return;
 
-    const code = pre.textContent || '';
+    const code = pre.textContent || "";
     navigator.clipboard.writeText(code);
 
     const id = Math.random().toString(36);
     copiedBlock = id;
-    button.setAttribute('data-copied-id', id);
+    button.setAttribute("data-copied-id", id);
 
     setTimeout(() => {
       if (copiedBlock === id) copiedBlock = null;
@@ -65,48 +68,51 @@
     return {
       update(newHtml: string) {
         // Find all pre > code blocks that don't have wrappers yet
-        const pres = node.querySelectorAll('pre:not(.enhanced)');
-        pres.forEach(pre => {
-          pre.classList.add('enhanced');
-          const wrapper = document.createElement('div');
-          wrapper.className = 'code-block-wrapper group relative my-4 rounded-md bg-foreground/95';
-          
-          const header = document.createElement('div');
-          header.className = 'flex items-center justify-between px-4 py-2 text-xs text-zinc-400 border-b border-zinc-800';
-          
-          const lang = Array.from(pre.querySelector('code')?.classList || []).find(c => c.startsWith('language-'))?.replace('language-', '') || 'Code';
+        const pres = node.querySelectorAll("pre:not(.enhanced)");
+        pres.forEach((pre) => {
+          pre.classList.add("enhanced");
+          const wrapper = document.createElement("div");
+          wrapper.className =
+            "code-block-wrapper group relative my-4 rounded-md bg-foreground/95";
+
+          const header = document.createElement("div");
+          header.className =
+            "flex items-center justify-between px-4 py-2 text-xs text-zinc-400 border-b border-zinc-800";
+
+          const lang =
+            Array.from(pre.querySelector("code")?.classList || [])
+              .find((c) => c.startsWith("language-"))
+              ?.replace("language-", "") || "Code";
           header.innerHTML = `
             <span>${lang}</span>
             <button class="copy-btn hover:text-white transition-colors flex items-center gap-1">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
             </button>
           `;
-          
+
           pre.replaceWith(wrapper);
           wrapper.appendChild(header);
-          
-          const scrollContainer = document.createElement('div');
-          scrollContainer.className = 'overflow-x-auto p-4';
+
+          const scrollContainer = document.createElement("div");
+          scrollContainer.className = "overflow-x-auto p-4";
           scrollContainer.appendChild(pre);
           wrapper.appendChild(scrollContainer);
         });
 
         // Add event listener for copy buttons
-        node.addEventListener('click', handleCopy);
+        node.addEventListener("click", handleCopy);
       },
       destroy() {
-        node.removeEventListener('click', handleCopy);
-      }
+        node.removeEventListener("click", handleCopy);
+      },
     };
   }
 </script>
 
-<div 
+<div
   class="prose prose-sm dark:prose-invert max-w-none break-words {className}"
-  class:streaming={streaming}
+  class:streaming
   use:enhanceCodeBlocks={html}
 >
   {@html html}
 </div>
-
-


### PR DESCRIPTION
## Summary

This PR fixes 3 blocking issues discovered during real-world integration of `@svadmin/ui@0.14.0` with **Vite 8 + Tailwind CSS v4**.

### Fix 1: MarkdownRenderer highlight.js ESM incompatibility

`highlight.js` is a CJS module that does not provide an ESM `default` export. The current `import hljs from 'highlight.js'` causes Vite to throw:

```
SyntaxError: The requested module does not provide an export named 'default'
```

**Fix**: Use namespace import with fallback:
```js
import * as hljsModule from 'highlight.js';
const hljs = 'default' in hljsModule ? hljsModule.default : hljsModule;
```

### Fix 2: Tailwind CSS v4 `@source` directive guidance

Tailwind CSS v4 does **not** scan `node_modules` by default. Since `@svadmin/ui` ships raw `.svelte` source files, all utility classes used by its components (`flex`, `h-full`, `w-64`, `fixed`, `border-r`, etc.) are never generated — causing the **entire sidebar layout to collapse**.

**Fix**: Added `@source` directive guidance to README.

### Fix 3: Vite `optimizeDeps` configuration guidance

CJS peer dependencies (`highlight.js`, `marked`, `marked-highlight`, `isomorphic-dompurify`) need to be explicitly included in `optimizeDeps.include` for proper pre-bundling.

**Fix**: Added `optimizeDeps` configuration example to README.

## Files Changed

- `packages/ui/src/components/MarkdownRenderer.svelte` — ESM-safe highlight.js import
- `README.md` — Tailwind v4 + Vite integration guide section