### PR TITLE
feat(core): add fetchWithInterceptor and createFeatureGate

### DIFF
--- a/packages/core/src/http.test.ts
+++ b/packages/core/src/http.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { createFetchWithInterceptor } from './http';
+
+interface MutableLocation {
+  href: string;
+  pathname: string;
+}
+
+interface TestWindow {
+  location: MutableLocation;
+}
+
+const originalWindow = (globalThis as { window?: TestWindow }).window;
+
+afterEach(() => {
+  if (originalWindow) {
+    (globalThis as { window?: TestWindow }).window = originalWindow;
+  } else {
+    delete (globalThis as { window?: TestWindow }).window;
+  }
+});
+
+function mockFetchWithStatus(status: number) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = mock(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return new Response(null, { status });
+  });
+
+  return { calls, fetchImpl };
+}
+
+function expectPresent<T>(value: T | undefined): T {
+  expect(value).toBeDefined();
+  return value as T;
+}
+
+describe('createFetchWithInterceptor', () => {
+  test('adds CSRF header for mutating requests', async () => {
+    const { calls, fetchImpl } = mockFetchWithStatus(200);
+    const fetcher = createFetchWithInterceptor({ fetchImpl });
+
+    await fetcher('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(calls).toHaveLength(1);
+    const headers = new Headers(expectPresent(calls[0]).init?.headers);
+    expect(headers.get('X-Requested-With')).toBe('XMLHttpRequest');
+    expect(headers.get('Content-Type')).toBe('application/json');
+  });
+
+  test('does not add CSRF header for safe requests', async () => {
+    const { calls, fetchImpl } = mockFetchWithStatus(200);
+    const fetcher = createFetchWithInterceptor({ fetchImpl });
+
+    await fetcher('/api/users', { method: 'GET' });
+
+    const headers = new Headers(expectPresent(calls[0]).init?.headers);
+    expect(headers.get('X-Requested-With')).toBeNull();
+  });
+
+  test('throws configured forbidden message for 403', async () => {
+    const { fetchImpl } = mockFetchWithStatus(403);
+    const fetcher = createFetchWithInterceptor({
+      fetchImpl,
+      forbiddenMessage: 'No access',
+    });
+
+    await expect(fetcher('/api/admin')).rejects.toThrow('No access');
+  });
+
+  test('uses injected fetch implementation', async () => {
+    const { fetchImpl } = mockFetchWithStatus(204);
+    const fetcher = createFetchWithInterceptor({ fetchImpl });
+
+    const response = await fetcher('/api/ping');
+
+    expect(response.status).toBe(204);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test('redirects to login on browser 401', async () => {
+    const { fetchImpl } = mockFetchWithStatus(401);
+    (globalThis as { window?: TestWindow }).window = {
+      location: { href: 'https://app.test/current', pathname: '/projects/list' },
+    };
+    const fetcher = createFetchWithInterceptor({ fetchImpl, loginPath: '/login' });
+
+    await expect(fetcher('/api/private')).rejects.toThrow('Unauthorized');
+
+    expect((globalThis as { window?: TestWindow }).window?.location.href).toBe(
+      '/login?returnTo=%2Fprojects%2Flist',
+    );
+  });
+
+  test('throws unauthorized without redirecting when window is unavailable', async () => {
+    const { fetchImpl } = mockFetchWithStatus(401);
+    delete (globalThis as { window?: TestWindow }).window;
+    const fetcher = createFetchWithInterceptor({ fetchImpl });
+
+    await expect(fetcher('/api/private')).rejects.toThrow('Unauthorized');
+  });
+});

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -1,0 +1,66 @@
+/**
+ * HTTP fetch 工具 — 带 CSRF 防护、401 自动跳转、403 拦截的 fetch wrapper。
+ */
+
+export interface FetchWithInterceptorOptions {
+  /** 401 时跳转的登录页路径 */
+  loginPath?: string;
+  /** 403 时抛出的错误消息 */
+  forbiddenMessage?: string;
+  /** 是否自动添加 X-Requested-With header (CSRF 防护) */
+  csrfProtection?: boolean;
+}
+
+const DEFAULT_OPTIONS: Required<FetchWithInterceptorOptions> = {
+  loginPath: "/auth/login",
+  forbiddenMessage: "Forbidden: 该操作已被安全策略拒绝",
+  csrfProtection: true,
+};
+
+/**
+ * 带拦截器的 fetch — 自动注入 CSRF header，401 跳转登录，403 抛异常。
+ *
+ * @example
+ * ```ts
+ * const fetcher = createFetchWithInterceptor({ loginPath: '/login' });
+ * const res = await fetcher('/api/users');
+ * ```
+ */
+export function createFetchWithInterceptor(
+  options: FetchWithInterceptorOptions = {},
+): (url: string, init?: RequestInit) => Promise<Response> {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+
+  return async (url: string, init: RequestInit = {}): Promise<Response> => {
+    const headers = new Headers(init.headers || {});
+
+    if (
+      opts.csrfProtection &&
+      init.method &&
+      ["POST", "PUT", "DELETE", "PATCH"].includes(init.method.toUpperCase())
+    ) {
+      headers.set("X-Requested-With", "XMLHttpRequest");
+    }
+
+    const res = await fetch(url, { ...init, headers });
+
+    if (!res.ok) {
+      if (res.status === 401) {
+        const returnTo = typeof window !== "undefined"
+          ? encodeURIComponent(window.location.pathname)
+          : "";
+        window.location.href = `${opts.loginPath}?returnTo=${returnTo}`;
+        throw new Error("Unauthorized");
+      }
+      if (res.status === 403) {
+        throw new Error(opts.forbiddenMessage);
+      }
+    }
+    return res;
+  };
+}
+
+/**
+ * 便捷全局实例 — 使用默认配置。
+ */
+export const fetchWithInterceptor = createFetchWithInterceptor();

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -9,12 +9,34 @@ export interface FetchWithInterceptorOptions {
   forbiddenMessage?: string;
   /** 是否自动添加 X-Requested-With header (CSRF 防护) */
   csrfProtection?: boolean;
+  /** 自定义 fetch 实现，便于测试或 SSR 环境注入 */
+  fetchImpl?: FetchWithInterceptor;
+  /** 自定义 401 重定向处理，便于测试或 SSR 环境注入 */
+  onUnauthorized?: (loginPath: string, returnTo: string) => void;
 }
 
-const DEFAULT_OPTIONS: Required<FetchWithInterceptorOptions> = {
+export type FetchWithInterceptor = (url: string, init?: RequestInit) => Promise<Response>;
+
+const DEFAULT_OPTIONS: Required<Omit<FetchWithInterceptorOptions, 'fetchImpl' | 'onUnauthorized'>> & {
+  fetchImpl: FetchWithInterceptor;
+  onUnauthorized: (loginPath: string, returnTo: string) => void;
+} = {
   loginPath: "/auth/login",
   forbiddenMessage: "Forbidden: 该操作已被安全策略拒绝",
   csrfProtection: true,
+  get fetchImpl() {
+    if (typeof globalThis !== "undefined" && typeof globalThis.fetch === "function") {
+      return (url: string, init?: RequestInit) => globalThis.fetch(url, init);
+    }
+    return async () => {
+      throw new Error("No fetch implementation found. Pass fetchImpl in options.");
+    };
+  },
+  onUnauthorized: (loginPath, returnTo) => {
+    if (typeof window !== "undefined") {
+      window.location.href = `${loginPath}?returnTo=${returnTo}`;
+    }
+  },
 };
 
 /**
@@ -28,7 +50,7 @@ const DEFAULT_OPTIONS: Required<FetchWithInterceptorOptions> = {
  */
 export function createFetchWithInterceptor(
   options: FetchWithInterceptorOptions = {},
-): (url: string, init?: RequestInit) => Promise<Response> {
+): FetchWithInterceptor {
   const opts = { ...DEFAULT_OPTIONS, ...options };
 
   return async (url: string, init: RequestInit = {}): Promise<Response> => {
@@ -42,14 +64,14 @@ export function createFetchWithInterceptor(
       headers.set("X-Requested-With", "XMLHttpRequest");
     }
 
-    const res = await fetch(url, { ...init, headers });
+    const res = await opts.fetchImpl(url, { ...init, headers });
 
     if (!res.ok) {
       if (res.status === 401) {
         const returnTo = typeof window !== "undefined"
           ? encodeURIComponent(window.location.pathname)
           : "";
-        window.location.href = `${opts.loginPath}?returnTo=${returnTo}`;
+        opts.onUnauthorized(opts.loginPath, returnTo);
         throw new Error("Unauthorized");
       }
       if (res.status === 403) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -130,4 +130,4 @@ export type {
 
 // HTTP fetch utilities
 export { createFetchWithInterceptor, fetchWithInterceptor } from './http';
-export type { FetchWithInterceptorOptions } from './http';
+export type { FetchWithInterceptor, FetchWithInterceptorOptions } from './http';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,7 @@ export {
 export { matchRoute, navigate, currentPath, setActiveRouterProvider, beforeEach, afterEach, resetRouter } from './router';
 export type { RouteGuard } from './router';
 export { readURLState, writeURLState } from './url-sync';
-export { setAccessControlProvider, getAccessControlProvider, getAccessControlOptions, canAccessAsync } from './permissions.svelte';
+export { setAccessControlProvider, getAccessControlProvider, getAccessControlOptions, canAccessAsync, createFeatureGate } from './permissions.svelte';
 export { useLive, useSubscription, usePublish } from './live.svelte';
 export { toast, getToastQueue, consumeToastQueue, getPromiseQueue, consumePromiseQueue, resetToast } from './toast.svelte';
 export { notify, closeNotification, setNotificationProvider, getNotificationProvider } from './notification.svelte';
@@ -72,7 +72,7 @@ export type {
 } from './types';
 export type { InvalidateScope } from './options.svelte';
 export type { LiveProvider, LiveEvent, LiveMode } from './live.svelte';
-export type { Action, CanParams, CanResult, AccessControlProvider } from './permissions.svelte';
+export type { Action, CanParams, CanResult, AccessControlProvider, FeatureGateConfig, FeatureGateUser } from './permissions.svelte';
 export type { AuditEntry, AuditHandler } from './audit';
 export { useCan } from './useCan';
 export type { UseCanOptions, UseCanResult } from './useCan';
@@ -127,3 +127,7 @@ export type {
   TaskListResult,
   TaskSubscription,
 } from './types';
+
+// HTTP fetch utilities
+export { createFetchWithInterceptor, fetchWithInterceptor } from './http';
+export type { FetchWithInterceptorOptions } from './http';

--- a/packages/core/src/permissions.svelte.ts
+++ b/packages/core/src/permissions.svelte.ts
@@ -95,3 +95,69 @@ export async function canAccessAsync(resourceOrBatch: string | CanParams[], acti
   
   return provider.can({ resource: resourceOrBatch, action: action!, params }) as Promise<CanResult>;
 }
+
+// ─── Feature Gate ─────────────────────────────────────────────
+
+/**
+ * 角色层级定义 (高权 → 低权)
+ */
+const ROLE_HIERARCHY = ["superadmin", "admin", "manager", "user", "viewer", "guest"];
+
+export interface FeatureGateConfig {
+  /** 允许访问的角色列表 */
+  roles?: string[];
+  /** 需要的最低角色 (含以上所有角色) */
+  minRole?: string;
+  /** 需要的权限列表 (全部匹配) */
+  permissions?: string[];
+}
+
+export interface FeatureGateUser {
+  role: string;
+  permissions: string[];
+}
+
+/**
+ * 创建功能门控函数 — 基于角色和权限判断用户是否可访问某功能。
+ *
+ * @example
+ * ```ts
+ * const canUseCode = createFeatureGate({
+ *   minRole: 'manager',
+ *   permissions: ['code:execute'],
+ * });
+ *
+ * if (canUseCode(user)) { ... }
+ * ```
+ */
+export function createFeatureGate(config: FeatureGateConfig): (user: FeatureGateUser) => boolean {
+  return (user: FeatureGateUser): boolean => {
+    // 角色白名单
+    if (config.roles && !config.roles.includes(user.role)) {
+      return false;
+    }
+
+    // 最低角色层级检查
+    if (config.minRole) {
+      const userIndex = ROLE_HIERARCHY.indexOf(user.role);
+      const minIndex = ROLE_HIERARCHY.indexOf(config.minRole);
+      if (userIndex === -1 || minIndex === -1 || userIndex > minIndex) {
+        return false;
+      }
+    }
+
+    // 权限检查 (全部匹配)
+    if (config.permissions && config.permissions.length > 0) {
+      const hasAll = config.permissions.every((permission) => {
+        if (user.permissions.includes("*")) return true;
+        if (user.permissions.includes(permission)) return true;
+        const [resource] = permission.split(":");
+        if (resource && user.permissions.includes(`${resource}:*`)) return true;
+        return false;
+      });
+      if (!hasAll) return false;
+    }
+
+    return true;
+  };
+}


### PR DESCRIPTION
## Summary

从 xgic-ai-chat 提取通用 HTTP 和 RBAC 工具到 `@svadmin/core`。

### 新增内容

**1. `createFetchWithInterceptor()` (`http.ts`)**
- 自动注入 CSRF header (`X-Requested-With`) 给 mutating requests
- 401 自动跳转登录页 (含 returnTo)
- 403 抛出 forbidden 错误
- 可配置 loginPath、forbiddenMessage、csrfProtection

**2. `createFeatureGate()` (`permissions.svelte.ts`)**
- 角色白名单 / 最低角色层级 / 权限列表全部匹配
- 通配权限支持 (`resource:*`)
- 替代应用中分散的手写角色/权限检查

### Source
- `xgic-ai-chat/packages/volt-studio-shell/src/lib/providers.ts`
- `xgic-ai-chat/packages/volt-studio-shell/src/lib/code-access.ts`

### Test plan
- [x] `tsc --noEmit` 通过
- [ ] 单元测试