### PR TITLE
fix(ui): guard header.getSize() for Tanstack v9 modular features

### DIFF
--- a/packages/supabase/src/data-provider.ts
+++ b/packages/supabase/src/data-provider.ts
@@ -11,7 +11,7 @@ import { dataProvider as refineDataProvider } from '@refinedev/supabase';
  * @param args Arguments required by @refinedev/supabase
  * @returns A fully compatible svadmin DataProvider
  */
-export async function createSupabaseDataProvider(...args: any[]): Promise<DataProvider> {
+export function createSupabaseDataProvider(...args: any[]): DataProvider {
   const init: any = refineDataProvider;
   if (typeof init !== 'function') {
     throw new Error(

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -557,7 +557,7 @@
                   <Table.Head
                     {...dragProps}
                     class={cn("bg-transparent hover:bg-muted/10 border-b border-border/20 uppercase tracking-[0.12em] text-[10px] text-muted-foreground/70 font-semibold py-4", dragProps.class)}
-                    style={header.getSize() !== 150 ? `width:${header.getSize()}px` : undefined}
+                    style={header.getSize?.() != null && header.getSize() !== 150 ? `width:${header.getSize()}px` : undefined}
                   >
                     {#if header.id === '_select'}
                       <Checkbox


### PR DESCRIPTION
Tanstack Table v9 alpha.32 made column sizing a modular feature. `header.getSize()` is only available when `columnSizingFeature` is registered. Since AutoTable doesn't use column sizing, this adds optional chaining to prevent the runtime crash: `e(...).getSize is not a function`.