### PR TITLE
fix: allow nullable task record fields

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,6 +119,8 @@ export type { UseSelectOptions } from './hooks.svelte';
 export type { UseFormReturn } from './form-hooks.svelte';
 export type {
   TaskProvider,
+  TaskDateValue,
+  TaskMessageValue,
   TaskRecord,
   SubmitTaskOptions,
   TaskHandle,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -194,6 +194,9 @@ export interface DataProvider {
 
 // ─── TaskProvider ─────────────────────────────────────────────
 
+export type TaskDateValue = string | Date | null;
+export type TaskMessageValue = string | null;
+
 export interface TaskRecord extends BaseRecord {
   id: string;
   name?: string;
@@ -203,7 +206,7 @@ export interface TaskRecord extends BaseRecord {
   priority?: number;
   queueName?: string;
   queue_name?: string;
-  message?: string;
+  message?: TaskMessageValue;
   payload?: unknown;
   /**
    * Task output payload. `result` is the canonical camelCase field used by
@@ -213,16 +216,21 @@ export interface TaskRecord extends BaseRecord {
    */
   result?: unknown;
   result_data?: unknown;
-  createdAt?: string | Date;
-  created_at?: string | Date;
-  updatedAt?: string | Date;
-  updated_at?: string | Date;
-  startedAt?: string | Date;
-  started_at?: string | Date;
-  finishedAt?: string | Date;
-  finished_at?: string | Date;
-  cancelledAt?: string | Date;
-  cancelled_at?: string | Date;
+  /**
+   * Task lifecycle timestamps. Supabase/Postgres mirrors often expose nullable
+   * columns for lifecycle phases that have not happened yet, and svadmin UI
+   * helpers intentionally skip nullish values with `??` fallback ordering.
+   */
+  createdAt?: TaskDateValue;
+  created_at?: TaskDateValue;
+  updatedAt?: TaskDateValue;
+  updated_at?: TaskDateValue;
+  startedAt?: TaskDateValue;
+  started_at?: TaskDateValue;
+  finishedAt?: TaskDateValue;
+  finished_at?: TaskDateValue;
+  cancelledAt?: TaskDateValue;
+  cancelled_at?: TaskDateValue;
   /**
    * Task failure payload/message. `error` carries structured error details
    * when available; `errorMessage` and `error_message` are string fallbacks for
@@ -230,8 +238,8 @@ export interface TaskRecord extends BaseRecord {
    * `errorMessage`, then `error_message`, matching `resolveTaskError`.
    */
   error?: unknown;
-  errorMessage?: string;
-  error_message?: string;
+  errorMessage?: TaskMessageValue;
+  error_message?: TaskMessageValue;
 }
 
 export interface SubmitTaskOptions {

--- a/packages/ui/src/components/task-utils.test.ts
+++ b/packages/ui/src/components/task-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import type { TaskRecord } from '@svadmin/core';
+import {
+  resolveTaskCreatedAt,
+  resolveTaskError,
+  resolveTaskMessage,
+  resolveTaskResult,
+  resolveTaskUpdatedAt,
+} from './task-utils';
+
+describe('task-utils compatibility resolvers', () => {
+  test('skips nullable timestamp fields using lifecycle fallback order', () => {
+    const task: TaskRecord = {
+      id: 'task-1',
+      updatedAt: null,
+      updated_at: null,
+      finishedAt: null,
+      finished_at: null,
+      startedAt: null,
+      started_at: '2026-04-26T01:00:00.000Z',
+      createdAt: null,
+      created_at: '2026-04-26T00:00:00.000Z',
+    };
+
+    expect(resolveTaskUpdatedAt(task)).toBe('2026-04-26T01:00:00.000Z');
+    expect(resolveTaskCreatedAt(task)).toBe('2026-04-26T00:00:00.000Z');
+  });
+
+  test('keeps documented result and error fallback priority with null fields', () => {
+    const task: TaskRecord = {
+      id: 'task-2',
+      result: null,
+      result_data: { url: 'https://example.test/result.png' },
+      error: null,
+      errorMessage: null,
+      error_message: 'Remote worker failed',
+      message: null,
+    };
+
+    expect(resolveTaskResult(task)).toEqual({ url: 'https://example.test/result.png' });
+    expect(resolveTaskError(task)).toBe('Remote worker failed');
+    expect(resolveTaskMessage(task)).toBe('Remote worker failed');
+  });
+});


### PR DESCRIPTION
## Summary
- Allow TaskRecord lifecycle timestamp and message compatibility fields to be null.
- Export TaskDateValue and TaskMessageValue for downstream providers.
- Add resolver coverage for nullable Supabase/Postgres-style task records.

## Why
Supabase/Postgres task mirrors commonly expose not-yet-populated lifecycle columns as null. Downstream apps should not need to strip nulls before passing records to svadmin task UI helpers.

## Validation
- cd packages/ui && bun run test -- src/components/task-utils.test.ts src/components/TaskQueueDrawer.test.svelte.ts
- bun run typecheck (0 errors, existing 18 warnings)
