### PR TITLE
docs(i18n): clarify useTranslation reactive usage

### DIFF
--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -72,18 +72,18 @@ Available: `blue`, `green`, `purple`, `orange`, `rose`, `teal`, `slate`
 
 ## Internationalization (I18n)
 
-`@svadmin/core` includes a lightweight, native Svelte 5 `$derived` powered internationalization system via the `useTranslation` hook. The returned `t` and properties are fully reactive:
+`@svadmin/core` includes a lightweight internationalization system via the `useTranslation` hook. In components, keep the returned object intact and access its properties in markup so Svelte reads the latest values during render:
 
 ```svelte
 <script>
   import { useTranslation, addTranslations } from '@svadmin/core';
 
-  const { t, locale, setLocale, getAvailableLocales } = useTranslation();
+  const i18n = useTranslation();
 
   addTranslations('ja-JP', { 'common.test': 'テスト' });
 </script>
 
-<h1>{t('common.save')}</h1>
-<p>Current language: {locale}</p>
-<button onclick={() => setLocale('ja-JP')}>Switch to Japanese</button>
+<h1>{i18n.t('common.save')}</h1>
+<p>Current language: {i18n.locale}</p>
+<button onclick={() => i18n.setLocale('ja-JP')}>Switch to Japanese</button>
 ```

--- a/docs/src/content/docs/zh-cn/reference/configuration.md
+++ b/docs/src/content/docs/zh-cn/reference/configuration.md
@@ -72,18 +72,18 @@ interface FieldDefinition {
 
 ## 国际化 (I18n)
 
-`@svadmin/core` 原生集成了基于 Svelte 5 Runes `$derived` 驱动的轻量级多语言系统 `useTranslation`。获取返回的 `t` 和属性后天然具备 Svelte 的响应式能力：
+`@svadmin/core` 内置了基于 `useTranslation` 的轻量级多语言系统。在组件中建议保留返回对象，并在模板中通过属性访问，让 Svelte 在渲染时读取最新值：
 
 ```svelte
 <script>
   import { useTranslation, addTranslations } from '@svadmin/core';
 
-  const { t, locale, setLocale, getAvailableLocales } = useTranslation();
+  const i18n = useTranslation();
 
   addTranslations('ja-JP', { 'common.test': 'テスト' });
 </script>
 
-<h1>{t('common.save')}</h1>
-<p>当前语言: {locale}</p>
-<button onclick={() => setLocale('ja-JP')}>切到日语</button>
+<h1>{i18n.t('common.save')}</h1>
+<p>当前语言: {i18n.locale}</p>
+<button onclick={() => i18n.setLocale('ja-JP')}>切到日语</button>
 ```


### PR DESCRIPTION
## Summary
- remove the misleading `$derived` powered claim from the I18n configuration docs
- recommend keeping the `useTranslation()` return object intact instead of destructuring reactive reads
- update English and Chinese examples to use `i18n.t(...)`, `i18n.locale`, and `i18n.setLocale(...)`

## Review notes
This is docs-only. It intentionally avoids the earlier runtime `$derived.by()` patch because that code path needs a broader API compatibility discussion.

## Verification
- `bun test packages/` -> 357 pass
- `bunx tsc --noEmit -p packages/core/tsconfig.json` -> pass
- `git diff --check` -> pass

## Known unrelated local checks
- `bun run docs:build` currently fails on `docs/astro.config.mjs` Starlight sidebar `autogenerate` config shape; the same failure reproduces on current `main` and is unrelated to this content-only diff.
- `bun run typecheck` currently reports existing optional provider/example module resolution errors and 18 warnings outside this docs diff.