### PR TITLE
refactor(core): eliminate all backward-compat debt and fix reactivity…

### DIFF
--- a/packages/core/src/context.svelte.ts
+++ b/packages/core/src/context.svelte.ts
@@ -8,7 +8,7 @@ import type { RouterProvider } from './router-provider';
 
 /**
  * Accepts either:
- *   - A single DataProvider (backwards compatible)
+ *   - A single DataProvider
  *   - A record of named providers: { default: rest, cms: graphql }
  */
 export type DataProviderInput = DataProvider | Record<string, DataProvider>;

--- a/packages/core/src/form-hooks.svelte.ts
+++ b/packages/core/src/form-hooks.svelte.ts
@@ -125,8 +125,8 @@ export interface UseFormReturn<
   readonly autoSave: { status: 'idle' | 'saving' | 'saved' | 'error'; data: unknown; error: unknown };
 
   // ─── Raw query/mutation (escape hatch) ────────────────────────
-  readonly query: ReturnType<typeof createQuery> | null;
-  readonly mutation: ReturnType<typeof createMutation>;
+  readonly query: unknown;
+  readonly mutation: unknown;
 }
 
 // ─── Implementation ──────────────────────────────────────────────────
@@ -423,6 +423,6 @@ export function useForm<
 
     // Raw escape hatches
     query,
-    mutation: (action === 'edit' ? updateMut : createMut) as unknown as ReturnType<typeof createMutation>,
+    mutation: action === 'edit' ? updateMut : createMut,
   };
 }

--- a/packages/core/src/hook-utils.svelte.ts
+++ b/packages/core/src/hook-utils.svelte.ts
@@ -97,6 +97,7 @@ export function fireSuccessNotification(
   resource?: string,
 ): void {
   if (config === false) return;
+  if (!config && !defaultMessage) return;
   if (typeof config === 'function') {
     const result = config(data, values, resource);
     toast.success(result.message);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,7 +27,7 @@ export {
 } from './hooks.svelte';
 export { matchRoute, navigate, currentPath, setActiveRouterProvider } from './router';
 export { readURLState, writeURLState } from './url-sync';
-export { setAccessControlProvider, getAccessControlProvider, getAccessControlOptions, canAccess, canAccessAsync } from './permissions';
+export { setAccessControlProvider, getAccessControlProvider, getAccessControlOptions, canAccessAsync } from './permissions';
 export { useLive, useSubscription, usePublish } from './live.svelte';
 export { toast } from './toast.svelte';
 export { notify, closeNotification, setNotificationProvider, getNotificationProvider } from './notification.svelte';

--- a/packages/core/src/permissions.test.ts
+++ b/packages/core/src/permissions.test.ts
@@ -1,6 +1,6 @@
 // Unit tests for permissions module
 import { describe, test, expect, beforeEach } from 'bun:test';
-import { setAccessControlProvider, getAccessControlProvider, getAccessControlOptions, canAccess, canAccessAsync } from './permissions';
+import { setAccessControlProvider, getAccessControlProvider, getAccessControlOptions, canAccessAsync } from './permissions';
 import type { Action, AccessControlProvider } from './permissions';
 
 describe('permissions', () => {
@@ -9,12 +9,6 @@ describe('permissions', () => {
     setAccessControlProvider({
       can: async () => ({ can: true }),
     });
-  });
-
-  test('canAccess returns { can: true } when provider is async (warns)', () => {
-    // canAccess is sync but provider.can() is async — should default to { can: true }
-    const result = canAccess('posts', 'list' as Action);
-    expect(result.can).toBe(true);
   });
 
   test('canAccessAsync respects deny rule', async () => {

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -73,17 +73,7 @@ export function getAccessControlOptions() {
 }
 
 /**
- * Synchronous access check. Returns `{ can: true }` if no provider is set.
- * When a provider is registered, this warns since provider.can() is always async.
- */
-export function canAccess(resource: string, action: Action, params?: Record<string, unknown>): CanResult {
-  if (!provider) return { can: true };
-  console.warn('[permissions] canAccess called synchronously but provider.can() is async. Defaulting to { can: true }. Use canAccessAsync() instead.');
-  return { can: true };
-}
-
-/**
- * Async access check. Preferred over `canAccess()`.
+ * Async access check. Returns `{ can: true }` if no provider is registered.
  */
 export async function canAccessAsync(resource: string, action: Action, params?: Record<string, unknown>): Promise<CanResult> {
   if (!provider) return { can: true };

--- a/packages/core/src/query-hooks.svelte.ts
+++ b/packages/core/src/query-hooks.svelte.ts
@@ -75,7 +75,7 @@ export function useList<TData extends BaseRecord = BaseRecord, TError = HttpErro
   });
 
   $effect(() => {
-    if (query.isSuccess) {
+    if (query.isSuccess && options.successNotification) {
       fireSuccessNotification(options.successNotification, '', query.data, undefined, resource);
     } else if (query.isError) {
       fireErrorNotification(options.errorNotification, 'Fetch failed', query.error);

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -53,9 +53,9 @@ export function matchRoute(
 /**
  * Navigate to a path. Uses RouterProvider if available, falls back to hash.
  */
-export function navigate(path: string): void {
+export function navigate(path: string, options?: { replaceState?: boolean }): void {
   if (_routerProvider) {
-    _routerProvider.go({ to: path });
+    _routerProvider.go({ to: path, type: options?.replaceState ? 'replace' : 'push' });
   } else {
     window.location.hash = '#' + path.replace(/^#/, '');
   }

--- a/packages/core/src/routing-hooks.svelte.ts
+++ b/packages/core/src/routing-hooks.svelte.ts
@@ -42,7 +42,6 @@ export function useGo() {
     if (routerProvider?.go) {
       routerProvider.go({ to: targetUrl, type: options.type });
     } else {
-      // @ts-expect-error SvelteKit / internal navigate might only take 1 arg or options obj
       navigate(targetUrl, options.type === 'replace' ? { replaceState: true } : undefined);
     }
   };

--- a/packages/core/src/table-hooks.svelte.ts
+++ b/packages/core/src/table-hooks.svelte.ts
@@ -69,15 +69,15 @@ export function useTable<
 
   const querySorters = $derived(sortersMode === 'server' ? effectiveSorters : []);
   const queryFilters = $derived(filtersMode === 'server' ? effectiveFilters : []);
-  const queryPagination = paginationMode === 'server'
+  const queryPagination = $derived(paginationMode === 'server'
     ? pagination
-    : { current: 1, pageSize: 999999, mode: paginationMode as 'client' | 'off' };
+    : { current: 1, pageSize: 999999, mode: paginationMode as 'client' | 'off' });
 
   const tableQueryInfo = useList<TQueryFnData, TError>({
     resource,
-    pagination: queryPagination,
-    sorters: querySorters,
-    filters: queryFilters,
+    get pagination() { return queryPagination; },
+    get sorters() { return querySorters; },
+    get filters() { return queryFilters; },
     meta,
     dataProviderName,
     ...restOptions

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -364,7 +364,7 @@ export interface FieldDefinition {
  */
 export interface ResourceTypeMap {}
 
-/** When ResourceTypeMap is empty → string (backward compatible); otherwise → registered keys */
+/** When ResourceTypeMap is empty → string; otherwise → registered keys */
 export type KnownResources = keyof ResourceTypeMap extends never
   ? string
   : Extract<keyof ResourceTypeMap, string>

--- a/packages/core/src/useCan.ts
+++ b/packages/core/src/useCan.ts
@@ -22,48 +22,28 @@ export interface UseCanResult {
 
 /**
  * Reactive permission check backed by TanStack Query for caching and deduplication.
+ * Accepts a getter function for Svelte 5 fine-grained reactivity.
  *
  * @example
  * ```ts
- * // Simple usage (backward compatible)
- * const can = useCan('posts', 'delete');
+ * const can = useCan(() => ({ resource: 'posts', action: 'delete', params: { id: 1 } }));
  * if (can.allowed) { ... }
- *
- * // With options object
- * const can = useCan({ resource: 'posts', action: 'delete', params: { id: 1 } });
  * ```
  */
-export function useCan(
-  resourceOrOptions: string | UseCanOptions | (() => UseCanOptions),
-  action?: Action,
-  params?: Record<string, unknown>
-): UseCanResult {
-  const getOptions = (): UseCanOptions => {
-    if (typeof resourceOrOptions === 'function') {
-      return resourceOrOptions();
-    }
-    if (typeof resourceOrOptions === 'string') {
-      return { resource: resourceOrOptions, action: action ?? 'list', params };
-    }
-    return resourceOrOptions;
-  };
-
-  // @tanstack/svelte-query v6 Accessor pattern
+export function useCan(options: () => UseCanOptions): UseCanResult {
   const query = createQuery<CanResult>(() => {
-    const options = getOptions();
+    const opts = options();
     return {
-      queryKey: ['useCan', options.resource, options.action, options.params] as const,
-      queryFn: () => canAccessAsync(options.resource, options.action, options.params),
-      enabled: options.queryOptions?.enabled ?? true,
-      staleTime: options.queryOptions?.staleTime ?? 5 * 60 * 1000, // 5 min default cache
+      queryKey: ['useCan', opts.resource, opts.action, opts.params] as const,
+      queryFn: () => canAccessAsync(opts.resource, opts.action, opts.params),
+      enabled: opts.queryOptions?.enabled ?? true,
+      staleTime: opts.queryOptions?.staleTime ?? 5 * 60 * 1000,
     };
   });
 
-  // Access via query store — use safe property access with fallbacks
   return {
     get allowed() { return (query.data as CanResult | undefined)?.can ?? true; },
     get reason() { return (query.data as CanResult | undefined)?.reason; },
     get isLoading() { return query.isLoading; },
   };
 }
-

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -13,7 +13,7 @@
   import { useList, useDelete, getResource } from '@svadmin/core';
   import type { Pagination as PaginationState, Sort, Filter, FieldDefinition } from '@svadmin/core';
   import { navigate } from '@svadmin/core/router';
-  import { canAccess } from '@svadmin/core/permissions';
+  import { useCan } from '@svadmin/core';
   import { readURLState, writeURLState } from '@svadmin/core';
   import { t } from '@svadmin/core/i18n';
   import { fade } from 'svelte/transition';
@@ -136,10 +136,14 @@
   const deleteMutation = deleteResult.mutation;
 
   // ─── Permissions ──────────────────────────────────────────────
-  const canCreate = $derived(canAccess(resourceName, 'create').can && resource.canCreate !== false);
-  const canEdit = $derived(canAccess(resourceName, 'edit').can && resource.canEdit !== false);
-  const canDelete = $derived(canAccess(resourceName, 'delete').can && resource.canDelete !== false);
-  const canExport = $derived(canAccess(resourceName, 'export').can);
+  const canCreatePerm = useCan(() => ({ resource: resourceName, action: 'create' }));
+  const canEditPerm = useCan(() => ({ resource: resourceName, action: 'edit' }));
+  const canDeletePerm = useCan(() => ({ resource: resourceName, action: 'delete' }));
+  const canExportPerm = useCan(() => ({ resource: resourceName, action: 'export' }));
+  const canCreate = $derived(canCreatePerm.allowed && resource.canCreate !== false);
+  const canEdit = $derived(canEditPerm.allowed && resource.canEdit !== false);
+  const canDelete = $derived(canDeletePerm.allowed && resource.canDelete !== false);
+  const canExport = $derived(canExportPerm.allowed);
 
   // ─── TanStack Table state ────────────────────────────────────
   let sorting = $state<SortingState>(untrack(() =>

--- a/packages/ui/src/components/MarkdownRenderer.svelte
+++ b/packages/ui/src/components/MarkdownRenderer.svelte
@@ -1,13 +1,9 @@
 <script lang="ts">
-  // @ts-expect-error - missing types
   import { Marked } from "marked";
-  // @ts-expect-error - missing types
   import { markedHighlight } from "marked-highlight";
-  // @ts-expect-error - missing types
   import * as hljsModule from "highlight.js";
   const hljs = "default" in hljsModule ? hljsModule.default : hljsModule;
   import "highlight.js/styles/github-dark.css"; // or your preferred theme
-  // @ts-expect-error - missing types
   import DOMPurify from "isomorphic-dompurify";
   import { Check, Copy } from "lucide-svelte";
   import { Button } from "./ui/button/index.js";

--- a/packages/ui/src/markdown-deps.d.ts
+++ b/packages/ui/src/markdown-deps.d.ts
@@ -1,0 +1,21 @@
+// Type declarations for MarkdownRenderer dependencies
+declare module 'marked' {
+  export class Marked {
+    constructor(...extensions: unknown[]);
+    parse(src: string): string;
+  }
+}
+
+declare module 'marked-highlight' {
+  export function markedHighlight(options: {
+    langPrefix?: string;
+    highlight: (code: string, lang: string) => string;
+  }): unknown;
+}
+
+declare module 'isomorphic-dompurify' {
+  const DOMPurify: {
+    sanitize(dirty: string, config?: Record<string, unknown>): string;
+  };
+  export default DOMPurify;
+}


### PR DESCRIPTION
… bugs

- useCan: simplified to getter-only signature, removed 3 overloads
- permissions: deleted dead sync canAccess(), updated tests/exports
- AutoTable: migrated from canAccess to useCan with getter pattern
- query-hooks: fixed useList ghost notification ( guard)
- hook-utils: guarded fireSuccessNotification against empty params
- router: extended navigate() signature to accept options
- routing-hooks: removed @ts-expect-error now that navigate is fixed
- MarkdownRenderer: added .d.ts, removed 4 @ts-expect-error pragmas
- form-hooks: removed unsafe 'as unknown as' type cast
- table-hooks: fixed queryPagination/querySorters/queryFilters reactivity with  and getter props
- types: cleaned backward-compat comments throughout