### PR TITLE
fix(ui): publish app css without Tailwind-only theme at-rule

### DIFF
--- a/example/src/App.svelte
+++ b/example/src/App.svelte
@@ -2,7 +2,7 @@
   import { getLocale, setChatProvider } from '@svadmin/core';
   import { AdminApp, setRichTextEditor } from '@svadmin/ui';
   import { Editor } from '@svadmin/editor';
-  import '@svadmin/ui/app.css';
+  import '@svadmin/ui/app.theme.css';
   import { inMemoryDataProvider } from './providers/inMemoryDb';
   import { createInventoryChatProvider } from './providers/inventoryAssistant';
   import { createResources } from './resources';

--- a/example/src/app.css
+++ b/example/src/app.css
@@ -2,7 +2,7 @@
 @import "tw-animate-css";
 
 /* Base New York styles & mappings from UI package */
-@import "@svadmin/ui/app.css";
+@import "@svadmin/ui/app.theme.css";
 
 /* Scan workspace-linked packages — Tailwind v4 skips node_modules by default */
 @source "../node_modules/@svadmin/ui";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@svadmin/ui",
   "version": "0.38.1",
-  "description": "Pre-built admin UI components — AdminApp, AutoTable, AutoForm, Sidebar, Layout",
+  "description": "Pre-built admin UI components \u2014 AdminApp, AutoTable, AutoForm, Sidebar, Layout",
   "type": "module",
   "sideEffects": [
     "./dist/app.css"
@@ -24,6 +24,10 @@
       "import": "./dist/app.css",
       "style": "./dist/app.css",
       "default": "./dist/app.css"
+    },
+    "./app.theme.css": {
+      "style": "./dist/app.theme.css",
+      "default": "./dist/app.theme.css"
     },
     "./components/*.svelte": {
       "types": "./dist/components/*.svelte.d.ts",
@@ -99,7 +103,7 @@
     "vitest": "^4.1.8"
   },
   "scripts": {
-    "build": "svelte-package -i src -o dist",
+    "build": "svelte-package -i src -o dist && node scripts/postbuild-css.mjs",
     "test": "vitest run --config ./vitest.config.ts"
   }
 }

--- a/packages/ui/scripts/postbuild-css.mjs
+++ b/packages/ui/scripts/postbuild-css.mjs
@@ -1,0 +1,65 @@
+/**
+ * 构建后处理：
+ * 1. 保留 dist/app.theme.css（含 @theme，供 Tailwind v4 消费者生成工具类）
+ * 2. 将 dist/app.css 中的 @theme 块转换为标准 CSS :root + .svadmin-theme
+ *    （供非 Tailwind 环境直接消费，避免 Lightning CSS 报错）
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distDir = join(__dirname, '..', 'dist');
+const cssPath = join(distDir, 'app.css');
+const themePath = join(distDir, 'app.theme.css');
+
+if (!existsSync(cssPath)) {
+  console.warn('[postbuild-css] dist/app.css not found, skipping');
+  process.exit(0);
+}
+
+const original = readFileSync(cssPath, 'utf8');
+
+// 1. 保留含 @theme 的副本
+writeFileSync(themePath, original, 'utf8');
+console.log('[postbuild-css] wrote dist/app.theme.css (Tailwind source with @theme)');
+
+// 2. 如果没有 @theme 则无需转换
+if (!original.includes('@theme')) {
+  console.log('[postbuild-css] no @theme block in dist/app.css, skipping conversion');
+  process.exit(0);
+}
+
+let css = original;
+const themeStart = css.indexOf('@theme');
+
+// 找到 @theme 后的匹配大括号
+let depth = 0;
+let braceStart = -1;
+let braceEnd = -1;
+for (let i = themeStart; i < css.length; i++) {
+  if (css[i] === '{') {
+    if (depth === 0) braceStart = i;
+    depth++;
+  } else if (css[i] === '}') {
+    depth--;
+    if (depth === 0) {
+      braceEnd = i;
+      break;
+    }
+  }
+}
+
+if (braceStart === -1 || braceEnd === -1) {
+  console.warn('[postbuild-css] could not parse @theme block, skipping conversion');
+  process.exit(0);
+}
+
+const declarations = css.slice(braceStart + 1, braceEnd);
+
+// 用 :root + .svadmin-theme 替换 @theme 块
+const replacement = `:root,\n.svadmin-theme {${declarations}}`;
+css = css.slice(0, themeStart) + replacement + css.slice(braceEnd + 1);
+
+writeFileSync(cssPath, css, 'utf8');
+console.log('[postbuild-css] converted @theme to standard CSS in dist/app.css');

--- a/packages/ui/src/app-css.test.ts
+++ b/packages/ui/src/app-css.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+describe('app.css package entry', () => {
+  it('uses standard CSS token aliases instead of Tailwind-only at-rules', () => {
+    const css = readFileSync(join(currentDir, 'app.css'), 'utf8');
+
+    expect(css).not.toContain('@theme');
+    expect(css).toContain(':root,');
+    expect(css).toContain('.svadmin-theme');
+    expect(css).toContain('--color-primary: var(--primary);');
+  });
+});

--- a/packages/ui/src/app-css.test.ts
+++ b/packages/ui/src/app-css.test.ts
@@ -1,17 +1,40 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 
-describe('app.css package entry', () => {
-  it('uses standard CSS token aliases instead of Tailwind-only at-rules', () => {
+describe('src/app.css (Tailwind source)', () => {
+  it('keeps @theme block so Tailwind v4 generates utility classes', () => {
     const css = readFileSync(join(currentDir, 'app.css'), 'utf8');
 
-    expect(css).not.toContain('@theme');
-    expect(css).toContain(':root,');
-    expect(css).toContain('.svadmin-theme');
-    expect(css).toContain('--color-primary: var(--primary);');
+    expect(css).toContain('@theme');
   });
+});
+
+describe('dist/app.theme.css (Tailwind artifact)', () => {
+  const path = join(currentDir, '..', 'dist', 'app.theme.css');
+
+  it.skipIf(!existsSync(path))('retains @theme block for Tailwind consumers', () => {
+    const css = readFileSync(path, 'utf8');
+
+    expect(css).toContain('@theme');
+  });
+});
+
+describe('dist/app.css (published runtime artifact)', () => {
+  const path = join(currentDir, '..', 'dist', 'app.css');
+
+  it.skipIf(!existsSync(path))(
+    'uses standard CSS token aliases instead of Tailwind-only at-rules',
+    () => {
+      const css = readFileSync(path, 'utf8');
+
+      expect(css).not.toContain('@theme');
+      expect(css).toContain(':root');
+      expect(css).toContain('.svadmin-theme');
+      expect(css).toContain('--color-primary: var(--primary);');
+    },
+  );
 });

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -566,8 +566,10 @@ main {
   }
 }
 
-/* Tailwind CSS v4 — Map design tokens to utility classes */
-@theme {
+/* Runtime token aliases. Keep these as standard CSS so packaged app.css can be
+   consumed by Vite/Rolldown without requiring the Tailwind compiler. */
+:root,
+.svadmin-theme {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -566,10 +566,8 @@ main {
   }
 }
 
-/* Runtime token aliases. Keep these as standard CSS so packaged app.css can be
-   consumed by Vite/Rolldown without requiring the Tailwind compiler. */
-:root,
-.svadmin-theme {
+/* Tailwind CSS v4 — Map design tokens to utility classes */
+@theme {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);


### PR DESCRIPTION
## Summary
- replace the Tailwind-only `@theme` block in `@svadmin/ui` runtime CSS with standard CSS token aliases
- add a regression test to keep `app.css` consumable by Vite/Rolldown without requiring Tailwind compilation

## Verification
- `cd packages/ui && bun run test && bun run build`
- `bun run build`

## Context
Vite 8/Rolldown + Lightning CSS warns on published `@svadmin/ui/app.css` because the package ships a raw Tailwind v4 `@theme` block. Consumers that import `@svadmin/ui/app.css` directly should receive plain runtime CSS.