### PR TITLE
fix(ui): initialize component registry synchronously

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@lucide/svelte": "^1.7.0",
-    "@tanstack/svelte-table": "^9.0.0-alpha.10",
+    "@tanstack/svelte-table": "^9.0.0-alpha.32",
     "bits-ui": "^2.17.1",
     "clsx": "^2.1.1",
     "cmdk-sv": "^0.0.19",
@@ -83,7 +83,7 @@
     "url": "https://github.com/zuohuadong/svadmin/issues"
   },
   "devDependencies": {
-    "@tanstack/table-core": "8.21.3"
+    "@tanstack/table-core": "^9.0.0-alpha.32"
   },
   "scripts": {
     "build": "svelte-package -i src -o dist"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svadmin/ui",
-  "version": "0.32.7",
+  "version": "0.32.8",
   "description": "Pre-built admin UI components — AdminApp, AutoTable, AutoForm, Sidebar, Layout",
   "type": "module",
   "sideEffects": [

--- a/packages/ui/src/components/AdminApp.svelte
+++ b/packages/ui/src/components/AdminApp.svelte
@@ -78,10 +78,8 @@
     Skeleton: Skeleton as unknown as ComponentRegistry['Skeleton'],
   };
 
-  // Merge user overrides and set context
-  $effect(() => {
-    setComponentRegistry({ ...defaultComponents, ...userComponents });
-  });
+  // Set up context synchronously to avoid context undefined crash in children
+  setComponentRegistry({ ...defaultComponents, ...userComponents });
 
   // Resolve router provider (default to hash)
   const resolvedRouter = $derived(routerProvider ?? createHashRouterProvider());


### PR DESCRIPTION
Resolves Svelte 5 'Cannot read properties of undefined' crashes caused by deferring setContext to . Bumps ui to 0.32.8