### PR TITLE
fix(ui): migrate tanstack table API to createCoreRowModel for alpha.32 compat

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svadmin/ui",
-  "version": "0.32.6",
+  "version": "0.32.7",
   "description": "Pre-built admin UI components — AdminApp, AutoTable, AutoForm, Sidebar, Layout",
   "type": "module",
   "sideEffects": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svadmin/ui",
-  "version": "0.32.5",
+  "version": "0.32.6",
   "description": "Pre-built admin UI components — AdminApp, AutoTable, AutoForm, Sidebar, Layout",
   "type": "module",
   "sideEffects": [

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -9,7 +9,7 @@
     type ColumnVisibilityState,
     type ExpandedState,
   } from '@tanstack/svelte-table';
-  import { getCoreRowModel } from '@tanstack/table-core';
+  import { createCoreRowModel } from '@tanstack/table-core';
 
   import { useList, useDelete, useDeleteMany, getResource, notify } from '@svadmin/core';
   import type { Pagination as PaginationState, Sort, Filter, FieldDefinition } from '@svadmin/core';
@@ -280,7 +280,7 @@
   const tbl = createTable({
     get data() { return query.data?.data ?? []; },
     get columns() { return columns; },
-    getCoreRowModel: getCoreRowModel(),
+    getCoreRowModel: createCoreRowModel(),
     manualPagination: true,
     manualSorting: true,
     getRowId: (row: any) => String(row[primaryKey]),


### PR DESCRIPTION
Refactors getCoreRowModel to createCoreRowModel so that @svadmin/ui supports @tanstack/table-core@9.0.0-alpha.32 natively, preventing MISSING_EXPORT errors during compilation. Bumps ui to 0.32.7