### PR TITLE
fix(ui,supabase): resolve Svelte 5 context self-lookup crash and Vite dynamic import loss

### DIFF
--- a/packages/supabase/src/data-provider.ts
+++ b/packages/supabase/src/data-provider.ts
@@ -1,5 +1,9 @@
 import type { DataProvider } from '@svadmin/core';
 import { createRefineAdapter } from '@svadmin/refine-adapter';
+// Static import — dynamic import() gets dropped by Vite/Rollup in static SPA builds
+// @ts-ignore Peer dependency
+import { dataProvider as refineDataProvider } from '@refinedev/supabase';
+
 /**
  * Creates a supabase data provider using the official @refinedev/supabase package.
  * Requires `@refinedev/supabase` to be installed.
@@ -8,22 +12,11 @@ import { createRefineAdapter } from '@svadmin/refine-adapter';
  * @returns A fully compatible svadmin DataProvider
  */
 export async function createSupabaseDataProvider(...args: any[]): Promise<DataProvider> {
-  let pkg: any;
-  try {
-    // @ts-ignore Peer dependency
-    pkg = await import('@refinedev/supabase');
-  } catch {
-    throw new Error(
-      '[svadmin/supabase] Missing required dependency: @refinedev/supabase.\n' +
-      'The Supabase data provider requires this package to function.\n' +
-      'Install it with: bun add @refinedev/supabase'
-    );
-  }
-  const init: any = pkg.dataProvider || pkg.default || pkg.DataProvider;
+  const init: any = refineDataProvider;
   if (typeof init !== 'function') {
     throw new Error(
       '[svadmin/supabase] Failed to resolve @refinedev/supabase data provider. ' +
-      'Ensure the package is installed correctly.'
+      'Ensure the package is installed correctly: bun add @refinedev/supabase'
     );
   }
   const refineProvider = init(...args);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@lucide/svelte": "^1.7.0",
-    "@tanstack/svelte-table": "^9.0.0-alpha.10",
+    "@tanstack/svelte-table": "^9.0.0-alpha.32",
     "bits-ui": "^2.17.1",
     "clsx": "^2.1.1",
     "cmdk-sv": "^0.0.19",
@@ -83,7 +83,7 @@
     "url": "https://github.com/zuohuadong/svadmin/issues"
   },
   "devDependencies": {
-    "@tanstack/table-core": "8.21.3"
+    "@tanstack/table-core": "^9.0.0-alpha.32"
   },
   "scripts": {
     "build": "svelte-package -i src -o dist"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svadmin/ui",
-  "version": "0.32.7",
+  "version": "0.32.8",
   "description": "Pre-built admin UI components — AdminApp, AutoTable, AutoForm, Sidebar, Layout",
   "type": "module",
   "sideEffects": [

--- a/packages/ui/src/components/AdminApp.svelte
+++ b/packages/ui/src/components/AdminApp.svelte
@@ -78,8 +78,10 @@
     Skeleton: Skeleton as unknown as ComponentRegistry['Skeleton'],
   };
 
-  // Set up context synchronously to avoid context undefined crash in children
-  setComponentRegistry({ ...defaultComponents, ...userComponents });
+  // Merge and keep a local reference — setContext is only visible to *children*,
+  // so we must use the local variable for lookups within this component.
+  const mergedComponents: ComponentRegistry = { ...defaultComponents, ...userComponents };
+  setComponentRegistry(mergedComponents);
 
   // Resolve router provider (default to hash)
   const resolvedRouter = $derived(routerProvider ?? createHashRouterProvider());
@@ -195,27 +197,27 @@
         {/if}
       {:else if route === '/:resource' || route === '/:parent/:parentId/:resource'}
         {#key params.resource}
-          {@const Comp = getComponentRegistry().AutoTable}
+          {@const Comp = mergedComponents.AutoTable}
           <Comp resourceName={params.resource} />
         {/key}
       {:else if route === '/:resource/create' || route === '/:parent/:parentId/:resource/create'}
         {#key params.resource}
-          {@const Comp = getComponentRegistry().AutoForm}
+          {@const Comp = mergedComponents.AutoForm}
           <Comp resourceName={params.resource} mode="create" />
         {/key}
       {:else if route === '/:resource/edit/:id' || route === '/:parent/:parentId/:resource/edit/:id'}
         {#key `${params.resource}-${params.id}`}
-          {@const Comp = getComponentRegistry().AutoForm}
+          {@const Comp = mergedComponents.AutoForm}
           <Comp resourceName={params.resource} mode="edit" id={params.id} />
         {/key}
       {:else if route === '/:resource/show/:id' || route === '/:parent/:parentId/:resource/show/:id'}
         {#key `${params.resource}-${params.id}`}
-          {@const Comp = getComponentRegistry().ShowPage}
+          {@const Comp = mergedComponents.ShowPage}
           <Comp resourceName={params.resource} id={params.id} />
         {/key}
       {:else if route === '/:resource/clone/:id' || route === '/:parent/:parentId/:resource/clone/:id'}
         {#key `${params.resource}-clone-${params.id}`}
-          {@const Comp = getComponentRegistry().AutoForm}
+          {@const Comp = mergedComponents.AutoForm}
           <Comp resourceName={params.resource} mode="clone" id={params.id} />
         {/key}
       {/if}

--- a/packages/ui/src/components/AdminApp.svelte
+++ b/packages/ui/src/components/AdminApp.svelte
@@ -78,10 +78,8 @@
     Skeleton: Skeleton as unknown as ComponentRegistry['Skeleton'],
   };
 
-  // Merge user overrides and set context
-  $effect(() => {
-    setComponentRegistry({ ...defaultComponents, ...userComponents });
-  });
+  // Set up context synchronously to avoid context undefined crash in children
+  setComponentRegistry({ ...defaultComponents, ...userComponents });
 
   // Resolve router provider (default to hash)
   const resolvedRouter = $derived(routerProvider ?? createHashRouterProvider());


### PR DESCRIPTION
## Two critical runtime bugs fixed

### 1. AdminApp context self-reference crash (white screen)
Svelte 5's `setContext` is only visible to **child** components. `AdminApp` was calling `getComponentRegistry()` in its own template to resolve `AutoTable`/`AutoForm`/`ShowPage`, which always returned `undefined`.

**Fix:** Keep a local `mergedComponents` variable and reference it directly in the template instead of going through `getContext`.

### 2. Supabase data provider missing in production builds
`@svadmin/supabase` used `await import('@refinedev/supabase')` inside a try/catch. Vite/Rollup drops dynamic imports it cannot statically analyze during SPA bundling, causing the runtime error even when the package is installed.

**Fix:** Replace dynamic `import()` with a static `import { dataProvider } from '@refinedev/supabase'`.