### PR TITLE
chore(ui): bump @svadmin/ui version to 0.32.6

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svadmin/ui",
-  "version": "0.32.5",
+  "version": "0.32.6",
   "description": "Pre-built admin UI components — AdminApp, AutoTable, AutoForm, Sidebar, Layout",
   "type": "module",
   "sideEffects": [


### PR DESCRIPTION
Releases the Svelte 5 context bounds fix for Breadcrumbs that was merged in #120 but skipped in the #121 release.