### PR TITLE
feat(edition): add multi-tenant white-label configuration package

### DIFF
--- a/packages/edition/README.md
+++ b/packages/edition/README.md
@@ -1,0 +1,27 @@
+# @svadmin/edition
+
+Multi-tenant edition and white-label configuration for svadmin apps.
+
+## Features
+
+- Runtime brand configuration (title, logo, nav labels, skills)
+- Defensive parsing with safe fallbacks
+- Fetch from server API endpoint
+
+## Install
+
+```bash
+bun add @svadmin/edition
+```
+
+## Usage
+
+```ts
+import { fetchEditionConfig, normalizeEditionConfig, defaultEditionConfig } from '@svadmin/edition';
+
+// Fetch from server at runtime
+const edition = await fetchEditionConfig();
+
+// Or parse known config
+const config = normalizeEditionConfig(inputFromServer);
+```

--- a/packages/edition/package.json
+++ b/packages/edition/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@svadmin/edition",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Multi-tenant edition and white-label configuration for svadmin apps",
+  "license": "MIT",
+  "keywords": [
+    "svadmin",
+    "edition",
+    "white-label",
+    "multi-tenant",
+    "branding"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zuohuadong/svadmin",
+    "directory": "packages/edition"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "files": ["src"],
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/edition/src/index.ts
+++ b/packages/edition/src/index.ts
@@ -1,0 +1,135 @@
+/**
+ * @svadmin/edition
+ *
+ * 多版本/多租户白标配置层。
+ * 允许运行时从服务端加载品牌配置 (标题、Logo、导航标签、技能列表等)。
+ */
+
+export type EditionName = "oss" | "cnb" | string;
+
+export type NavRoute = string;
+
+export interface EditionSkill {
+  id: string;
+  name: string;
+  description?: string;
+  category?: string;
+  path?: string;
+  enabled: boolean;
+}
+
+export interface EditionConfig {
+  edition: EditionName;
+  appTitle: string;
+  appSubtitle: string;
+  loginTitle: string;
+  loginSubtitle: string;
+  logoText: string;
+  logoUrl: string;
+  footerNote: string;
+  navLabels: Partial<Record<NavRoute, string>>;
+  skills: EditionSkill[];
+  /** 自定义扩展字段 */
+  extra?: Record<string, unknown>;
+}
+
+export const defaultEditionConfig: EditionConfig = {
+  edition: "oss",
+  appTitle: "SvAdmin",
+  appSubtitle: "Headless Admin Framework",
+  loginTitle: "SvAdmin",
+  loginSubtitle: "Svelte 5 Headless Admin",
+  logoText: "S",
+  logoUrl: "",
+  footerNote: "",
+  navLabels: {},
+  skills: [],
+};
+
+function stringValue(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value : fallback;
+}
+
+function normalizeSkill(value: unknown): EditionSkill | null {
+  if (!value || typeof value !== "object") return null;
+  const item = value as Record<string, unknown>;
+  const id = stringValue(item.id, "");
+  const name = stringValue(item.name, id);
+  if (!id || !name) return null;
+  return {
+    id,
+    name,
+    description: typeof item.description === "string" ? item.description : undefined,
+    category: typeof item.category === "string" ? item.category : undefined,
+    path: typeof item.path === "string" ? item.path : undefined,
+    enabled: item.enabled === undefined ? true : item.enabled !== false,
+  };
+}
+
+function normalizeNavLabels(
+  value: unknown,
+  knownRoutes?: readonly NavRoute[],
+): Partial<Record<NavRoute, string>> {
+  if (!value || typeof value !== "object") return {};
+  const source = value as Record<string, unknown>;
+  const labels: Partial<Record<NavRoute, string>> = {};
+  if (knownRoutes) {
+    for (const route of knownRoutes) {
+      if (typeof source[route] === "string") labels[route] = source[route];
+    }
+  } else {
+    for (const [key, val] of Object.entries(source)) {
+      if (typeof val === "string") labels[key] = val;
+    }
+  }
+  return labels;
+}
+
+/**
+ * 防御性解析任意输入为 EditionConfig。
+ * 缺失字段自动 fallback，非法值安全忽略。
+ */
+export function normalizeEditionConfig(
+  input: unknown,
+  fallback: EditionConfig = defaultEditionConfig,
+  knownRoutes?: readonly NavRoute[],
+): EditionConfig {
+  const source = input && typeof input === "object" ? input as Record<string, unknown> : {};
+  const skills = Array.isArray(source.skills)
+    ? source.skills.map(normalizeSkill).filter((s): s is EditionSkill => Boolean(s))
+    : fallback.skills;
+
+  return {
+    edition: stringValue(source.edition, fallback.edition),
+    appTitle: stringValue(source.appTitle, fallback.appTitle),
+    appSubtitle: stringValue(source.appSubtitle, fallback.appSubtitle),
+    loginTitle: stringValue(source.loginTitle, fallback.loginTitle),
+    loginSubtitle: stringValue(source.loginSubtitle, fallback.loginSubtitle),
+    logoText: stringValue(source.logoText, fallback.logoText),
+    logoUrl: typeof source.logoUrl === "string" ? source.logoUrl : fallback.logoUrl,
+    footerNote: stringValue(source.footerNote, fallback.footerNote),
+    navLabels: { ...fallback.navLabels, ...normalizeNavLabels(source.navLabels, knownRoutes) },
+    skills,
+    extra: typeof source.extra === "object" && source.extra !== null
+      ? source.extra as Record<string, unknown>
+      : fallback.extra,
+  };
+}
+
+/**
+ * 从服务端 API 获取 edition 配置。
+ * 默认请求 /api/edition 端点。
+ */
+export async function fetchEditionConfig(
+  endpoint = "/api/edition",
+): Promise<EditionConfig> {
+  try {
+    const res = await fetch(endpoint, {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return defaultEditionConfig;
+    return normalizeEditionConfig(await res.json());
+  } catch {
+    return defaultEditionConfig;
+  }
+}

--- a/packages/edition/tsconfig.json
+++ b/packages/edition/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

从 xgic-ai-chat 提取多版本/多租户白标配置层为独立的 `@svadmin/edition` 包。

### 功能
- `EditionConfig` 类型 — appTitle, logo, navLabels, skills 等品牌字段
- `normalizeEditionConfig()` — 防御性解析任意输入，缺失字段自动 fallback
- `fetchEditionConfig()` — 运行时从 `/api/edition` 加载配置
- 零依赖

### Source
`xgic-ai-chat/packages/volt-studio-shell/src/lib/edition.ts` + `edition-client.ts`

### Test plan
- [x] `tsc --noEmit` 通过
- [ ] 单元测试 (可后续补充)