### PR TITLE
feat(supauth-middleware): add server-side OIDC/JWT auth middleware package

### DIFF
--- a/packages/supauth-middleware/README.md
+++ b/packages/supauth-middleware/README.md
@@ -1,0 +1,45 @@
+# @svadmin/supauth-middleware
+
+Supauth/OIDC identity, RBAC and audit context middleware for svadmin server-side apps.
+
+## Features
+
+- JWT verification (RS256 via JWKS, HS256 symmetric signing)
+- OIDC Discovery auto-resolution
+- Claims-to-user mapping with GoTrue `app_metadata` support
+- Role-based access control (RBAC) with hierarchical permissions
+- Audit event generation
+
+## Install
+
+```bash
+bun add @svadmin/supauth-middleware
+```
+
+## Usage
+
+```ts
+import { SupauthAuthMiddleware } from '@svadmin/supauth-middleware';
+
+const auth = new SupauthAuthMiddleware({
+  issuer: 'https://auth.example.com',
+  clientId: 'my-app',
+  callbackUrl: 'https://app.example.com/auth/callback',
+  jwtSecret: process.env.JWT_SECRET, // for HS256
+});
+
+// Express / Bun.serve middleware
+const user = await auth.authenticate(request);
+auth.requirePermission('projects:write')(user);
+auth.requireMinRole('manager')(user);
+```
+
+## RBAC
+
+```ts
+import { hasPermission, hasMinRole, mapClaimsToUser } from '@svadmin/supauth-middleware';
+
+const user = mapClaimsToUser(jwtClaims);
+hasPermission(user, 'code:execute'); // boolean
+hasMinRole(user, 'admin'); // boolean
+```

--- a/packages/supauth-middleware/package.json
+++ b/packages/supauth-middleware/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@svadmin/supauth-middleware",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Supauth/OIDC identity, RBAC and audit context middleware for svadmin server-side apps",
+  "license": "MIT",
+  "keywords": [
+    "svadmin",
+    "supauth",
+    "oidc",
+    "jwt",
+    "rbac",
+    "middleware",
+    "gotrue"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zuohuadong/svadmin",
+    "directory": "packages/supauth-middleware"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "files": [
+    "src"
+  ],
+  "dependencies": {
+    "jose": "^6.2.3"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  },
+  "peerDependenciesMeta": {
+    "jose": {
+      "optional": false
+    }
+  }
+}

--- a/packages/supauth-middleware/src/index.ts
+++ b/packages/supauth-middleware/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @svadmin/supauth-middleware
+ *
+ * Supauth/OIDC 身份、RBAC 与审计上下文中间件。
+ * 支持任意 OIDC 兼容身份提供商 (GoTrue, Keycloak, Auth0, Okta 等)。
+ *
+ * 功能:
+ *   - JWT 验签 (RS256 via JWKS, HS256 symmetric)
+ *   - OIDC Discovery 自动发现
+ *   - Claims 到用户模型映射 (含 GoTrue app_metadata 路径)
+ *   - RBAC 角色/权限检查
+ *   - 审计事件生成
+ */
+
+export {
+  SupauthAuthMiddleware,
+  AuthError,
+} from './middleware';
+
+export {
+  mapClaimsToUser,
+  validateRole,
+  hasPermission,
+  hasMinRole,
+} from './rbac';
+
+export {
+  fetchOidcDiscovery,
+  buildAuthorizationUrl,
+} from './oidc';
+
+export type {
+  VoltUser,
+  VoltRole,
+  AuditEvent,
+  SupauthConfig,
+  ClaimsMapping,
+  OidcDiscovery,
+} from './types';
+
+export { ROLE_PERMISSIONS } from './types';

--- a/packages/supauth-middleware/src/middleware.ts
+++ b/packages/supauth-middleware/src/middleware.ts
@@ -1,0 +1,161 @@
+import * as jose from "jose";
+import type { SupauthConfig, AuditEvent, VoltUser, VoltRole } from "./types";
+import { mapClaimsToUser, hasPermission, hasMinRole } from "./rbac";
+
+export class AuthError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number = 401) {
+    super(message);
+    this.name = "AuthError";
+    this.status = status;
+  }
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new AuthError("Invalid JWT format", 401);
+  }
+  const payload = parts[1]!;
+  const decoded = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+  return JSON.parse(decoded);
+}
+
+export interface SupauthMiddleware {
+  /** 从请求中提取并验证用户 */
+  authenticate(request: Request): Promise<VoltUser>;
+  /** 检查权限，无权限时抛出 AuthError */
+  requirePermission(permission: string): (user: VoltUser) => void;
+  /** 检查角色，不满足时抛出 AuthError */
+  requireMinRole(role: VoltRole): (user: VoltUser) => void;
+  /** 创建审计事件 */
+  createAuditEvent(
+    user: VoltUser,
+    action: string,
+    resourceType: string,
+    resourceId?: string,
+    details?: Record<string, unknown>,
+  ): AuditEvent;
+}
+
+export class SupauthAuthMiddleware implements SupauthMiddleware {
+  private config: SupauthConfig;
+  private jwksSet?: ReturnType<typeof jose.createRemoteJWKSet>;
+  private initError?: Error;
+
+  constructor(config: SupauthConfig) {
+    this.config = config;
+    if (config.issuer && !config.skipSignatureVerification) {
+      const jwksUrl = config.jwksUrl || `${config.issuer.replace(/\/+$/, "")}/.well-known/jwks.json`;
+      try {
+        this.jwksSet = jose.createRemoteJWKSet(new URL(jwksUrl));
+      } catch (err) {
+        const errorInstance = err instanceof Error ? err : new Error(String(err));
+        this.initError = errorInstance;
+        console.error(`[supauth-middleware] Failed to initialize remote JWKSet: ${errorInstance.message}`);
+      }
+    }
+  }
+
+  async authenticate(request: Request): Promise<VoltUser> {
+    const authHeader = request.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      throw new AuthError("Missing or invalid Authorization header", 401);
+    }
+
+    const token = authHeader.slice(7);
+    let claims: Record<string, unknown>;
+
+    if (this.config.issuer && !this.config.skipSignatureVerification) {
+      try {
+        const header = jose.decodeProtectedHeader(token);
+        const secret = this.config.jwtSecret;
+        if (header.alg === "HS256" && secret) {
+          const { payload } = await jose.jwtVerify(token, new TextEncoder().encode(secret), {
+            issuer: this.config.issuer,
+            audience: this.config.audience,
+            algorithms: ["HS256"],
+          });
+          claims = payload as Record<string, unknown>;
+        } else {
+          if (!this.jwksSet) {
+            if (this.initError) {
+              throw new AuthError(`JWKS verifier initialization failed: ${this.initError.message}`, 401);
+            }
+            throw new AuthError("JWKS verifier is uninitialized or failed to fetch keys", 401);
+          }
+          const { payload } = await jose.jwtVerify(token, this.jwksSet, {
+            issuer: this.config.issuer,
+            audience: this.config.audience,
+          });
+          claims = payload as Record<string, unknown>;
+        }
+      } catch (err) {
+        if (err instanceof AuthError) throw err;
+        throw new AuthError(`JWT signature verification failed: ${err instanceof Error ? err.message : err}`, 401);
+      }
+    } else {
+      claims = decodeJwtPayload(token);
+      const exp = claims.exp as number | undefined;
+      if (exp && Date.now() / 1000 > exp) {
+        throw new AuthError("Token expired", 401);
+      }
+      if (this.config.issuer && claims.iss !== this.config.issuer) {
+        throw new AuthError(`Invalid issuer: ${claims.iss}`, 401);
+      }
+      if (this.config.audience) {
+        const aud = claims.aud;
+        const audienceMatch = Array.isArray(aud)
+          ? aud.includes(this.config.audience)
+          : aud === this.config.audience;
+        if (!audienceMatch) {
+          throw new AuthError("Invalid audience", 401);
+        }
+      }
+    }
+
+    return mapClaimsToUser(claims, this.config.claimsMapping);
+  }
+
+  requirePermission(permission: string): (user: VoltUser) => void {
+    return (user: VoltUser) => {
+      if (!hasPermission(user, permission)) {
+        throw new AuthError(
+          `Permission denied: requires ${permission}, user has [${user.permissions.join(", ")}]`,
+          403,
+        );
+      }
+    };
+  }
+
+  requireMinRole(role: VoltRole): (user: VoltUser) => void {
+    return (user: VoltUser) => {
+      if (!hasMinRole(user, role)) {
+        throw new AuthError(
+          `Role denied: requires ${role} or higher, user is ${user.role}`,
+          403,
+        );
+      }
+    };
+  }
+
+  createAuditEvent(
+    user: VoltUser,
+    action: string,
+    resourceType: string,
+    resourceId?: string,
+    details?: Record<string, unknown>,
+  ): AuditEvent {
+    return {
+      timestamp: new Date().toISOString(),
+      action,
+      userId: user.id,
+      userRole: user.role,
+      tenantId: user.tenantId,
+      resourceType,
+      resourceId,
+      details,
+    };
+  }
+}

--- a/packages/supauth-middleware/src/oidc.ts
+++ b/packages/supauth-middleware/src/oidc.ts
@@ -1,0 +1,32 @@
+import type { SupauthConfig, OidcDiscovery } from "./types";
+import { AuthError } from "./middleware";
+
+/** 获取 OIDC Discovery 文档 */
+export async function fetchOidcDiscovery(issuerUrl: string): Promise<OidcDiscovery> {
+  const url = `${issuerUrl.replace(/\/+$/, "")}/.well-known/openid-configuration`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new AuthError(`OIDC discovery failed: ${response.status}`, response.status);
+  }
+  return response.json();
+}
+
+/** 生成 OIDC 授权 URL */
+export function buildAuthorizationUrl(
+  config: SupauthConfig,
+  state: string,
+  codeChallenge?: string,
+): string {
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: config.clientId,
+    redirect_uri: config.callbackUrl,
+    scope: "openid profile email",
+    state,
+  });
+  if (codeChallenge) {
+    params.set("code_challenge", codeChallenge);
+    params.set("code_challenge_method", "S256");
+  }
+  return `${config.issuer}/authorize?${params.toString()}`;
+}

--- a/packages/supauth-middleware/src/rbac.ts
+++ b/packages/supauth-middleware/src/rbac.ts
@@ -1,0 +1,101 @@
+import type { VoltRole, VoltUser, ClaimsMapping } from "./types";
+import { ROLE_PERMISSIONS } from "./types";
+
+const DEFAULT_CLAIMS_MAPPING: ClaimsMapping = {
+  sub: "sub",
+  email: "email",
+  name: "name",
+  role: "role",
+  tenantId: "app_metadata.supaoauth.current_org_id",
+  teamId: "app_metadata.supaoauth.current_team_id",
+  permissions: "app_metadata.supaoauth.permissions",
+};
+
+/** 嵌套属性访问 (支持 "a.b.c" 格式) */
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const keys = path.split(".");
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (current === null || current === undefined || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+/** 验证角色值 */
+export function validateRole(role: string): VoltRole {
+  const validRoles: VoltRole[] = ["superadmin", "admin", "manager", "user", "viewer", "guest"];
+  if (validRoles.includes(role as VoltRole)) {
+    return role as VoltRole;
+  }
+  return "user";
+}
+
+/**
+ * 从 JWT claims 提取业务角色。
+ * GoTrue 模式下 JWT role 只有 anon/authenticated，业务角色在 app_metadata.supaoauth.roles 数组中。
+ */
+function extractRole(rawRole: unknown, claims: Record<string, unknown>): VoltRole {
+  if (Array.isArray(rawRole) && rawRole.length > 0) {
+    return validateRole(String(rawRole[0]));
+  }
+  if (typeof rawRole === "string" && rawRole !== "anon" && rawRole !== "authenticated") {
+    return validateRole(rawRole);
+  }
+  const supaoauthRoles = getNestedValue(claims, "app_metadata.supaoauth.roles");
+  if (Array.isArray(supaoauthRoles) && supaoauthRoles.length > 0) {
+    return validateRole(String(supaoauthRoles[0]));
+  }
+  return "user";
+}
+
+/** 从 JWT claims 映射 VoltUser */
+export function mapClaimsToUser(
+  claims: Record<string, unknown>,
+  mapping?: Partial<ClaimsMapping>,
+): VoltUser {
+  const m = { ...DEFAULT_CLAIMS_MAPPING, ...mapping };
+
+  const id = String(getNestedValue(claims, m.sub) ?? "");
+  const email = String(getNestedValue(claims, m.email) ?? "");
+  const rawName = getNestedValue(claims, m.name) ?? getNestedValue(claims, "preferred_username") ?? "";
+  const name = String(rawName);
+  const rawRole = getNestedValue(claims, m.role);
+  const role = extractRole(rawRole, claims);
+  const tenantId = String(
+    getNestedValue(claims, m.tenantId)
+    ?? getNestedValue(claims, "app_metadata.tenant_id")
+    ?? "default"
+  );
+  const teamId = String(
+    getNestedValue(claims, m.teamId)
+    ?? getNestedValue(claims, "app_metadata.team_id")
+    ?? ""
+  ) || undefined;
+  const rawPerms = getNestedValue(claims, m.permissions)
+    ?? getNestedValue(claims, "app_metadata.permissions");
+  const permissions = Array.isArray(rawPerms)
+    ? rawPerms.map(String)
+    : ROLE_PERMISSIONS[role];
+
+  return { id, email, name, role, tenantId, teamId, permissions, rawClaims: claims };
+}
+
+/** 检查用户是否有指定权限 */
+export function hasPermission(user: VoltUser, permission: string): boolean {
+  if (user.permissions.includes("*")) return true;
+  if (user.permissions.includes(permission)) return true;
+  const [resource] = permission.split(":");
+  if (resource && user.permissions.includes(`${resource}:*`)) return true;
+  return false;
+}
+
+/** 检查用户是否属于指定角色或更高 */
+export function hasMinRole(user: VoltUser, minRole: VoltRole): boolean {
+  const hierarchy: VoltRole[] = ["superadmin", "admin", "manager", "user", "viewer", "guest"];
+  const userIndex = hierarchy.indexOf(user.role);
+  const minIndex = hierarchy.indexOf(minRole);
+  return userIndex <= minIndex;
+}

--- a/packages/supauth-middleware/src/types.ts
+++ b/packages/supauth-middleware/src/types.ts
@@ -1,0 +1,127 @@
+/** 用户角色层级 */
+export type VoltRole =
+  | "superadmin"
+  | "admin"
+  | "manager"
+  | "user"
+  | "viewer"
+  | "guest";
+
+/** 角色权限映射 */
+export const ROLE_PERMISSIONS: Record<VoltRole, string[]> = {
+  superadmin: ["*"],
+  admin: [
+    "projects:read", "projects:write", "projects:delete",
+    "users:read", "users:write", "users:delete",
+    "automation:read", "automation:write", "automation:delete",
+    "settings:read", "settings:write",
+    "chat:read", "chat:write",
+    "code:read", "code:write", "code:execute",
+    "knowledge:read", "knowledge:write", "knowledge:admin",
+    "models:read",
+    "audit:read",
+  ],
+  manager: [
+    "projects:read", "projects:write",
+    "users:read",
+    "automation:read", "automation:write",
+    "settings:read",
+    "chat:read", "chat:write",
+    "code:read",
+    "knowledge:read", "knowledge:write",
+    "models:read",
+  ],
+  user: [
+    "projects:read", "projects:write",
+    "automation:read",
+    "chat:read", "chat:write",
+    "code:read",
+    "knowledge:read",
+    "models:read",
+  ],
+  viewer: [
+    "projects:read",
+    "automation:read",
+    "chat:read",
+    "knowledge:read",
+    "models:read",
+  ],
+  guest: ["chat:read"],
+};
+
+/** 用户上下文 (从 JWT claims 映射) */
+export interface VoltUser {
+  /** 用户唯一 ID */
+  id: string;
+  /** 登录邮箱 */
+  email: string;
+  /** 展示名 */
+  name: string;
+  /** 用户角色 */
+  role: VoltRole;
+  /** 所属租户 ID */
+  tenantId: string;
+  /** 团队 ID (可选) */
+  teamId?: string;
+  /** 权限列表 */
+  permissions: string[];
+  /** JWT 原始 claims */
+  rawClaims: Record<string, unknown>;
+}
+
+/** 审计事件 */
+export interface AuditEvent {
+  timestamp: string;
+  action: string;
+  userId: string;
+  userRole: VoltRole;
+  tenantId: string;
+  resourceType: string;
+  resourceId?: string;
+  details?: Record<string, unknown>;
+  sourceIp?: string;
+  requestId?: string;
+}
+
+/** 认证配置 */
+export interface SupauthConfig {
+  /** OIDC Issuer URL */
+  issuer: string;
+  /** JWKS URL (可从 discovery 自动获取) */
+  jwksUrl?: string;
+  /** OIDC Client ID */
+  clientId: string;
+  /** OIDC Client Secret (用于 token exchange) */
+  clientSecret?: string;
+  /** 回调 URL */
+  callbackUrl: string;
+  /** JWT audience */
+  audience?: string;
+  /** HS256 JWT secret (GoTrue symmetric signing) */
+  jwtSecret?: string;
+  /** Claims 映射 */
+  claimsMapping?: Partial<ClaimsMapping>;
+  /** 跳过 JWT 签名验签 (仅本地调试使用) */
+  skipSignatureVerification?: boolean;
+}
+
+/** Claims 到用户字段的映射 */
+export interface ClaimsMapping {
+  sub: string;
+  email: string;
+  name: string;
+  role: string;
+  tenantId: string;
+  teamId: string;
+  permissions: string;
+}
+
+/** OIDC Discovery 文档 */
+export interface OidcDiscovery {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+  jwks_uri: string;
+  end_session_endpoint?: string;
+}

--- a/packages/supauth-middleware/tsconfig.json
+++ b/packages/supauth-middleware/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

从 xgic-ai-chat 提取后端身份认证中间件为独立的 `@svadmin/supauth-middleware` 包。

### 功能
- JWT 验签 (RS256 via JWKS, HS256 symmetric)
- OIDC Discovery 自动发现
- Claims 到用户模型映射 (含 GoTrue `app_metadata.supaoauth` 嵌套路径支持)
- RBAC 角色/权限检查 (superadmin > admin > manager > user > viewer > guest)
- 权限通配匹配 (`projects:*` 匹配 `projects:read`)
- 审计事件生成

### 包结构
```
packages/supauth-middleware/
├── src/
│   ├── index.ts        # barrel exports
│   ├── types.ts        # VoltUser, VoltRole, SupauthConfig, AuditEvent
│   ├── middleware.ts    # SupauthAuthMiddleware class
│   ├── rbac.ts         # mapClaimsToUser, hasPermission, hasMinRole
│   └── oidc.ts         # fetchOidcDiscovery, buildAuthorizationUrl
├── package.json
├── tsconfig.json
└── README.md
```

### 依赖
- `jose` — JWT 验签和 JWKS

### Test plan
- [x] `tsc --noEmit` 通过
- [ ] 单元测试 (可后续补充)