### PR TITLE
Handle invalid Supabase refresh tokens and expose query client config

### DIFF
--- a/packages/supabase/src/auth-provider.ts
+++ b/packages/supabase/src/auth-provider.ts
@@ -3,6 +3,26 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { AuthProvider, Identity, AuthActionResult, CheckResult } from '@svadmin/core';
 import { audit } from '@svadmin/core';
 
+const INVALID_REFRESH_TOKEN_MESSAGES = [
+  'refresh token is not valid',
+  'invalid refresh token',
+  'refresh_token_not_found',
+  'jwt expired',
+];
+
+function isInvalidRefreshTokenError(error: unknown): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return INVALID_REFRESH_TOKEN_MESSAGES.some((fragment) => message.includes(fragment));
+}
+
+async function clearInvalidSession(client: SupabaseClient): Promise<void> {
+  await client.auth.signOut({ scope: 'local' });
+}
+
 export function createSupabaseAuthProvider(client: SupabaseClient): AuthProvider {
   return {
     async login({ email, password }: Record<string, unknown>): Promise<AuthActionResult> {
@@ -23,16 +43,42 @@ export function createSupabaseAuthProvider(client: SupabaseClient): AuthProvider
     },
 
     async check(): Promise<CheckResult> {
-      const { data: { session } } = await client.auth.getSession();
+      const { data: { session }, error } = await client.auth.getSession();
+      if (error) {
+        if (isInvalidRefreshTokenError(error)) {
+          await clearInvalidSession(client);
+          return {
+            authenticated: false,
+            redirectTo: '/login',
+            logout: true,
+            error: { message: 'Session expired, please sign in again.' },
+          };
+        }
+
+        return {
+          authenticated: false,
+          redirectTo: '/login',
+          logout: true,
+          error: { message: 'Session validation failed.' },
+        };
+      }
       if (session) return { authenticated: true };
       return { authenticated: false, redirectTo: '/login', logout: true };
     },
 
     async getIdentity(): Promise<Identity | null> {
-      const { data: { user } } = await client.auth.getUser();
+      const { data: { user }, error } = await client.auth.getUser();
+      if (error && isInvalidRefreshTokenError(error)) {
+        await clearInvalidSession(client);
+        return null;
+      }
       if (!user) return null;
       
-      const { data: { session } } = await client.auth.getSession();
+      const { data: { session }, error: sessionError } = await client.auth.getSession();
+      if (sessionError && isInvalidRefreshTokenError(sessionError)) {
+        await clearInvalidSession(client);
+        return null;
+      }
       
       return {
         id: user.id,
@@ -44,7 +90,11 @@ export function createSupabaseAuthProvider(client: SupabaseClient): AuthProvider
     },
 
     async getPermissions(): Promise<unknown> {
-      const { data: { user } } = await client.auth.getUser();
+      const { data: { user }, error } = await client.auth.getUser();
+      if (error && isInvalidRefreshTokenError(error)) {
+        await clearInvalidSession(client);
+        return null;
+      }
       return user?.user_metadata?.role ?? 'user';
     },
 
@@ -71,6 +121,11 @@ export function createSupabaseAuthProvider(client: SupabaseClient): AuthProvider
     },
 
     async onError(error: unknown): Promise<{ redirectTo?: string; logout?: boolean }> {
+      if (isInvalidRefreshTokenError(error)) {
+        await clearInvalidSession(client);
+        return { redirectTo: '/login', logout: true };
+      }
+
       if (error instanceof Error && error.message.includes('401')) {
         // Pre-flight check: race-condition guard
         // Supabase might have just refreshed the token in the background right after our fetch failed

--- a/packages/supabase/src/supabase.test.ts
+++ b/packages/supabase/src/supabase.test.ts
@@ -135,6 +135,24 @@ describe('Supabase AuthProvider', () => {
     expect(result.logout).toBe(true);
   });
 
+  test('check clears invalid refresh token sessions', async () => {
+    const { createSupabaseAuthProvider } = await import('./auth-provider');
+    const client = createMockSupabaseClient({
+      auth: {
+        getSession: mock(async () => ({
+          data: { session: null },
+          error: new Error('Refresh token is not valid'),
+        })),
+      }
+    });
+    const auth = createSupabaseAuthProvider(client);
+    const result = await auth.check();
+    expect(result.authenticated).toBe(false);
+    expect(result.logout).toBe(true);
+    expect(result.redirectTo).toBe('/login');
+    expect(client.auth.signOut).toHaveBeenCalled();
+  });
+
   test('getIdentity surfaces user metadata', async () => {
     const { createSupabaseAuthProvider } = await import('./auth-provider');
     const auth = createSupabaseAuthProvider(createMockSupabaseClient());
@@ -150,6 +168,22 @@ describe('Supabase AuthProvider', () => {
     const auth = createSupabaseAuthProvider(createMockSupabaseClient());
     const role = await auth.getPermissions?.();
     expect(role).toBe('admin');
+  });
+
+  test('getIdentity clears invalid refresh token sessions', async () => {
+    const { createSupabaseAuthProvider } = await import('./auth-provider');
+    const client = createMockSupabaseClient({
+      auth: {
+        getUser: mock(async () => ({
+          data: { user: null },
+          error: new Error('Invalid refresh token'),
+        })),
+      }
+    });
+    const auth = createSupabaseAuthProvider(client);
+    const identity = await auth.getIdentity();
+    expect(identity).toBeNull();
+    expect(client.auth.signOut).toHaveBeenCalled();
   });
 
   test('onError returns logout true on 401 with no session', async () => {
@@ -171,6 +205,16 @@ describe('Supabase AuthProvider', () => {
     const result = await auth.onError!(new Error('401 Unauthorized'));
     expect(result.logout).toBeUndefined();
     expect(client.auth.signOut).not.toHaveBeenCalled();
+  });
+
+  test('onError logs out on invalid refresh token', async () => {
+    const { createSupabaseAuthProvider } = await import('./auth-provider');
+    const client = createMockSupabaseClient();
+    const auth = createSupabaseAuthProvider(client);
+    const result = await auth.onError!(new Error('Refresh token is not valid'));
+    expect(result.logout).toBe(true);
+    expect(result.redirectTo).toBe('/login');
+    expect(client.auth.signOut).toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/components/AdminApp.svelte
+++ b/packages/ui/src/components/AdminApp.svelte
@@ -7,7 +7,7 @@
   import { t } from '@svadmin/core/i18n';
   import { navigate } from '@svadmin/core/router';
   import { currentPath } from '@svadmin/core/router';
-  import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
+  import { QueryClient, QueryClientProvider, type DefaultOptions } from '@tanstack/svelte-query';
   import { setComponentRegistry, getComponentRegistry, type ComponentRegistry } from '../component-registry.svelte.js';
   import Layout from './Layout.svelte';
   import AutoTable from './AutoTable.svelte';
@@ -49,6 +49,10 @@
     siteUrl?: string;
     /** Routing strategy for Sidebar links ('hash' | 'path' | 'auto') */
     routeMode?: 'hash' | 'path' | 'auto';
+    /** Optional TanStack Query client override. */
+    queryClient?: QueryClient;
+    /** Optional TanStack Query default options override when QueryClient is not supplied. */
+    queryClientDefaultOptions?: DefaultOptions;
   }
 
   let {
@@ -66,6 +70,8 @@
     menu,
     siteUrl,
     routeMode,
+    queryClient: providedQueryClient,
+    queryClientDefaultOptions,
   }: Props = $props();
 
   // Default component registry
@@ -107,11 +113,12 @@
     if (defaultTheme) setTheme(defaultTheme);
   });
 
-  const queryClient = new QueryClient({
+  const queryClient = $derived(providedQueryClient ?? new QueryClient({
     defaultOptions: {
       queries: { staleTime: 30_000, retry: 1 },
+      ...queryClientDefaultOptions,
     },
-  });
+  }));
 
   // Initialize router with provider synchronously
   initRouter(resolvedRouter);


### PR DESCRIPTION
## Summary
- handle invalid Supabase refresh token errors by clearing local sessions and redirecting to login
- add tests covering invalid refresh token flows in the Supabase auth provider
- let AdminApp accept an injected QueryClient or query client default options so apps can tune retry behavior

## Motivation
Apps using  currently need to patch around  errors locally. In practice this leaves stale sessions in storage and causes repeated list/query retries. This PR moves that behavior into the shared provider and exposes a supported way for apps to customize TanStack Query defaults without forking .

## Notes
- Existing  behavior is preserved by default (, ).
- The new props are optional and backward compatible.

## Validation
- bun test v1.3.12 (700fc117) (auth-provider and live-provider tests pass; existing data-provider tests still fail in this workspace because  is unavailable in the test environment)
