### PR TITLE
fix(supabase): allow supacloud js 0.12

### DIFF
--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -23,7 +23,7 @@
     "@svadmin/core": "workspace:*",
     "@supabase/supabase-js": "^2.0.0",
     "@refinedev/supabase": "^5.0.0",
-    "@supacloud/js": "^0.10.0"
+    "@supacloud/js": "^0.12.0"
   },
   "license": "MIT",
   "author": "zuohuadong",


### PR DESCRIPTION
## Summary
- Allow @svadmin/supabase to work with @supacloud/js 0.12.x
- Keeps the SupaCloud adapter peer range aligned with the current SupaCloud JS SDK release

## Test Plan
- bun run typecheck

Note: this fix was already fast-forwarded to main in commit aaaa330; this PR branch mirrors the same change for review traceability.