### PR TITLE
fix(core): point permissions export to Svelte source

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,8 +38,8 @@
       "default": "./src/i18n.svelte.ts"
     },
     "./permissions": {
-      "types": "./src/permissions.ts",
-      "default": "./src/permissions.ts"
+      "types": "./src/permissions.svelte.ts",
+      "default": "./src/permissions.svelte.ts"
     },
     "./toast": {
       "types": "./src/toast.svelte.ts",


### PR DESCRIPTION
## Problem

`@svadmin/core@0.30.0` publishes the `./permissions` subpath pointing at `./src/permissions.ts`, but the package and repository contain `src/permissions.svelte.ts` instead.

Current package metadata:

```json
"./permissions": {
  "types": "./src/permissions.ts",
  "default": "./src/permissions.ts"
}
```

The npm tarball includes `src/permissions.svelte.ts`, not `src/permissions.ts`.

## Fix

Point the `./permissions` subpath export to `./src/permissions.svelte.ts`, matching the file that is actually published.

## Validation

- Checked `@svadmin/core@0.30.0` npm tarball: `src/permissions.svelte.ts` exists and `src/permissions.ts` is missing
- Verified repository has `packages/core/src/permissions.svelte.ts` and not `packages/core/src/permissions.ts`
- `npm pack --dry-run --json` from `packages/core` includes `src/permissions.svelte.ts` and not `src/permissions.ts`
- `git diff --check`