### PR TITLE
fix(ui): pass components as icons & migrate tanstack instance methods

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -298,7 +298,7 @@ export interface MenuItem {
   /** Display label. Falls back to `t('menu.${name}')` if omitted */
   label?: string;
   /** Icon name string (maps to lucide icon set) or Svelte component */
-  icon?: string;
+  icon?: string | any;
   /** Navigation path — omit for parent-only menu nodes */
   href?: string;
   /** Open in new tab (useful for external links) */

--- a/packages/supabase/src/data-provider.ts
+++ b/packages/supabase/src/data-provider.ts
@@ -11,7 +11,7 @@ import { dataProvider as refineDataProvider } from '@refinedev/supabase';
  * @param args Arguments required by @refinedev/supabase
  * @returns A fully compatible svadmin DataProvider
  */
-export async function createSupabaseDataProvider(...args: any[]): Promise<DataProvider> {
+export function createSupabaseDataProvider(...args: any[]): DataProvider {
   const init: any = refineDataProvider;
   if (typeof init !== 'function') {
     throw new Error(

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -9,7 +9,13 @@
     type ColumnVisibilityState,
     type ExpandedState,
   } from '@tanstack/svelte-table';
-  import { createCoreRowModel } from '@tanstack/table-core';
+  import { 
+    createCoreRowModel, 
+    column_getCanSort, 
+    column_getIsSorted, 
+    column_toggleSorting, 
+    header_getSize 
+  } from '@tanstack/table-core';
 
   import { useList, useDelete, useDeleteMany, getResource, notify } from '@svadmin/core';
   import type { Pagination as PaginationState, Sort, Filter, FieldDefinition } from '@svadmin/core';
@@ -557,7 +563,7 @@
                   <Table.Head
                     {...dragProps}
                     class={cn("bg-transparent hover:bg-muted/10 border-b border-border/20 uppercase tracking-[0.12em] text-[10px] text-muted-foreground/70 font-semibold py-4", dragProps.class)}
-                    style={header.getSize?.() != null && header.getSize() !== 150 ? `width:${header.getSize()}px` : undefined}
+                    style={header_getSize(header) != null && header_getSize(header) !== 150 ? `width:${header_getSize(header)}px` : undefined}
                   >
                     {#if header.id === '_select'}
                       <Checkbox
@@ -568,17 +574,17 @@
                       <!-- empty -->
                     {:else if header.id === '_actions'}
                       <span class="text-right block">{t('common.actions')}</span>
-                    {:else if header.column.getCanSort()}
+                    {:else if column_getCanSort(header.column)}
                       <Button
                         variant="ghost"
                         size="sm"
                         class="flex items-center gap-1 hover:text-foreground -ml-2 h-auto py-1 px-2 uppercase tracking-wide text-[0.7rem] font-semibold"
-                        onclick={() => header.column.toggleSorting()}
+                        onclick={() => column_toggleSorting(header.column)}
                       >
                         {visibleFields.find(f => f.key === header.id)?.label ?? header.id}
                         <span class="text-xs opacity-50">
-                          {#if header.column.getIsSorted() === 'asc'}↑
-                          {:else if header.column.getIsSorted() === 'desc'}↓
+                          {#if column_getIsSorted(header.column) === 'asc'}↑
+                          {:else if column_getIsSorted(header.column) === 'desc'}↓
                           {:else}⇅
                           {/if}
                         </span>

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -557,7 +557,7 @@
                   <Table.Head
                     {...dragProps}
                     class={cn("bg-transparent hover:bg-muted/10 border-b border-border/20 uppercase tracking-[0.12em] text-[10px] text-muted-foreground/70 font-semibold py-4", dragProps.class)}
-                    style={header.getSize() !== 150 ? `width:${header.getSize()}px` : undefined}
+                    style={header.getSize?.() != null && header.getSize() !== 150 ? `width:${header.getSize()}px` : undefined}
                   >
                     {#if header.id === '_select'}
                       <Checkbox

--- a/packages/ui/src/components/Sidebar.svelte
+++ b/packages/ui/src/components/Sidebar.svelte
@@ -99,7 +99,7 @@
           items.push({
             path: `/${r.name}`,
             label: r.label,
-            Icon: iconMap[r.icon ?? r.name] ?? Settings,
+            Icon: (typeof r.icon === 'string' ? iconMap[r.icon] : r.icon) ?? iconMap[r.name] ?? Settings,
             group: r.group,
           });
         }

--- a/packages/ui/src/components/SidebarItem.svelte
+++ b/packages/ui/src/components/SidebarItem.svelte
@@ -27,8 +27,9 @@
     folder: Folder,
   };
 
-  function getIcon(name?: string): typeof LayoutDashboard {
+  function getIcon(name?: string | any): typeof LayoutDashboard {
     if (!name) return depth === 0 ? Settings : Folder;
+    if (typeof name !== 'string') return name; // if it's already a component
     return iconMap[name] ?? Settings;
   }
 


### PR DESCRIPTION
Previously, `MenuItem.icon` strictly required a string that was mapped to predefined icons in `iconMap`. This prevented users from using custom Lucide icons or other Svelte components without overriding the entire Sidebar component.

Because Svelte 5 snippets/components can be passed around, this change allows passing a Component directly to `MenuItem.icon` and `ResourceDefinition.icon`, bypassing the hardcoded `iconMap`. This makes it trivial to use any `lucide-svelte` component or custom SVG directly in the resource definitions.