### PR TITLE
fix(ui): fix DropdownMenu being open by default and unable to close

### DIFF
--- a/packages/ui/src/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/packages/ui/src/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { cn, type WithElementRef } from "../../../utils.js";
 	import type { HTMLAttributes } from "svelte/elements";
+	import { getContext } from "svelte";
 
 	type Props = WithElementRef<HTMLAttributes<HTMLDivElement>> & {
 		align?: "start" | "center" | "end";
@@ -13,8 +14,11 @@
 		children,
 		...restProps
 	}: Props = $props();
+
+	let isOpen = $derived(getContext<() => boolean>("svadmin-dropdown-open")?.() ?? true);
 </script>
 
+{#if isOpen}
 <div
 	bind:this={ref}
 	data-slot="dropdown-menu-content"
@@ -28,3 +32,4 @@
 >
 	{@render children?.()}
 </div>
+{/if}

--- a/packages/ui/src/components/ui/dropdown-menu/dropdown-menu.svelte
+++ b/packages/ui/src/components/ui/dropdown-menu/dropdown-menu.svelte
@@ -16,12 +16,16 @@
 		...restProps
 	}: Props = $props();
 
+	import { setContext } from "svelte";
+
 	function handleClickOutside(e: MouseEvent) {
 		if (ref && !ref.contains(e.target as Node)) {
 			open = false;
 			onOpenChange?.(false);
 		}
 	}
+
+	setContext("svadmin-dropdown-open", () => open);
 
 	$effect(() => {
 		if (open) {


### PR DESCRIPTION
- **Cause**: `@svadmin/ui` v0.22.0 refactored the `DropdownMenu` component and removed the `bits-ui` dependency, but missed passing down the `open` state. Because Svelte 5 snippets render their children directly by default, `DropdownMenu.Content` lacked conditional rendering logic and was forced to display unconditionally.
- **Fix**: Passed the `open` state down via `setContext` in `DropdownMenu.Root`, and wrapped the child content with `{#if isOpen}` guided by `getContext` inside `DropdownMenuContent`. This restores the original click-to-toggle dropdown functionality.