### PR TITLE
fix(ui): add types for component deep imports

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,11 @@
       "style": "./dist/app.css",
       "default": "./dist/app.css"
     },
+    "./components/*.svelte": {
+      "types": "./dist/components/*.svelte.d.ts",
+      "svelte": "./dist/components/*.svelte",
+      "default": "./dist/components/*.svelte"
+    },
     "./components/*": "./dist/components/*"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- add explicit export conditions for @svadmin/ui/components/*.svelte
- expose generated .svelte.d.ts files through the package exports map
- keep the existing ./components/* fallback for non-Svelte utility deep imports

## Why
Consumers can use component deep imports to lazy-load heavy UI pieces, but TypeScript/svelte-check currently cannot resolve @svadmin/ui/components/AdminApp.svelte because the wildcard export has no types condition.

## Validation
- bun run --cwd packages/ui build
- temporary TypeScript consumer with moduleResolution=bundler importing @svadmin/ui/components/AdminApp.svelte and ConfigErrorScreen.svelte
- bun run typecheck (passes with existing warnings)