### PR TITLE
fix(ui): pin tanstack svelte-table alpha dependency

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@lucide/svelte": "^1.7.0",
-    "@tanstack/svelte-table": "^9.0.0-alpha.32",
+    "@tanstack/svelte-table": "9.0.0-alpha.32",
     "bits-ui": "^2.17.1",
     "clsx": "^2.1.1",
     "cmdk-sv": "^0.0.19",


### PR DESCRIPTION
## Summary
- pin `@tanstack/svelte-table` in `packages/ui` to the exact `9.0.0-alpha.32` version
- avoid consumers resolving to `alpha.34+` while `AutoTable.svelte` still imports the older helper exports

## Why
`@svadmin/ui@0.34.0` currently publishes `@tanstack/svelte-table` as `^9.0.0-alpha.32`. In consuming apps this can resolve to `9.0.0-alpha.34`, but that version no longer exports helpers such as `column_getCanSort`, `column_getIsSorted`, and `column_toggleSorting`.

That breaks production builds with errors like:

- `column_getCanSort is not exported by @tanstack/svelte-table`
- `column_getIsSorted is not exported by @tanstack/svelte-table`
- `column_toggleSorting is not exported by @tanstack/svelte-table`

Pinning the alpha dependency is the minimal safe fix until `@svadmin/ui` is updated to the newer TanStack API surface.

## Validation
- confirmed the published `dist/components/AutoTable.svelte` still imports the alpha.32-era helpers
- confirmed the consumer breakage occurs when the dependency resolves to `@tanstack/svelte-table@9.0.0-alpha.34`
- upstream workspace `typecheck` is currently failing for unrelated pre-existing issues, so this PR keeps scope to the dependency declaration only
