### PR TITLE
fix(ui): honor normalized border color tokens

### DIFF
--- a/docs/components/theming.md
+++ b/docs/components/theming.md
@@ -79,6 +79,20 @@ This injects CSS variables directly onto `<html>`, taking highest priority over 
 
 这会将 CSS 变量直接注入 `<html>`，优先级高于 `app.css` 的默认值。
 
+Color tokens should normally contain a complete CSS `<color>` value. For legacy Tailwind/shadcn themes that store only HSL channels, normalize the semantic mapping so both svadmin's base reset and Tailwind utilities receive a valid color:
+
+颜色 token 通常应保存完整的 CSS `<color>` 值。如果旧版 Tailwind/shadcn 主题只保存 HSL 通道，请在语义映射中归一化，确保 svadmin 基础重置和 Tailwind 工具类都收到有效颜色：
+
+```css
+:root { --border: 214.3 31.8% 91.4%; }
+
+@theme { --color-border: hsl(var(--border)); }
+```
+
+Using `border-color: var(--border)` with channel-only values is invalid CSS and falls back to `currentColor`, which can create unexpectedly dark borders.
+
+将仅含通道的值直接用于 `border-color: var(--border)` 属于无效 CSS，会回退到 `currentColor`，从而产生异常深色边框。
+
 ### ThemeConfig Reference / 配置参考
 
 | Property | Type | Default | Description / 描述 |

--- a/packages/ui/src/app-css.test.ts
+++ b/packages/ui/src/app-css.test.ts
@@ -11,4 +11,11 @@ describe('src/app.css (Tailwind source)', () => {
 
     expect(css).toContain('@theme');
   });
+
+  it('uses the semantic border token in the global reset', () => {
+    const css = readFileSync(join(currentDir, 'app.css'), 'utf8');
+
+    expect(css).toContain('border-color: var(--color-border, var(--border));');
+    expect(css).not.toMatch(/border-color:\s*var\(--border\);/);
+  });
 });

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -8,12 +8,12 @@
  */
 
 @layer base {
-  /* Global border-color reset — ensures Tailwind border utilities
-   * (border-r, border-t, etc.) use the theme color instead of currentColor */
+  /* Use the semantic token so consumers can normalize legacy channel-only
+   * values without the base reset falling back to currentColor. */
   *,
   ::after,
   ::before {
-    border-color: var(--border);
+    border-color: var(--color-border, var(--border));
   }
 
   :root {


### PR DESCRIPTION
## Summary
- route the global border reset through the semantic --color-border token
- retain --border as a fallback for non-Tailwind consumers
- document how legacy HSL channel tokens must be normalized
- add a regression assertion for the reset contract

## Why
Channel-only HSL values such as 214.3 31.8% 91.4% are invalid when passed directly to border-color. Browsers then fall back to currentColor, which can render unexpectedly dark outlines. Consumers can normalize those values in --color-border while hex and OKLCH tokens continue to work unchanged.

## Verification
- bun run test in packages/ui: 12 files, 35 tests passed
- bun run test: all repository unit and custom Vitest suites passed
- bun run build:packages
- bun run typecheck: 0 errors and 0 warnings
- bun run lint
- git diff --check