### PR TITLE
fix(ui): remove stale null-checks on useCan result and add AC provide…

### DIFF
--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -13,7 +13,7 @@
   import { useList, useDelete, getResource } from '@svadmin/core';
   import type { Pagination as PaginationState, Sort, Filter, FieldDefinition } from '@svadmin/core';
   import { navigate } from '@svadmin/core/router';
-  import { useCan } from '@svadmin/core';
+  import { useCan, getAccessControlProvider } from '@svadmin/core';
   import { readURLState, writeURLState } from '@svadmin/core';
   import { t } from '@svadmin/core/i18n';
   import { fade } from 'svelte/transition';
@@ -136,10 +136,11 @@
   const deleteMutation = deleteResult.mutation;
 
   // ─── Permissions ──────────────────────────────────────────────
-  const canCreatePerm = useCan(() => ({ resource: resourceName, action: 'create' }));
-  const canEditPerm = useCan(() => ({ resource: resourceName, action: 'edit' }));
-  const canDeletePerm = useCan(() => ({ resource: resourceName, action: 'delete' }));
-  const canExportPerm = useCan(() => ({ resource: resourceName, action: 'export' }));
+  const acEnabled = $derived(!!getAccessControlProvider());
+  const canCreatePerm = useCan(() => ({ resource: resourceName, action: 'create', queryOptions: { enabled: acEnabled } }));
+  const canEditPerm = useCan(() => ({ resource: resourceName, action: 'edit', queryOptions: { enabled: acEnabled } }));
+  const canDeletePerm = useCan(() => ({ resource: resourceName, action: 'delete', queryOptions: { enabled: acEnabled } }));
+  const canExportPerm = useCan(() => ({ resource: resourceName, action: 'export', queryOptions: { enabled: acEnabled } }));
   const canCreate = $derived(canCreatePerm.allowed && resource.canCreate !== false);
   const canEdit = $derived(canEditPerm.allowed && resource.canEdit !== false);
   const canDelete = $derived(canDeletePerm.allowed && resource.canDelete !== false);

--- a/packages/ui/src/components/buttons/CloneButton.svelte
+++ b/packages/ui/src/components/buttons/CloneButton.svelte
@@ -21,7 +21,7 @@
     variant="outline"
     size={hideText ? 'icon' : 'sm'}
     class={className}
-    disabled={can ? !can.allowed : false}
+    disabled={!can.allowed}
     onclick={() => nav.clone(resource, recordItemId)}
   >
     <Copy class="h-4 w-4" />

--- a/packages/ui/src/components/buttons/CreateButton.svelte
+++ b/packages/ui/src/components/buttons/CreateButton.svelte
@@ -20,7 +20,7 @@
     variant="default"
     size={hideText ? 'icon' : 'default'}
     class={className}
-    disabled={can ? !can.allowed : false}
+    disabled={!can.allowed}
     onclick={() => nav.create(resource)}
   >
     <Plus class="h-4 w-4" />

--- a/packages/ui/src/components/buttons/DeleteButton.svelte
+++ b/packages/ui/src/components/buttons/DeleteButton.svelte
@@ -49,7 +49,7 @@
       variant="ghost"
       size={hideText ? 'icon' : 'sm'}
       class="text-destructive hover:text-destructive {className}"
-      disabled={can ? !can.allowed : false}
+      disabled={!can.allowed}
       onclick={handleDelete}
     >
       <Trash2 class="h-4 w-4" />

--- a/packages/ui/src/components/buttons/EditButton.svelte
+++ b/packages/ui/src/components/buttons/EditButton.svelte
@@ -21,7 +21,7 @@
     variant="outline"
     size={hideText ? 'icon' : 'sm'}
     class={className}
-    disabled={can ? !can.allowed : false}
+    disabled={!can.allowed}
     onclick={() => nav.edit(resource, recordItemId)}
   >
     <Pencil class="h-4 w-4" />

--- a/packages/ui/src/components/buttons/ExportButton.svelte
+++ b/packages/ui/src/components/buttons/ExportButton.svelte
@@ -21,7 +21,7 @@
     variant="outline"
     size={hideText ? 'icon' : 'sm'}
     class={className}
-    disabled={isLoading || (can ? !can.allowed : false)}
+    disabled={isLoading || !can.allowed}
     onclick={triggerExport}
   >
     <Download class="h-4 w-4" />

--- a/packages/ui/src/components/buttons/ImportButton.svelte
+++ b/packages/ui/src/components/buttons/ImportButton.svelte
@@ -47,7 +47,7 @@
     variant="outline"
     size={hideText ? 'icon' : 'sm'}
     class={className}
-    disabled={importHook.isLoading || (can ? !can.allowed : false)}
+    disabled={importHook.isLoading || !can.allowed}
     onclick={triggerImport}
   >
     <Upload class="h-4 w-4" />

--- a/packages/ui/src/components/buttons/ShowButton.svelte
+++ b/packages/ui/src/components/buttons/ShowButton.svelte
@@ -22,7 +22,7 @@
     variant="ghost"
     size={hideText ? 'icon' : 'sm'}
     class={className}
-    disabled={can ? !can.allowed : false}
+    disabled={!can.allowed}
     onclick={() => nav.show(resource, recordItemId)}
   >
     <Eye class="h-4 w-4" />


### PR DESCRIPTION
…r guard to AutoTable

After the useCan refactor to getter-based signature (a5ae668), can is always a UseCanResult object (never null). The ternary can ? !can.allowed : false is dead code from the old pattern.

Changes:
- Simplify disabled={can ? !can.allowed : false} to disabled={!can.allowed} across all 7 button components (Clone, Create, Delete, Edit, Export, Import, Show)
- Add queryOptions.enabled guard to AutoTable useCan calls using getAccessControlProvider() — only run permission queries when an AccessControlProvider is actually registered