### PR TITLE
fix(ui): prevent AutoTable sorting sync update-loop in Svelte 5

### DIFF
--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -237,24 +237,18 @@
     }
   });
 
-  // Sync TanStack sorting → server sorters
+  // Sync external sorters ? local sorting state (controlled mode only)
   $effect(() => {
-    const newSorters: Sort[] = sorting.map(s => ({
-      field: s.id,
-      order: s.desc ? 'desc' as const : 'asc' as const,
-    }));
-    if (JSON.stringify(newSorters) !== JSON.stringify(sorters)) {
-      sorters = newSorters;
+    if (!externalSorters) return;
+    if (JSON.stringify(externalSorters) !== JSON.stringify(sorters)) {
+      sorters = externalSorters;
+    }
+    const nextSorting = externalSorters.map(s => ({ id: s.field, desc: s.order === 'desc' }));
+    if (JSON.stringify(nextSorting) !== JSON.stringify(sorting)) {
+      sorting = nextSorting;
     }
   });
 
-  // Sync external sorters → TanStack sorting state
-  $effect(() => {
-    const newSorting = sorters.map(s => ({ id: s.field, desc: s.order === 'desc' }));
-    if (JSON.stringify(newSorting) !== JSON.stringify(sorting)) {
-      sorting = newSorting;
-    }
-  });
 
   // ─── Auto-generate columns from resource fields ──────────────
   const visibleFields = $derived(
@@ -311,7 +305,21 @@
       get columnOrder() { return columnOrder; },
     },
     onSortingChange: (updater: any) => {
-      sorting = typeof updater === 'function' ? updater(sorting) : updater;
+      const nextSorting = typeof updater === 'function' ? updater(sorting) : updater;
+      sorting = nextSorting;
+
+      const nextSorters: Sort[] = nextSorting.map((s: any) => ({
+        field: s.id,
+        order: s.desc ? 'desc' as const : 'asc' as const,
+      }));
+
+      if (JSON.stringify(nextSorters) !== JSON.stringify(sorters)) {
+        sorters = nextSorters;
+      }
+
+      if ((pagination.current ?? 1) !== 1) {
+        pagination = { ...pagination, current: 1 };
+      }
     },
     onColumnVisibilityChange: (updater: any) => {
       columnVisibility = typeof updater === 'function' ? updater(columnVisibility) : updater;


### PR DESCRIPTION
## Background
In a SvelteKit integration, pages using `AutoTable` can intermittently hit `Maximum call stack size exceeded` / `effect_update_depth_exceeded` during route bootstrap.

The core issue is a bidirectional reactive sync loop between TanStack `sorting` state and svadmin `sorters` state:
- Effect A syncs `sorting -> sorters`
- Effect B syncs `sorters -> sorting`

Under reactive timing edges this can oscillate and repeatedly enqueue updates.

## Fix
- Move `sorting -> sorters` sync into `onSortingChange` (event-driven, not effect-driven)
- Keep only a single effect for controlled mode (`externalSorters -> sorters/sorting`)
- Reset pagination to page 1 when sorting changes

This removes the self-referential effect cycle while preserving controlled/uncontrolled behavior.

## Scope
File changed:
- `packages/ui/src/components/AutoTable.svelte`
