### PR TITLE
fix(supabase): remove vestigial async from createSupabaseDataProvider

### DIFF
--- a/packages/supabase/src/data-provider.ts
+++ b/packages/supabase/src/data-provider.ts
@@ -11,7 +11,7 @@ import { dataProvider as refineDataProvider } from '@refinedev/supabase';
  * @param args Arguments required by @refinedev/supabase
  * @returns A fully compatible svadmin DataProvider
  */
-export async function createSupabaseDataProvider(...args: any[]): Promise<DataProvider> {
+export function createSupabaseDataProvider(...args: any[]): DataProvider {
   const init: any = refineDataProvider;
   if (typeof init !== 'function') {
     throw new Error(


### PR DESCRIPTION
## Problem
`createSupabaseDataProvider` was still marked `async` returning `Promise<DataProvider>`, even though v0.9.8 switched to static imports and the function body contains no `await`.

This forces consumers to either:
- Use `await` (breaks Svelte 5 top-level scripts which don't allow it)
- Cast with `as unknown as DataProvider` (ugly workaround)

## Fix
Remove `async` keyword and change return type to `DataProvider`.

## Impact
**Breaking (minor):** Consumers using `await createSupabaseDataProvider()` will get a TS warning that await has no effect on non-Promise. The function still works correctly either way at runtime.