### PR TITLE
fix(ui): add types for component deep imports

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,11 @@
       "style": "./dist/app.css",
       "default": "./dist/app.css"
     },
+    "./components/*.svelte": {
+      "types": "./dist/components/*.svelte.d.ts",
+      "svelte": "./dist/components/*.svelte",
+      "default": "./dist/components/*.svelte"
+    },
     "./components/*": "./dist/components/*"
   },
   "peerDependencies": {


### PR DESCRIPTION
Expose Svelte component deep imports with explicit types conditions so consumers can lazy-load @svadmin/ui/components/*.svelte without local ambient module declarations.