### PR TITLE
fix(e2e): use existing 'products' resource instead of non-existent 'posts'

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -42,12 +42,12 @@ test.describe('CRUD Operations', () => {
   });
 
   test('list page loads data', async ({ page }) => {
-    await page.goto('/#/posts');
+    await page.goto('/#/products');
     await expect(page.locator('table, [class*="table"]').first()).toBeVisible({ timeout: 10000 });
   });
 
   test('navigate to create page', async ({ page }) => {
-    await page.goto('/#/posts');
+    await page.goto('/#/products');
     const createBtn = page.getByRole('button', { name: /create/i });
     await createBtn.waitFor({ state: 'visible', timeout: 10000 });
     await createBtn.click();
@@ -55,7 +55,7 @@ test.describe('CRUD Operations', () => {
   });
 
   test('navigate to edit page', async ({ page }) => {
-    await page.goto('/#/posts');
+    await page.goto('/#/products');
     await page.locator('table tbody tr, [class*="table"] [class*="row"]').first().waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
     const editBtn = page.locator('a[href*="edit"], button:has-text("Edit")').first();
     if (await editBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
@@ -82,11 +82,11 @@ test.describe('Navigation', () => {
   });
 
   test('browser back button works', async ({ page }) => {
-    await page.goto('/#/posts');
+    await page.goto('/#/products');
     await page.waitForLoadState('networkidle');
     await page.goto('/#/users');
     await page.waitForLoadState('networkidle');
     await page.goBack();
-    await expect(page).toHaveURL(/posts/, { timeout: 5000 });
+    await expect(page).toHaveURL(/products/, { timeout: 5000 });
   });
 });

--- a/e2e/autosave.spec.ts
+++ b/e2e/autosave.spec.ts
@@ -12,7 +12,7 @@ test.describe('AutoSave Race Conditions', () => {
   });
 
   test('queued autoSave modifications are preserved during pending API requests', async ({ page }) => {
-    await page.goto('/#/posts');
+    await page.goto('/#/products');
     // Wait for table to render
     await page.locator('table tbody tr, [class*="table"] [class*="row"]').first().waitFor({ state: 'visible', timeout: 10000 });
 
@@ -33,7 +33,7 @@ test.describe('AutoSave Race Conditions', () => {
 
     let apiInterceptCount = 0;
 
-    await page.route('**/posts/*', async (route, request) => {
+    await page.route('**/products/*', async (route, request) => {
       if (request.method() === 'PATCH' || request.method() === 'PUT') {
         apiInterceptCount++;
         await new Promise(resolve => setTimeout(resolve, 2000));


### PR DESCRIPTION
## 问题

PR #170 的 E2E 测试全部失败，3 个测试 case 报错：

1. **CRUD Operations > list page loads data** — `page.locator('table')` 找不到元素
2. **CRUD Operations > navigate to create page** — `getByRole('button', { name: /create/i })` 超时
3. **AutoSave Race Conditions > queued autoSave modifications** — `table tbody tr` 找不到

## 根因

E2E 测试访问 `/#/posts`，但 example 应用根本没有 `posts` 资源。example 使用的是库存管理域模型，资源名为 `products`、`skus`、`categories` 等。页面路由 `/#/posts` 不会渲染列表组件，所以 table 和按钮都找不到。

## 修复

将所有 `posts` 引用替换为 `products`：

- `e2e/app.spec.ts`: 4 处 `/#/posts` → `/#/products`，1 处正则 `/posts/` → `/products/`
- `e2e/autosave.spec.ts`: 1 处 `/#/posts` → `/#/products`，1 处 route 拦截 `**/posts/*` → `**/products/*`