### PR TITLE
fix(ui): add missing DraggableHeader import in AutoTable

### DIFF
--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -36,6 +36,7 @@
   import ConfirmDialog from './ConfirmDialog.svelte';
   import TooltipButton from './TooltipButton.svelte';
   import InlineEdit from './InlineEdit.svelte';
+  import DraggableHeader from './DraggableHeader.svelte';
   import type { Snippet } from 'svelte';
 
   // ─── Props with Snippet composability ─────────────────────────


### PR DESCRIPTION
Fixes a ReferenceError where DraggableHeader was not defined when rendering the AutoTable component, caused by a missing import after recent refactors.