### PR TITLE
feat(sso): add rotation-safe browser session lifecycle

### DIFF
--- a/docs/src/content/docs/providers/sso.md
+++ b/docs/src/content/docs/providers/sso.md
@@ -55,6 +55,8 @@ interface SSOConfig {
   postLogoutRedirectUri?: string;
   /** Token storage. Default: 'local' (localStorage) */
   storage?: 'local' | 'session' | TokenStorage;
+  /** Storage namespace. Defaults to an issuer/client-specific key. */
+  storageKey?: string;
   /** Custom identity mapper */
   mapIdentity?: (userinfo: Record<string, unknown>) => Identity;
   /** Auto-refresh tokens. Default: true */
@@ -63,6 +65,8 @@ interface SSOConfig {
   refreshBuffer?: number;
   /** Extra authorization request params, e.g. audience or prompt */
   authorizationParams?: Record<string, string>;
+  /** Custom refresh lock for non-browser runtimes or coordinated tabs. */
+  refreshLock?: RefreshLock;
 }
 ```
 
@@ -78,7 +82,11 @@ The provider automatically fetches your IdP's configuration from `/.well-known/o
 
 ### Token Refresh
 
-When `autoRefresh: true` (default), the provider schedules automatic token refresh before the access token expires. If refresh fails, the user is logged out.
+When `autoRefresh: true` (default), the provider schedules refresh before the access token expires. Browser refreshes use Web Locks when available, and concurrent refresh calls in one provider share a single result.
+
+Retryable failures such as network errors, `503`, or lock acquisition failures retain the current session for a later retry. Terminal OAuth errors such as `invalid_grant`, `refresh_token_not_found`, or refresh-token reuse clear the session and require a new login.
+
+The default storage key is isolated by issuer and client ID. Existing `svadmin_sso_*` sessions are migrated once when the derived namespace is empty. Set `storageKey` explicitly when several providers intentionally share one session namespace.
 
 ### Custom Identity Mapping
 
@@ -107,7 +115,7 @@ const permissions = await authProvider.getPermissions();
 
 ### Calling Protected APIs
 
-Use `getAccessToken()` when your admin console needs to call a backend API with the current SSO session:
+Use `createAuthenticatedFetch()` for protected API calls. It adds the current access token, refreshes after one `401`, and safely replays the request once. A `403` is returned unchanged and does not refresh or sign out the user.
 
 ```typescript
 const authProvider = createSSOAuthProvider({
@@ -117,7 +125,35 @@ const authProvider = createSSOAuthProvider({
   authorizationParams: { audience: 'admin-api' },
 });
 
-const token = await authProvider.getAccessToken();
+const authFetch = authProvider.createAuthenticatedFetch();
+const response = await authFetch('/api/reports', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ range: '30d' }),
+});
+```
+
+The original request must be replayable. A consumed `Request` body fails explicitly with `request_not_replayable` instead of sending a partial retry.
+
+Use `getAccessToken()` only when a library requires the raw token and owns its own retry behavior:
+
+```typescript
+const token = await authProvider.getAccessToken({ minValiditySeconds: 60 });
+```
+
+### Session Events
+
+Subscribe to rotation and logout changes when application state must follow the auth session:
+
+```typescript
+const unsubscribe = authProvider.onAuthStateChange((event, session) => {
+  if (event === 'TOKEN_REFRESHED') updateApiSession(session);
+  if (event === 'SIGNED_OUT') clearPrivateState();
+});
+
+// Call during application teardown.
+unsubscribe();
+authProvider.destroy();
 ```
 
 ## Callback Page

--- a/docs/src/content/docs/providers/sso.md
+++ b/docs/src/content/docs/providers/sso.md
@@ -57,6 +57,8 @@ interface SSOConfig {
   storage?: 'local' | 'session' | TokenStorage;
   /** Storage namespace. Defaults to an issuer/client-specific key. */
   storageKey?: string;
+  /** Explicit legacy namespace to migrate after confirming provider ownership. */
+  legacyStorageKey?: string;
   /** Custom identity mapper */
   mapIdentity?: (userinfo: Record<string, unknown>) => Identity;
   /** Auto-refresh tokens. Default: true */
@@ -67,6 +69,8 @@ interface SSOConfig {
   authorizationParams?: Record<string, string>;
   /** Custom refresh lock for non-browser runtimes or coordinated tabs. */
   refreshLock?: RefreshLock;
+  /** Injectable fetch implementation for tests and SSR runtimes. */
+  fetcher?: typeof fetch;
 }
 ```
 
@@ -82,11 +86,15 @@ The provider automatically fetches your IdP's configuration from `/.well-known/o
 
 ### Token Refresh
 
-When `autoRefresh: true` (default), the provider schedules refresh before the access token expires. Browser refreshes use Web Locks when available, and concurrent refresh calls in one provider share a single result.
+When `autoRefresh: true` (default), the provider schedules refresh before the access token expires. Browser refreshes use Web Locks when available plus a shared-storage lease, and concurrent refresh calls in one provider share a single result.
 
 Retryable failures such as network errors, `503`, or lock acquisition failures retain the current session for a later retry. Terminal OAuth errors such as `invalid_grant`, `refresh_token_not_found`, or refresh-token reuse clear the session and require a new login.
 
-The default storage key is isolated by issuer and client ID. Existing `svadmin_sso_*` sessions are migrated once when the derived namespace is empty. Set `storageKey` explicitly when several providers intentionally share one session namespace.
+The default storage key is isolated by issuer and client ID. Ambiguous `svadmin_sso_*` sessions are not claimed automatically because they contain no issuer/client ownership metadata. For a verified single-provider upgrade, set `legacyStorageKey: 'svadmin_sso'`; alternatively, keep using the legacy namespace with `storageKey: 'svadmin_sso'`.
+
+Cross-tab rotation coordination requires a shared storage backend. `sessionStorage` remains tab-isolated; use the default local storage or provide a shared `TokenStorage` when tabs must converge on the same rotated session.
+
+If local storage is unavailable, the default browser adapter falls back to `sessionStorage`; that fallback is intentionally tab-isolated.
 
 ### Custom Identity Mapping
 
@@ -134,6 +142,8 @@ const response = await authFetch('/api/reports', {
 ```
 
 The original request must be replayable. A consumed `Request` body fails explicitly with `request_not_replayable` instead of sending a partial retry.
+
+For non-idempotent operations, use an idempotency key accepted by the API before enabling automatic replay. A transport-level retry cannot prove whether an upstream processed a request before returning `401`.
 
 Use `getAccessToken()` only when a library requires the raw token and owns its own retry behavior:
 

--- a/docs/src/content/docs/providers/sso.md
+++ b/docs/src/content/docs/providers/sso.md
@@ -67,7 +67,7 @@ interface SSOConfig {
   refreshBuffer?: number;
   /** Extra authorization request params, e.g. audience or prompt */
   authorizationParams?: Record<string, string>;
-  /** Atomic refresh lock override for runtimes without Web Locks. */
+  /** Atomic authentication coordination lock override for runtimes without Web Locks. */
   refreshLock?: RefreshLock;
   /** Injectable fetch implementation for tests and SSR runtimes. */
   fetcher?: typeof fetch;
@@ -86,7 +86,7 @@ The provider automatically fetches your IdP's configuration from `/.well-known/o
 
 ### Token Refresh
 
-When `autoRefresh: true` (default), the provider schedules refresh before the access token expires. Browser refreshes use the atomic Web Locks API, and concurrent refresh calls in one provider share a single result. A browser without Web Locks fails refresh closed unless an atomic cross-context `refreshLock` is configured; it never falls back to a non-atomic local-storage lease.
+When `autoRefresh: true` (default), the provider schedules refresh before the access token expires. Browser refreshes and authentication commits use the atomic Web Locks API, and concurrent refresh calls in one provider share a single result. A browser without Web Locks fails refresh and token commits closed unless an atomic cross-context `refreshLock` is configured; it never falls back to a non-atomic local-storage lease. Local logout still clears the current tab.
 
 Retryable failures such as network errors, `503`, or lock acquisition failures retain the current session for a later retry. Terminal OAuth errors such as `invalid_grant`, `refresh_token_not_found`, or refresh-token reuse clear the session and require a new login.
 

--- a/docs/src/content/docs/providers/sso.md
+++ b/docs/src/content/docs/providers/sso.md
@@ -67,7 +67,7 @@ interface SSOConfig {
   refreshBuffer?: number;
   /** Extra authorization request params, e.g. audience or prompt */
   authorizationParams?: Record<string, string>;
-  /** Custom refresh lock for non-browser runtimes or coordinated tabs. */
+  /** Atomic refresh lock override for runtimes without Web Locks. */
   refreshLock?: RefreshLock;
   /** Injectable fetch implementation for tests and SSR runtimes. */
   fetcher?: typeof fetch;
@@ -86,13 +86,13 @@ The provider automatically fetches your IdP's configuration from `/.well-known/o
 
 ### Token Refresh
 
-When `autoRefresh: true` (default), the provider schedules refresh before the access token expires. Browser refreshes use Web Locks when available plus a shared-storage lease, and concurrent refresh calls in one provider share a single result.
+When `autoRefresh: true` (default), the provider schedules refresh before the access token expires. Browser refreshes use the atomic Web Locks API, and concurrent refresh calls in one provider share a single result. A browser without Web Locks fails refresh closed unless an atomic cross-context `refreshLock` is configured; it never falls back to a non-atomic local-storage lease.
 
 Retryable failures such as network errors, `503`, or lock acquisition failures retain the current session for a later retry. Terminal OAuth errors such as `invalid_grant`, `refresh_token_not_found`, or refresh-token reuse clear the session and require a new login.
 
 The default storage key is isolated by issuer and client ID. Ambiguous `svadmin_sso_*` sessions are not claimed automatically because they contain no issuer/client ownership metadata. For a verified single-provider upgrade, set `legacyStorageKey: 'svadmin_sso'`; alternatively, keep using the legacy namespace with `storageKey: 'svadmin_sso'`.
 
-Cross-tab rotation coordination requires a shared storage backend. `sessionStorage` remains tab-isolated; use the default local storage or provide a shared `TokenStorage` when tabs must converge on the same rotated session.
+Cross-tab rotation coordination requires both Web Locks (or a custom atomic `refreshLock`) and a shared storage backend. `sessionStorage` remains tab-isolated; use the default local storage or provide a shared `TokenStorage` when tabs must converge on the same rotated session.
 
 If local storage is unavailable, the default browser adapter falls back to `sessionStorage`; that fallback is intentionally tab-isolated.
 

--- a/packages/core/src/hook-utils.svelte.ts
+++ b/packages/core/src/hook-utils.svelte.ts
@@ -8,7 +8,7 @@ import type { AdminContextAccessor } from './context.svelte';
 import { notify } from './notification.svelte';
 
 // ─── Auth Error Delegate ────────────────────────────────────────
-// Delegate auth errors (401/403) to authProvider.onError() — refine pattern
+// Delegate auth errors to authProvider.onError() — refine pattern
 
 export async function checkError(
   error: unknown,
@@ -29,7 +29,7 @@ export async function checkError(
     }
     if (error && typeof error === 'object' && 'statusCode' in error) {
       const status = (error as { statusCode: number }).statusCode;
-      if (status === 401 || status === 403) {
+      if (status === 401) {
         await adminContext.navigate('/login');
       }
     }

--- a/packages/core/src/hook-utils.svelte.ts
+++ b/packages/core/src/hook-utils.svelte.ts
@@ -20,7 +20,7 @@ export async function checkError(
       const result = await authProvider.onError(error);
       if (!result) return;
       if (result.logout) {
-        try { await authProvider.logout?.(); } catch { /* logout failure should not block redirect */ }
+        await authProvider.logout?.();
         await adminContext.navigate(result.redirectTo ?? '/login');
       } else if (result.redirectTo) {
         await adminContext.navigate(result.redirectTo);

--- a/packages/core/src/hook-utils.test.svelte.ts
+++ b/packages/core/src/hook-utils.test.svelte.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { checkError } from './hook-utils.svelte';
+import type { AdminContextAccessor } from './context.svelte';
+
+describe('checkError', () => {
+  it('does not navigate when logout cannot clear the session', async () => {
+    let navigations = 0;
+    const context = {
+      authProvider: {
+        onError: async () => ({ logout: true, redirectTo: '/login' }),
+        logout: async () => { throw new Error('session could not be cleared'); },
+      },
+      navigate: async () => { navigations += 1; },
+    } as unknown as AdminContextAccessor;
+
+    await checkError({ statusCode: 401 }, context);
+
+    expect(navigations).toBe(0);
+  });
+});

--- a/packages/core/src/http-error.test.ts
+++ b/packages/core/src/http-error.test.ts
@@ -28,6 +28,22 @@ describe('HttpError', () => {
     expect(err instanceof Error).toBe(true);
     expect(err instanceof HttpError).toBe(true);
   });
+
+  test('preserves structured response metadata and cause', () => {
+    const cause = new Error('upstream failed');
+    const body = { code: 'upstream_error', details: { requestId: 'req-1' } };
+    const err = new HttpError('Bad Gateway', 502, undefined, {
+      code: 'upstream_error',
+      details: body.details,
+      body,
+      cause,
+    });
+
+    expect(err.code).toBe('upstream_error');
+    expect(err.details).toEqual({ requestId: 'req-1' });
+    expect(err.body).toBe(body);
+    expect(err.cause).toBe(cause);
+  });
 });
 
 describe('CrudOperator types', () => {

--- a/packages/core/src/http.test.ts
+++ b/packages/core/src/http.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { createFetchWithInterceptor } from './http';
+import { HttpError } from './types';
 
 interface MutableLocation {
   href: string;
@@ -71,6 +72,117 @@ describe('createFetchWithInterceptor', () => {
     await expect(fetcher('/api/admin')).rejects.toThrow('No access');
   });
 
+  test('preserves structured error fields from JSON responses', async () => {
+    const fetcher = createFetchWithInterceptor({
+      fetchImpl: async () => new Response(JSON.stringify({
+        message: 'Token expired',
+        code: 'token_expired',
+        details: { expiredAt: '2026-07-18T00:00:00Z' },
+      }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      onUnauthorized: () => undefined,
+    });
+
+    try {
+      await fetcher('/api/private');
+      throw new Error('Expected request to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpError);
+      const httpError = error as HttpError;
+      expect(httpError.statusCode).toBe(401);
+      expect(httpError.code).toBe('token_expired');
+      expect(httpError.details).toEqual({ expiredAt: '2026-07-18T00:00:00Z' });
+      expect(httpError.body).toEqual({
+        message: 'Token expired',
+        code: 'token_expired',
+        details: { expiredAt: '2026-07-18T00:00:00Z' },
+      });
+    }
+  });
+
+  test('parses nested BFF error envelopes', async () => {
+    const fetcher = createFetchWithInterceptor({
+      fetchImpl: async () => new Response(JSON.stringify({
+        error: {
+          message: 'Session expired',
+          code: 'session_expired',
+          details: { reason: 'idle_timeout' },
+        },
+      }), { status: 401 }),
+      onUnauthorized: () => undefined,
+    });
+
+    try {
+      await fetcher('/api/private');
+      throw new Error('Expected request to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpError);
+      expect(error).toMatchObject({
+        message: 'Session expired',
+        statusCode: 401,
+        code: 'session_expired',
+        details: { reason: 'idle_timeout' },
+      });
+    }
+  });
+
+  test('preserves non-auth HTTP responses for caller-owned handling', async () => {
+    const fetcher = createFetchWithInterceptor({
+      fetchImpl: async () => new Response(JSON.stringify({
+        error_code: 'refresh_token_not_found',
+        message: 'Refresh Token Not Found',
+      }), { status: 400 }),
+    });
+
+    const response = await fetcher('/oauth/token');
+    expect(response.status).toBe(400);
+  });
+
+  test('marks an exhausted authenticated retry as terminal without starting another refresh', async () => {
+    const fetcher = createFetchWithInterceptor({
+      fetchImpl: async () => new Response(null, {
+        status: 401,
+        headers: { 'X-Svadmin-Auth-Retry': 'exhausted' },
+      }),
+      onUnauthorized: () => undefined,
+    });
+
+    await expect(fetcher('/api/private')).rejects.toMatchObject({
+      statusCode: 401,
+      code: 'auth_retry_exhausted',
+    });
+  });
+
+  test('preserves structured auth errors thrown by an authenticated fetch layer', async () => {
+    const authError = Object.assign(new Error('Refresh Token Not Found'), {
+      statusCode: 400,
+      code: 'refresh_token_not_found',
+      details: { source: 'gotrue' },
+    });
+    const fetcher = createFetchWithInterceptor({
+      fetchImpl: async () => { throw authError; },
+    });
+
+    await expect(fetcher('/api/private')).rejects.toMatchObject({
+      statusCode: 400,
+      code: 'refresh_token_not_found',
+      details: { source: 'gotrue' },
+    });
+  });
+
+  test('does not invoke unauthorized handling for 403', async () => {
+    const onUnauthorized = mock(() => undefined);
+    const fetcher = createFetchWithInterceptor({
+      fetchImpl: async () => new Response(null, { status: 403 }),
+      onUnauthorized,
+    });
+
+    await expect(fetcher('/api/admin')).rejects.toBeInstanceOf(HttpError);
+    expect(onUnauthorized).not.toHaveBeenCalled();
+  });
+
   test('uses injected fetch implementation', async () => {
     const { fetchImpl } = mockFetchWithStatus(204);
     const fetcher = createFetchWithInterceptor({ fetchImpl });
@@ -101,5 +213,14 @@ describe('createFetchWithInterceptor', () => {
     const fetcher = createFetchWithInterceptor({ fetchImpl });
 
     await expect(fetcher('/api/private')).rejects.toThrow('Unauthorized');
+  });
+
+  test('preserves unstructured network failures', async () => {
+    const cause = new TypeError('socket closed');
+    const fetcher = createFetchWithInterceptor({
+      fetchImpl: async () => { throw cause; },
+    });
+
+    await expect(fetcher('/api/private')).rejects.toBe(cause);
   });
 });

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -1,11 +1,13 @@
 /**
- * HTTP fetch 工具 — 带 CSRF 防护、401 自动跳转、403 拦截的 fetch wrapper。
+ * HTTP fetch 工具 — 带 CSRF 防护、401 自动跳转和结构化错误语义。
  */
+
+import { HttpError, type ValidationErrors } from './types';
 
 export interface FetchWithInterceptorOptions {
   /** 401 时跳转的登录页路径 */
   loginPath?: string;
-  /** 403 时抛出的错误消息 */
+  /** 403 且服务端未返回消息时使用的错误消息 */
   forbiddenMessage?: string;
   /** 是否自动添加 X-Requested-With header (CSRF 防护) */
   csrfProtection?: boolean;
@@ -21,32 +23,103 @@ const DEFAULT_OPTIONS: Required<Omit<FetchWithInterceptorOptions, 'fetchImpl' | 
   fetchImpl: FetchWithInterceptor;
   onUnauthorized: (loginPath: string, returnTo: string) => void;
 } = {
-  loginPath: "/auth/login",
-  forbiddenMessage: "Forbidden: 该操作已被安全策略拒绝",
+  loginPath: '/auth/login',
+  forbiddenMessage: 'Forbidden: 该操作已被安全策略拒绝',
   csrfProtection: true,
   get fetchImpl() {
-    if (typeof globalThis !== "undefined" && typeof globalThis.fetch === "function") {
+    if (typeof globalThis !== 'undefined' && typeof globalThis.fetch === 'function') {
       return (url: string, init?: RequestInit) => globalThis.fetch(url, init);
     }
     return async () => {
-      throw new Error("No fetch implementation found. Pass fetchImpl in options.");
+      throw new Error('No fetch implementation found. Pass fetchImpl in options.');
     };
   },
   onUnauthorized: (loginPath, returnTo) => {
-    if (typeof window !== "undefined") {
+    if (typeof window !== 'undefined') {
       window.location.href = `${loginPath}?returnTo=${returnTo}`;
     }
   },
 };
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asStructuredHttpError(error: unknown): HttpError | null {
+  const record = asRecord(error);
+  if (!record || typeof record.statusCode !== 'number') return null;
+  const message = typeof record.message === 'string' ? record.message : 'HTTP request failed';
+  const errors = asValidationErrors(record.errors);
+  return new HttpError(message, record.statusCode, errors, {
+    code: typeof record.code === 'string' ? record.code : undefined,
+    details: record.details,
+    body: record.body,
+    cause: error,
+  });
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === 'string');
+}
+
+function asValidationErrors(value: unknown): ValidationErrors | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+
+  const valid = Object.values(record).every((entry) => (
+    typeof entry === 'string'
+    || (Array.isArray(entry) && entry.every((item) => typeof item === 'string'))
+  ));
+  return valid ? record as ValidationErrors : undefined;
+}
+
+async function readErrorBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+async function createResponseError(
+  response: Response,
+  forbiddenMessage: string,
+): Promise<HttpError> {
+  const body = await readErrorBody(response);
+  const record = asRecord(body);
+  const nestedError = asRecord(record?.error);
+  const code = response.headers.get('X-Svadmin-Auth-Retry') === 'exhausted'
+    ? 'auth_retry_exhausted'
+    : firstString(
+      record?.code,
+      record?.error_code,
+      nestedError?.code,
+      nestedError?.error_code,
+      record?.error,
+    );
+  const details = record?.details ?? nestedError?.details;
+  const message = firstString(
+    record?.message,
+    nestedError?.message,
+    record?.error_description,
+    nestedError?.error_description,
+    body,
+  ) ?? (response.status === 401 ? 'Unauthorized' : forbiddenMessage);
+
+  return new HttpError(
+    message,
+    response.status,
+    asValidationErrors(record?.errors ?? nestedError?.errors),
+    { code, details, body },
+  );
+}
+
 /**
- * 带拦截器的 fetch — 自动注入 CSRF header，401 跳转登录，403 抛异常。
- *
- * @example
- * ```ts
- * const fetcher = createFetchWithInterceptor({ loginPath: '/login' });
- * const res = await fetcher('/api/users');
- * ```
+ * 带拦截器的 fetch。Core 只保留错误语义；认证刷新和请求重放由认证提供方处理。
  */
 export function createFetchWithInterceptor(
   options: FetchWithInterceptorOptions = {},
@@ -55,34 +128,42 @@ export function createFetchWithInterceptor(
 
   return async (url: string, init: RequestInit = {}): Promise<Response> => {
     const headers = new Headers(init.headers || {});
-
     if (
-      opts.csrfProtection &&
-      init.method &&
-      ["POST", "PUT", "DELETE", "PATCH"].includes(init.method.toUpperCase())
+      opts.csrfProtection
+      && init.method
+      && ['POST', 'PUT', 'DELETE', 'PATCH'].includes(init.method.toUpperCase())
     ) {
-      headers.set("X-Requested-With", "XMLHttpRequest");
+      headers.set('X-Requested-With', 'XMLHttpRequest');
     }
 
-    const res = await opts.fetchImpl(url, { ...init, headers });
+    let response: Response;
+    try {
+      response = await opts.fetchImpl(url, { ...init, headers });
+    } catch (error) {
+      if (error instanceof HttpError) throw error;
+      const structuredError = asStructuredHttpError(error);
+      if (structuredError) throw structuredError;
+      throw error;
+    }
 
-    if (!res.ok) {
-      if (res.status === 401) {
-        const returnTo = typeof window !== "undefined"
-          ? encodeURIComponent(window.location.pathname)
-          : "";
+    if (response.ok || (response.status !== 401 && response.status !== 403)) {
+      return response;
+    }
+
+    const httpError = await createResponseError(response, opts.forbiddenMessage);
+    if (response.status === 401) {
+      const returnTo = typeof window !== 'undefined'
+        ? encodeURIComponent(window.location.pathname)
+        : '';
+      try {
         opts.onUnauthorized(opts.loginPath, returnTo);
-        throw new Error("Unauthorized");
-      }
-      if (res.status === 403) {
-        throw new Error(opts.forbiddenMessage);
+      } catch {
+        // 重定向适配器失败不能覆盖服务端的结构化 401 错误。
       }
     }
-    return res;
+    throw httpError;
   };
 }
 
-/**
- * 便捷全局实例 — 使用默认配置。
- */
+/** 便捷全局实例 — 使用默认配置。 */
 export const fetchWithInterceptor = createFetchWithInterceptor();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,7 +55,7 @@ export * from './query-keys';
 export { HttpError, UndoError } from './types';
 export type {
   DataProvider, AuthProvider, NotificationProvider, MutationMode,
-  ValidationErrors, CrudOperator, LogicalFilter, FieldFilter,
+  ValidationErrors, HttpErrorOptions, CrudOperator, LogicalFilter, FieldFilter,
   CustomParams, CustomResult,
   GetListParams, GetListResult,
   GetOneParams, GetOneResult,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,15 +6,35 @@ import type { Component } from 'svelte';
 
 export type ValidationErrors = Record<string, string | string[]>;
 
+export interface HttpErrorOptions {
+  code?: string;
+  details?: unknown;
+  body?: unknown;
+  cause?: unknown;
+}
+
 export class HttpError extends Error {
   statusCode: number;
   errors?: ValidationErrors;
+  code?: string;
+  details?: unknown;
+  body?: unknown;
+  override cause?: unknown;
 
-  constructor(message: string, statusCode: number, errors?: ValidationErrors) {
-    super(message);
+  constructor(
+    message: string,
+    statusCode: number,
+    errors?: ValidationErrors,
+    options: HttpErrorOptions = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
     this.name = 'HttpError';
     this.statusCode = statusCode;
     this.errors = errors;
+    this.code = options.code;
+    this.details = options.details;
+    this.body = options.body;
+    this.cause = options.cause;
   }
 }
 

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -344,6 +344,8 @@ describe('createSSOAuthProvider', () => {
 
     const check = provider.check();
     await exchangeStarted.promise;
+    storage.removeItem(`${STORAGE_PREFIX}pkce_verifier`);
+    storage.removeItem(`${STORAGE_PREFIX}state`);
     storageListener?.({
       key: `${STORAGE_PREFIX}tokens`,
       newValue: null,

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -277,6 +277,88 @@ describe('createSSOAuthProvider', () => {
     provider.destroy();
   });
 
+  test('does not let a stale callback exchange consume a newer login attempt', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'old-verifier');
+    storage.setItem(`${STORAGE_PREFIX}state`, 'old-state');
+    installWindow('http://app.test/callback?code=old-code&state=old-state');
+    const exchangeStarted = createDeferred<undefined>();
+    const exchangeResponse = createDeferred<Response>();
+    installFetch(() => {
+      exchangeStarted.resolve(undefined);
+      return exchangeResponse.promise;
+    });
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    const check = provider.check();
+    await exchangeStarted.promise;
+    expect((await provider.login({})).success).toBe(true);
+    const newerState = storage.getItem(`${STORAGE_PREFIX}state`);
+    expect(newerState).not.toBe('old-state');
+    exchangeResponse.resolve(jsonResponse({
+      access_token: 'stale-access',
+      refresh_token: 'stale-refresh',
+      token_type: 'Bearer',
+    }));
+
+    expect((await check).authenticated).toBe(false);
+    expect(await provider.getSession()).toBeNull();
+    expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBe(newerState);
+    provider.destroy();
+  });
+
+  test('does not restore a callback session after a remote sign-out event', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'verifier-123');
+    storage.setItem(`${STORAGE_PREFIX}state`, 'state-123');
+    installWindow('http://app.test/callback?code=code-123&state=state-123');
+    let storageListener: ((event: StorageEvent) => void) | undefined;
+    Object.assign(window, {
+      navigator: {},
+      addEventListener: (type: string, listener: (event: StorageEvent) => void) => {
+        if (type === 'storage') storageListener = listener;
+      },
+      removeEventListener: () => undefined,
+    });
+    const exchangeStarted = createDeferred<undefined>();
+    const exchangeResponse = createDeferred<Response>();
+    installFetch(() => {
+      exchangeStarted.resolve(undefined);
+      return exchangeResponse.promise;
+    });
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    const check = provider.check();
+    await exchangeStarted.promise;
+    storageListener?.({
+      key: `${STORAGE_PREFIX}tokens`,
+      newValue: null,
+    } as StorageEvent);
+    exchangeResponse.resolve(jsonResponse({
+      access_token: 'post-signout-access',
+      refresh_token: 'post-signout-refresh',
+      token_type: 'Bearer',
+    }));
+
+    expect((await check).authenticated).toBe(false);
+    expect(await provider.getSession()).toBeNull();
+    provider.destroy();
+  });
+
   test('rejects callback token responses with an empty token_type', async () => {
     const storage = createMemoryStorage();
     storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'verifier-123');
@@ -421,6 +503,44 @@ describe('createSSOAuthProvider', () => {
       email: 'admin@example.com',
       avatar: 'https://example.com/avatar.png',
     });
+  });
+
+  test('returns userinfo after refreshing an expired session', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}tokens`, JSON.stringify({
+      access_token: 'expired-access',
+      refresh_token: 'refresh-123',
+      expires_at: 1,
+      token_type: 'Bearer',
+    }));
+    const calls = installFetch((url, init) => {
+      if (url === manualEndpoints.token_endpoint) {
+        return jsonResponse({
+          access_token: 'fresh-access',
+          refresh_token: 'refresh-456',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        });
+      }
+      expect(url).toBe(manualEndpoints.userinfo_endpoint);
+      expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer fresh-access');
+      return jsonResponse({ sub: 'user-123', name: 'Fresh User' });
+    });
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    expect(await provider.getIdentity()).toMatchObject({ id: 'user-123', name: 'Fresh User' });
+    expect(calls.map(({ url }) => url)).toEqual([
+      manualEndpoints.token_endpoint,
+      manualEndpoints.userinfo_endpoint,
+    ]);
+    provider.destroy();
   });
 
   test('does not call userinfo without a session', async () => {

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { createSSOAuthProvider, type TokenStorage } from './auth-provider';
 
-const STORAGE_PREFIX = 'svadmin_sso_';
+const STORAGE_PREFIX = `svadmin_sso:${encodeURIComponent('https://idp.test')}:${encodeURIComponent('admin-console')}_`;
 
 type FetchCall = {
   url: string;
@@ -54,9 +54,12 @@ function installFetch(handler: (url: string, init?: RequestInit) => Response | P
   const calls: FetchCall[] = [];
   Object.defineProperty(globalThis, 'fetch', {
     value: async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      calls.push({ url, init });
-      return handler(url, init);
+      const url = input instanceof Request ? input.url : String(input);
+      const effectiveInit = input instanceof Request
+        ? { method: input.method, headers: input.headers, signal: input.signal }
+        : init;
+      calls.push({ url, init: effectiveInit });
+      return handler(url, effectiveInit);
     },
     configurable: true,
     writable: true,
@@ -135,6 +138,41 @@ describe('createSSOAuthProvider', () => {
     expect(redirectUrl.searchParams.get('code_challenge')).not.toBe(storage.getItem(`${STORAGE_PREFIX}pkce_verifier`));
   });
 
+  test('isolates direct providers by issuer and client id without explicit storage keys', async () => {
+    const storage = createMemoryStorage();
+    const firstPrefix = `svadmin_sso:${encodeURIComponent('https://idp.test')}:${encodeURIComponent('client-a')}_`;
+    const secondPrefix = `svadmin_sso:${encodeURIComponent('https://idp.test')}:${encodeURIComponent('client-b')}_`;
+    storage.setItem(`${firstPrefix}tokens`, JSON.stringify({
+      access_token: 'access-a',
+      token_type: 'Bearer',
+    }));
+    storage.setItem(`${secondPrefix}tokens`, JSON.stringify({
+      access_token: 'access-b',
+      token_type: 'Bearer',
+    }));
+    const first = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'client-a',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+    const second = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'client-b',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    expect((await first.getSession())?.access_token).toBe('access-a');
+    expect((await second.getSession())?.access_token).toBe('access-b');
+    first.destroy();
+    second.destroy();
+  });
+
   test('discovers OIDC endpoints before redirecting to the authorization server', async () => {
     const storage = createMemoryStorage();
     const calls = installFetch((url) => {
@@ -194,6 +232,32 @@ describe('createSSOAuthProvider', () => {
     expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBeNull();
     expect(await provider.getAccessToken()).toBe('access-123');
     expect(await provider.getPermissions?.()).toEqual(['admin']);
+  });
+
+  test('rejects callback token responses with an empty token_type', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'verifier-123');
+    storage.setItem(`${STORAGE_PREFIX}state`, 'state-123');
+    installWindow('http://app.test/callback?code=code-123&state=state-123');
+    installFetch(() => jsonResponse({
+      access_token: 'access-123',
+      token_type: '',
+    }));
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    const result = await provider.check();
+
+    expect(result.authenticated).toBe(false);
+    expect(result.error).toMatchObject({ name: 'invalid_token_response' });
+    expect(await provider.getSession()).toBeNull();
+    provider.destroy();
   });
 
   test('rejects callback codes without matching state', async () => {
@@ -288,7 +352,7 @@ describe('createSSOAuthProvider', () => {
     }));
     const calls = installFetch((url, init) => {
       expect(url).toBe(manualEndpoints.userinfo_endpoint);
-      expect(init?.headers).toEqual({ Authorization: 'Bearer access-123' });
+      expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer access-123');
       return jsonResponse({
         sub: 'user-123',
         name: 'Admin User',

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -406,8 +406,8 @@ describe('createSSOAuthProvider', () => {
     expect(result.authenticated).toBe(false);
     expect(result.error?.message).toBe('State mismatch');
     expect(calls).toHaveLength(0);
-    expect(storage.getItem(`${STORAGE_PREFIX}pkce_verifier`)).toBeNull();
-    expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBeNull();
+    expect(storage.getItem(`${STORAGE_PREFIX}pkce_verifier`)).toBe('verifier-123');
+    expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBe('state-123');
   });
 
   test('surfaces OAuth callback errors and clears transient state', async () => {
@@ -540,6 +540,33 @@ describe('createSSOAuthProvider', () => {
       manualEndpoints.token_endpoint,
       manualEndpoints.userinfo_endpoint,
     ]);
+    provider.destroy();
+  });
+
+  test('does not clear a valid session or newer login state for a stale callback', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}tokens`, JSON.stringify({
+      access_token: 'valid-access',
+      token_type: 'Bearer',
+    }));
+    storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'new-verifier');
+    storage.setItem(`${STORAGE_PREFIX}state`, 'new-state');
+    installWindow('http://app.test/callback?code=old-code&state=old-state');
+    const calls = installFetch(() => jsonResponse({ access_token: 'unexpected' }));
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    expect((await provider.check()).authenticated).toBe(false);
+    expect((await provider.getSession())?.access_token).toBe('valid-access');
+    expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBe('new-state');
+    expect(storage.getItem(`${STORAGE_PREFIX}pkce_verifier`)).toBe('new-verifier');
+    expect(calls).toHaveLength(0);
     provider.destroy();
   });
 

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -414,7 +414,9 @@ describe('createSSOAuthProvider', () => {
     const storage = createMemoryStorage();
     storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'verifier-123');
     storage.setItem(`${STORAGE_PREFIX}state`, 'state-123');
-    installWindow('http://app.test/callback?error=access_denied&error_description=Denied');
+    installWindow(
+      'http://app.test/callback?error=access_denied&error_description=Denied&state=state-123',
+    );
     const provider = createSSOAuthProvider({
       issuer: 'https://idp.test',
       clientId: 'admin-console',
@@ -427,10 +429,38 @@ describe('createSSOAuthProvider', () => {
     const result = await provider.check();
 
     expect(result.authenticated).toBe(false);
-    expect(result.logout).toBe(true);
+    expect(result.logout).toBeUndefined();
     expect(result.error).toEqual({ message: 'Denied', name: 'access_denied' });
     expect(storage.getItem(`${STORAGE_PREFIX}pkce_verifier`)).toBeNull();
     expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBeNull();
+  });
+
+  test('does not clear a valid session or newer login state for a stale OAuth error', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}tokens`, JSON.stringify({
+      access_token: 'valid-access',
+      token_type: 'Bearer',
+    }));
+    storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'new-verifier');
+    storage.setItem(`${STORAGE_PREFIX}state`, 'new-state');
+    installWindow('http://app.test/callback?error=access_denied&state=old-state');
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    const result = await provider.check();
+
+    expect(result.authenticated).toBe(false);
+    expect(result.logout).toBeUndefined();
+    expect((await provider.getSession())?.access_token).toBe('valid-access');
+    expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBe('new-state');
+    expect(storage.getItem(`${STORAGE_PREFIX}pkce_verifier`)).toBe('new-verifier');
+    provider.destroy();
   });
 
   test('refreshes expired tokens during auth checks and access-token reads', async () => {

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -379,4 +379,24 @@ describe('createSSOAuthProvider', () => {
       avatar: 'https://example.com/avatar.png',
     });
   });
+
+  test('does not call userinfo without a session', async () => {
+    const storage = createMemoryStorage();
+    const calls = installFetch(() => jsonResponse({
+      sub: 'unexpected-user',
+      name: 'Unexpected User',
+    }));
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    expect(await provider.getIdentity()).toBeNull();
+    expect(calls).toHaveLength(0);
+    provider.destroy();
+  });
 });

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -67,6 +67,15 @@ function installFetch(handler: (url: string, init?: RequestInit) => Response | P
   return calls;
 }
 
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => { resolve = complete; });
+  return { promise, resolve };
+}
+
 function uninstallFetch(): void {
   Reflect.deleteProperty(globalThis, 'fetch');
 }
@@ -232,6 +241,40 @@ describe('createSSOAuthProvider', () => {
     expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBeNull();
     expect(await provider.getAccessToken()).toBe('access-123');
     expect(await provider.getPermissions?.()).toEqual(['admin']);
+  });
+
+  test('does not restore a callback session after logout cancels an in-flight exchange', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'verifier-123');
+    storage.setItem(`${STORAGE_PREFIX}state`, 'state-123');
+    installWindow('http://app.test/callback?code=code-123&state=state-123');
+    const exchangeStarted = createDeferred<undefined>();
+    const exchangeResponse = createDeferred<Response>();
+    installFetch(() => {
+      exchangeStarted.resolve(undefined);
+      return exchangeResponse.promise;
+    });
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    const check = provider.check();
+    await exchangeStarted.promise;
+    await provider.logout();
+    exchangeResponse.resolve(jsonResponse({
+      access_token: 'post-logout-access',
+      refresh_token: 'post-logout-refresh',
+      token_type: 'Bearer',
+    }));
+
+    expect((await check).authenticated).toBe(false);
+    expect(await provider.getSession()).toBeNull();
+    provider.destroy();
   });
 
   test('rejects callback token responses with an empty token_type', async () => {
@@ -425,6 +468,37 @@ describe('createSSOAuthProvider', () => {
     expect(await identity).toBeNull();
     expect(calls).toHaveLength(0);
     expect((await logout).success).toBe(true);
+    provider.destroy();
+  });
+
+  test('does not return userinfo when logout wins after the request starts', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}tokens`, JSON.stringify({
+      access_token: 'access-123',
+      token_type: 'Bearer',
+    }));
+    const userinfoStarted = createDeferred<undefined>();
+    const userinfoResponse = createDeferred<Response>();
+    installFetch(() => {
+      userinfoStarted.resolve(undefined);
+      return userinfoResponse.promise;
+    });
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    const identity = provider.getIdentity();
+    await userinfoStarted.promise;
+    await provider.logout();
+    userinfoResponse.resolve(jsonResponse({ sub: 'stale-user', name: 'Stale User' }));
+
+    expect(await identity).toBeNull();
+    expect(await provider.getSession()).toBeNull();
     provider.destroy();
   });
 });

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -399,4 +399,32 @@ describe('createSSOAuthProvider', () => {
     expect(calls).toHaveLength(0);
     provider.destroy();
   });
+
+  test('does not call userinfo when logout wins during endpoint discovery', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}tokens`, JSON.stringify({
+      access_token: 'access-123',
+      token_type: 'Bearer',
+    }));
+    const calls = installFetch(() => jsonResponse({
+      sub: 'cookie-user',
+      name: 'Cookie User',
+    }));
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    const identity = provider.getIdentity();
+    const logout = provider.logout();
+
+    expect(await identity).toBeNull();
+    expect(calls).toHaveLength(0);
+    expect((await logout).success).toBe(true);
+    provider.destroy();
+  });
 });

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -614,8 +614,14 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
       const now = Math.floor(Date.now() / 1000);
       if (session.expires_at !== undefined && session.expires_at <= now) {
         if (!session.refresh_token) {
-          sessions.clearSession();
-          return { authenticated: false, logout: true };
+          try {
+            if (await sessions.getAccessToken()) return { authenticated: true };
+            return sessions.getLoginState()
+              ? { authenticated: false }
+              : { authenticated: false, logout: true };
+          } catch (error) {
+            return { authenticated: false, error: getErrorResult(error) };
+          }
         }
 
         try {

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -48,7 +48,10 @@ export interface SSOConfig {
   refreshBuffer?: number;
   /** Additional authorization request parameters, e.g. audience or prompt. */
   authorizationParams?: Record<string, string>;
-  /** Optional extra lock; shared storage still provides the final refresh lease. */
+  /**
+   * Atomic refresh lock override. Browsers use Web Locks by default and fail
+   * closed when unavailable; non-browser runtimes serialize within the process.
+   */
   refreshLock?: RefreshLock;
   /** Injectable fetch implementation for testing and SSR runtimes. */
   fetcher?: typeof fetch;
@@ -425,6 +428,16 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     email: (userinfo.email as string) ?? undefined,
   }));
 
+  const authorizationSource = {
+    getAuthorizationHeader: async (options?: GetAccessTokenOptions) => {
+      const accessToken = await sessions.getAccessToken(options);
+      const session = sessions.getSession();
+      return accessToken && session?.access_token === accessToken
+        ? `${session.token_type} ${accessToken}`
+        : null;
+    },
+  };
+
   const provider: SSOAuthProvider = {
     async login() {
       if (typeof window === 'undefined') {
@@ -556,7 +569,11 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
       if (!sessions.getSession()) return null;
       try {
         const endpoints = await discover();
-        const response = await provider.createAuthenticatedFetch()(endpoints.userinfo_endpoint);
+        const response = await buildAuthenticatedFetch(
+          authorizationSource,
+          getFetcher(),
+          { requireAuthorization: true },
+        )(endpoints.userinfo_endpoint);
         if (!response.ok) return null;
         return mapIdentity(await response.json() as Record<string, unknown>);
       } catch {
@@ -580,15 +597,10 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     refreshSession: () => sessions.refreshSession(),
     getAccessToken: (options) => sessions.getAccessToken(options),
     onAuthStateChange: (callback) => sessions.onAuthStateChange(callback),
-    createAuthenticatedFetch: (fetcher) => buildAuthenticatedFetch({
-      getAuthorizationHeader: async (options) => {
-        const accessToken = await sessions.getAccessToken(options);
-        const session = sessions.getSession();
-        return accessToken && session?.access_token === accessToken
-          ? `${session.token_type} ${accessToken}`
-          : null;
-      },
-    }, fetcher ?? getFetcher()),
+    createAuthenticatedFetch: (fetcher) => buildAuthenticatedFetch(
+      authorizationSource,
+      fetcher ?? getFetcher(),
+    ),
     destroy: () => sessions.destroy(),
 
     async onError(error) {

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -404,10 +404,26 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     legacyStorageKey: config.legacyStorageKey,
   });
 
-  async function exchangeCode(code: string): Promise<SSOSession> {
-    const revision = sessions.getRevision();
-    const endpoints = await discover();
+  function assertAuthorizationExchangeCurrent(
+    authGeneration: number,
+    expectedState: string,
+  ): void {
+    if (
+      sessions.getAuthGeneration() === authGeneration
+      && sessions.getLoginState() === expectedState
+    ) return;
+
+    throw new SSOAuthError('Authorization exchange was cancelled by a newer session action', 409, {
+      code: 'authorization_exchange_cancelled',
+      retryable: false,
+    });
+  }
+
+  async function exchangeCode(code: string, expectedState: string): Promise<SSOSession> {
+    const authGeneration = sessions.getAuthGeneration();
     const verifier = sessions.getPKCEVerifier();
+    const endpoints = await discover();
+    assertAuthorizationExchangeCurrent(authGeneration, expectedState);
     const body = new URLSearchParams({
       grant_type: 'authorization_code',
       client_id: config.clientId,
@@ -417,14 +433,9 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     });
     const response = await requestToken(endpoints.token_endpoint, body, 'Token exchange failed');
     const session = normalizeTokenResponse(response, { tokenType: 'Bearer' }, 'Token exchange failed');
-    if (sessions.getRevision() !== revision) {
-      throw new SSOAuthError('Authorization exchange was cancelled by a newer session action', 409, {
-        code: 'authorization_exchange_cancelled',
-        retryable: false,
-      });
-    }
+    assertAuthorizationExchangeCurrent(authGeneration, expectedState);
     sessions.saveSession(session);
-    sessions.clearLoginState();
+    sessions.clearLoginState(expectedState);
     return session;
   }
 
@@ -451,6 +462,7 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
         return { success: false, error: { message: 'SSO login requires a browser environment' } };
       }
 
+      sessions.beginAuthAttempt();
       try {
         const endpoints = await discover();
         const { verifier, challenge } = await createPKCEChallenge();
@@ -535,13 +547,13 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
         }
 
         try {
-          await exchangeCode(code);
+          await exchangeCode(code, savedState);
           url.searchParams.delete('code');
           url.searchParams.delete('state');
           window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
           return { authenticated: true };
         } catch (error) {
-          sessions.clearLoginState();
+          sessions.clearLoginState(savedState);
           return { authenticated: false, error: getErrorResult(error) };
         }
       }
@@ -574,7 +586,7 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
 
     async getIdentity(): Promise<Identity | null> {
       if (!sessions.getSession()) return null;
-      const revision = sessions.getRevision();
+      const authGeneration = sessions.getAuthGeneration();
       try {
         const endpoints = await discover();
         const response = await buildAuthenticatedFetch(
@@ -584,7 +596,10 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
         )(endpoints.userinfo_endpoint);
         if (!response.ok) return null;
         const userinfo = await response.json() as Record<string, unknown>;
-        if (sessions.getRevision() !== revision || !sessions.getSession()) return null;
+        if (
+          sessions.getAuthGeneration() !== authGeneration
+          || !sessions.getSession()
+        ) return null;
         return mapIdentity(userinfo);
       } catch {
         return null;

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -49,8 +49,9 @@ export interface SSOConfig {
   /** Additional authorization request parameters, e.g. audience or prompt. */
   authorizationParams?: Record<string, string>;
   /**
-   * Atomic refresh lock override. Browsers use Web Locks by default and fail
-   * closed when unavailable; non-browser runtimes serialize within the process.
+   * Atomic authentication coordination lock override. Browsers use Web Locks
+   * by default and fail closed when unavailable; non-browser runtimes
+   * serialize within the process.
    */
   refreshLock?: RefreshLock;
   /** Injectable fetch implementation for testing and SSR runtimes. */
@@ -434,9 +435,12 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     const response = await requestToken(endpoints.token_endpoint, body, 'Token exchange failed');
     const session = normalizeTokenResponse(response, { tokenType: 'Bearer' }, 'Token exchange failed');
     assertAuthorizationExchangeCurrent(authGeneration, expectedState);
-    sessions.saveSession(session);
-    sessions.clearLoginState(expectedState);
-    return session;
+    return sessions.runAuthMutation(async () => {
+      assertAuthorizationExchangeCurrent(authGeneration, expectedState);
+      sessions.saveSession(session);
+      sessions.clearLoginState(expectedState);
+      return session;
+    });
   }
 
   const mapIdentity = config.mapIdentity ?? ((userinfo: Record<string, unknown>): Identity => ({
@@ -462,12 +466,23 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
         return { success: false, error: { message: 'SSO login requires a browser environment' } };
       }
 
-      sessions.beginAuthAttempt();
+      const state = generateRandomString(32);
       try {
+        await sessions.runAuthMutation(async () => {
+          sessions.beginAuthAttempt();
+          sessions.setLoginState('', state);
+        });
         const endpoints = await discover();
         const { verifier, challenge } = await createPKCEChallenge();
-        const state = generateRandomString(32);
-        sessions.setLoginState(verifier, state);
+        await sessions.runAuthMutation(async () => {
+          if (sessions.getLoginState() !== state) {
+            throw new SSOAuthError('Login attempt was superseded', 409, {
+              code: 'authorization_exchange_cancelled',
+              retryable: false,
+            });
+          }
+          sessions.setLoginState(verifier, state);
+        });
 
         const params = new URLSearchParams({
           response_type: 'code',
@@ -482,13 +497,23 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
         window.location.href = `${endpoints.authorization_endpoint}?${params}`;
         return { success: true };
       } catch (error) {
+        sessions.clearLoginState(state);
         return { success: false, error: getErrorResult(error) };
       }
     },
 
     async logout() {
       const session = sessions.getSession();
-      sessions.clearSession();
+      sessions.beginSignOut();
+      try {
+        await sessions.runAuthMutation(async () => {
+          sessions.clearSession();
+        });
+      } catch (error) {
+        if (!(error instanceof SSOAuthError) || error.code !== 'auth_lock_failed') throw error;
+        // 无跨上下文锁时 callback commit 同样会失败；本地登出仍应清理会话。
+        sessions.clearSession();
+      }
 
       try {
         const endpoints = await discover();
@@ -542,7 +567,6 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
       if (code) {
         const savedState = sessions.getLoginState();
         if (!state || !savedState || state !== savedState) {
-          sessions.clearSession();
           return { authenticated: false, error: { message: 'State mismatch' } };
         }
 

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -1,50 +1,27 @@
 /**
  * @svadmin/sso — OIDC/OAuth2 SSO AuthProvider for svadmin.
  *
- * Supports any OIDC-compliant Identity Provider:
- * - Okta
- * - Azure AD / Entra ID
- * - Amazon Cognito
- * - Keycloak
- * - Google Workspace
- * - Auth0
- * - Any custom OIDC server
- *
- * Uses the Authorization Code Flow with PKCE (no client secret needed in browser).
- *
- * @example
- * ```ts
- * import { createSSOAuthProvider } from '@svadmin/sso';
- * import { setAuthProvider } from '@svadmin/core';
-
-
- *
- * const authProvider = createSSOAuthProvider({
- *   issuer: 'https://your-tenant.okta.com',
- *   clientId: 'your-client-id',
- *   redirectUri: window.location.origin + '/callback',
- * });
- *
- * setAuthProvider(authProvider);
- * ```
+ * Uses the Authorization Code Flow with PKCE and supports rotation-safe
+ * refresh-token handling for browser applications.
  */
 
 import type { AuthProvider, Identity } from '@svadmin/core';
+import { createAuthenticatedFetch as buildAuthenticatedFetch } from './authenticated-fetch';
+import {
+  createSSOAuthNetworkError,
+  createSSOAuthResponseError,
+  isTerminalSessionError,
+  SSOAuthError,
+} from './errors';
+import {
+  createSessionManager,
+  type AuthStateChangeCallback,
+  type GetAccessTokenOptions,
+  type RefreshLock,
+  type SSOSession,
+} from './session-manager';
 
-// Safe base64url decode for JWT payloads
-function decodeJwtPayload(token: string): Record<string, unknown> | null {
-  if (!token) return null;
-  const parts = token.split('.');
-  if (parts.length < 2) return null;
-  const payloadStr = parts[1];
-  const padded = payloadStr + '='.repeat((4 - (payloadStr.length % 4)) % 4);
-  const binString = atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
-  const bytes = Uint8Array.from(binString, (m) => m.codePointAt(0) ?? 0);
-  return JSON.parse(new TextDecoder().decode(bytes));
-}
-
-
-// ─── Types ────────────────────────────────────────────────────
+const DEFAULT_STORAGE_KEY = 'svadmin_sso';
 
 export interface SSOConfig {
   /** OIDC Issuer URL (e.g., 'https://your-tenant.okta.com') */
@@ -59,6 +36,8 @@ export interface SSOConfig {
   postLogoutRedirectUri?: string;
   /** Token storage backend. Default: 'local' (localStorage) */
   storage?: 'local' | 'session' | TokenStorage;
+  /** Storage namespace. Default keeps compatibility with svadmin_sso_* keys. */
+  storageKey?: string;
   /** Custom identity mapper — transform OIDC userinfo to svadmin Identity */
   mapIdentity?: (userinfo: Record<string, unknown>) => Identity;
   /** Auto-refresh tokens before expiry. Default: true */
@@ -67,6 +46,10 @@ export interface SSOConfig {
   refreshBuffer?: number;
   /** Additional authorization request parameters, e.g. audience or prompt. */
   authorizationParams?: Record<string, string>;
+  /** Injectable lock used for refresh coordination. Defaults to navigator.locks. */
+  refreshLock?: RefreshLock;
+  /** Injectable fetch implementation for testing and SSR runtimes. */
+  fetcher?: typeof fetch;
   /**
    * Manual OAuth2 endpoints for providers that don't support OIDC discovery
    * (e.g., GitHub). When provided, OIDC auto-discovery is skipped.
@@ -86,7 +69,12 @@ export interface TokenStorage {
 }
 
 export interface SSOAuthProvider extends AuthProvider {
-  getAccessToken: () => Promise<string | null>;
+  getSession: () => Promise<SSOSession | null>;
+  refreshSession: () => Promise<SSOSession | null>;
+  getAccessToken: (options?: GetAccessTokenOptions) => Promise<string | null>;
+  onAuthStateChange: (callback: AuthStateChangeCallback) => () => void;
+  createAuthenticatedFetch: (fetcher?: typeof fetch) => typeof fetch;
+  destroy: () => void;
 }
 
 interface OIDCConfig {
@@ -96,155 +84,324 @@ interface OIDCConfig {
   end_session_endpoint?: string;
 }
 
-interface TokenSet {
-  access_token: string;
-  id_token?: string;
-  refresh_token?: string;
-  expires_at?: number;
-  token_type: string;
+type TokenResponse = Record<string, unknown>;
+
+interface TokenResponseDefaults {
+  idToken?: string;
+  refreshToken?: string;
+  tokenType: string;
 }
 
-// ─── PKCE Utilities ───────────────────────────────────────────
+type TokenStringField = 'access_token' | 'refresh_token' | 'token_type';
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  const payloadStr = parts[1];
+  const padded = payloadStr + '='.repeat((4 - (payloadStr.length % 4)) % 4);
+  const binString = atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+  const bytes = Uint8Array.from(binString, (value) => value.codePointAt(0) ?? 0);
+  return JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
+}
+
+function getAccessTokenExpiry(data: TokenResponse, accessToken: string): number | undefined {
+  if (typeof data.expires_in === 'number' && Number.isFinite(data.expires_in)) {
+    return Math.floor(Date.now() / 1000) + data.expires_in;
+  }
+
+  try {
+    const payload = decodeJwtPayload(accessToken);
+    return typeof payload?.exp === 'number' ? payload.exp : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function createInvalidTokenResponseError(
+  fallbackMessage: string,
+  field: string,
+  body: unknown,
+): SSOAuthError {
+  return new SSOAuthError(`${fallbackMessage}: invalid ${field}`, 502, {
+    code: 'invalid_token_response',
+    body,
+    retryable: true,
+  });
+}
+
+function readTokenResponse(body: unknown, fallbackMessage: string): TokenResponse {
+  if (typeof body === 'object' && body !== null && !Array.isArray(body)) {
+    return body as TokenResponse;
+  }
+  throw createInvalidTokenResponseError(fallbackMessage, 'response body', body);
+}
+
+function requireTokenString(
+  response: TokenResponse,
+  field: TokenStringField,
+  fallbackMessage: string,
+): string {
+  const token = response[field];
+  if (typeof token === 'string' && token.length > 0) return token;
+  throw createInvalidTokenResponseError(fallbackMessage, field, response);
+}
+
+function readOptionalTokenString(
+  response: TokenResponse,
+  field: TokenStringField,
+  fallback: string | undefined,
+  fallbackMessage: string,
+): string | undefined {
+  return response[field] === undefined
+    ? fallback
+    : requireTokenString(response, field, fallbackMessage);
+}
+
+function normalizeTokenResponse(
+  body: unknown,
+  defaults: TokenResponseDefaults,
+  fallbackMessage: string,
+): SSOSession {
+  const response = readTokenResponse(body, fallbackMessage);
+  const accessToken = requireTokenString(response, 'access_token', fallbackMessage);
+  return {
+    access_token: accessToken,
+    id_token: typeof response.id_token === 'string' ? response.id_token : defaults.idToken,
+    refresh_token: readOptionalTokenString(
+      response,
+      'refresh_token',
+      defaults.refreshToken,
+      fallbackMessage,
+    ),
+    expires_at: getAccessTokenExpiry(response, accessToken),
+    token_type: readOptionalTokenString(
+      response,
+      'token_type',
+      defaults.tokenType,
+      fallbackMessage,
+    ) ?? defaults.tokenType,
+  };
+}
 
 function generateRandomString(length: number): string {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
   const values = crypto.getRandomValues(new Uint8Array(length));
-  return Array.from(values, (v) => chars[v % chars.length]).join('');
-}
-
-async function sha256(plain: string): Promise<ArrayBuffer> {
-  const encoder = new TextEncoder();
-  return crypto.subtle.digest('SHA-256', encoder.encode(plain));
-}
-
-function base64urlEncode(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return Array.from(values, (value) => chars[value % chars.length]).join('');
 }
 
 async function createPKCEChallenge(): Promise<{ verifier: string; challenge: string }> {
   const verifier = generateRandomString(64);
-  const hashed = await sha256(verifier);
-  const challenge = base64urlEncode(hashed);
+  const hashed = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  const bytes = new Uint8Array(hashed);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const challenge = btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
   return { verifier, challenge };
 }
 
-// ─── Storage Helper ───────────────────────────────────────────
-
-const STORAGE_PREFIX = 'svadmin_sso_';
-
-function getStorage(config: SSOConfig): TokenStorage {
-  if (config.storage && typeof config.storage === 'object') return config.storage;
+function createMemoryStorage(): TokenStorage {
+  const values = new Map<string, string>();
   return {
-    getItem: (key) => typeof window !== 'undefined' ? (config.storage === 'session' ? sessionStorage : localStorage).getItem(key) : null,
-    setItem: (key, value) => { if (typeof window !== 'undefined') (config.storage === 'session' ? sessionStorage : localStorage).setItem(key, value); },
-    removeItem: (key) => { if (typeof window !== 'undefined') (config.storage === 'session' ? sessionStorage : localStorage).removeItem(key); },
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => { values.set(key, value); },
+    removeItem: (key) => { values.delete(key); },
   };
 }
 
-// ─── Provider ─────────────────────────────────────────────────
+function storageProbe(storage: Storage): boolean {
+  const probeKey = `svadmin_sso_probe_${Math.random().toString(36).slice(2)}`;
+  try {
+    storage.setItem(probeKey, '1');
+    storage.removeItem(probeKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-/**
- * Create an OIDC/OAuth2 SSO AuthProvider.
- */
+function unavailableStorage(): TokenStorage {
+  return {
+    getItem: () => null,
+    setItem: () => {
+      throw new SSOAuthError('Browser storage is unavailable', 0, {
+        code: 'storage_unavailable',
+        retryable: false,
+      });
+    },
+    removeItem: () => undefined,
+  };
+}
+
+function safeBrowserStorage(readStorage: () => Storage): Storage | null {
+  try {
+    const storage = readStorage();
+    return storageProbe(storage) ? storage : null;
+  } catch {
+    return null;
+  }
+}
+
+function getStorage(config: SSOConfig): TokenStorage {
+  if (config.storage && typeof config.storage === 'object') return config.storage;
+  if (typeof window === 'undefined') return createMemoryStorage();
+
+  const requestedStorage = config.storage === 'session'
+    ? safeBrowserStorage(() => window.sessionStorage)
+    : safeBrowserStorage(() => window.localStorage)
+      ?? safeBrowserStorage(() => window.sessionStorage);
+  if (!requestedStorage) return unavailableStorage();
+  return {
+    getItem: (key) => requestedStorage.getItem(key),
+    setItem: (key, value) => { requestedStorage.setItem(key, value); },
+    removeItem: (key) => { requestedStorage.removeItem(key); },
+  };
+}
+
+function getErrorResult(error: unknown): { message: string; name?: string } {
+  if (error instanceof SSOAuthError) {
+    return { message: error.message, name: error.code ?? error.name };
+  }
+  if (error instanceof Error) return { message: error.message, name: error.name };
+  return { message: String(error) };
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  if ('statusCode' in error && typeof error.statusCode === 'number') return error.statusCode;
+  if ('status' in error && typeof error.status === 'number') return error.status;
+  return undefined;
+}
+
+/** Create an OIDC/OAuth2 SSO AuthProvider. */
 export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
   const scopes = config.scopes ?? ['openid', 'profile', 'email'];
-  const autoRefresh = config.autoRefresh ?? true;
-  const refreshBuffer = config.refreshBuffer ?? 60;
+  const refreshBuffer = Math.max(0, config.refreshBuffer ?? 60);
   const storage = getStorage(config);
-
+  const storageKey = config.storageKey
+    ?? `${DEFAULT_STORAGE_KEY}:${encodeURIComponent(config.issuer)}:${encodeURIComponent(config.clientId)}`;
   let oidcConfig: OIDCConfig | null = null;
-  let refreshTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // ── OIDC Discovery ───────────────────────────────────────
+  function getFetcher(): typeof fetch {
+    const fetcher = config.fetcher ?? globalThis.fetch;
+    if (typeof fetcher !== 'function') {
+      throw new SSOAuthError('No fetch implementation found', 0, {
+        code: 'fetch_unavailable',
+        retryable: false,
+      });
+    }
+    return fetcher.bind(globalThis) as typeof fetch;
+  }
 
   async function discover(): Promise<OIDCConfig> {
     if (oidcConfig) return oidcConfig;
-
-    // Use manual endpoints if provided (e.g., GitHub)
     if (config.manualEndpoints) {
       oidcConfig = config.manualEndpoints;
       return oidcConfig;
     }
 
     const url = `${config.issuer.replace(/\/$/, '')}/.well-known/openid-configuration`;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`OIDC discovery failed: ${res.status} ${res.statusText}`);
-    oidcConfig = await res.json() as OIDCConfig;
+    let response: Response;
+    try {
+      response = await getFetcher()(url);
+    } catch (error) {
+      throw createSSOAuthNetworkError(error, 'OIDC discovery failed');
+    }
+    if (!response.ok) throw await createSSOAuthResponseError(response, 'OIDC discovery failed');
+
+    let discovered: Partial<OIDCConfig>;
+    try {
+      discovered = await response.json() as Partial<OIDCConfig>;
+    } catch (error) {
+      throw new SSOAuthError('OIDC discovery returned invalid JSON', 502, {
+        code: 'invalid_discovery_document',
+        retryable: true,
+        cause: error,
+      });
+    }
+    if (
+      typeof discovered.authorization_endpoint !== 'string'
+      || typeof discovered.token_endpoint !== 'string'
+      || typeof discovered.userinfo_endpoint !== 'string'
+    ) {
+      throw new SSOAuthError('OIDC discovery returned incomplete endpoints', 502, {
+        code: 'invalid_discovery_document',
+        body: discovered,
+      });
+    }
+    oidcConfig = discovered as OIDCConfig;
     return oidcConfig;
   }
 
-  // ── Token Management ─────────────────────────────────────
-
-  function getTokens(): TokenSet | null {
-    const raw = storage.getItem(`${STORAGE_PREFIX}tokens`);
-    if (!raw) return null;
-    try { return JSON.parse(raw) as TokenSet; }
-    catch { return null; }
-  }
-
-  function setTokens(tokens: TokenSet): void {
-    storage.setItem(`${STORAGE_PREFIX}tokens`, JSON.stringify(tokens));
-    if (autoRefresh && tokens.refresh_token && tokens.expires_at) {
-      scheduleRefresh(tokens);
-    }
-  }
-
-  function clearTokens(): void {
-    storage.removeItem(`${STORAGE_PREFIX}tokens`);
-    storage.removeItem(`${STORAGE_PREFIX}pkce_verifier`);
-    storage.removeItem(`${STORAGE_PREFIX}state`);
-    if (refreshTimer) clearTimeout(refreshTimer);
-  }
-
-  function scheduleRefresh(tokens: TokenSet): void {
-    if (refreshTimer) clearTimeout(refreshTimer);
-    if (!tokens.expires_at || !tokens.refresh_token) return;
-    const now = Math.floor(Date.now() / 1000);
-    const delay = Math.max(0, (tokens.expires_at - now - refreshBuffer)) * 1000;
-    const refreshToken = tokens.refresh_token;
-    refreshTimer = setTimeout(() => refreshAccessToken(refreshToken), delay);
-  }
-
-  async function refreshAccessToken(refreshToken: string): Promise<void> {
+  async function requestToken(
+    endpoint: string,
+    body: URLSearchParams,
+    fallbackMessage: string,
+  ): Promise<unknown> {
+    let response: Response;
     try {
-      const cfg = await discover();
-      const body = new URLSearchParams({
-        grant_type: 'refresh_token',
-        client_id: config.clientId,
-        refresh_token: refreshToken,
-      });
-      const res = await fetch(cfg.token_endpoint, {
+      response = await getFetcher()(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body,
       });
-      if (!res.ok) { clearTokens(); return; }
-      const data = await res.json();
-      if (!data.access_token) {
-        clearTokens();
-        return;
-      }
-      const newTokens: TokenSet = {
-        access_token: data.access_token,
-        id_token: data.id_token,
-        refresh_token: data.refresh_token ?? refreshToken,
-        expires_at: data.expires_in ? Math.floor(Date.now() / 1000) + data.expires_in : undefined,
-        token_type: data.token_type ?? 'Bearer',
-      };
-      setTokens(newTokens);
-    } catch {
-      clearTokens();
+    } catch (error) {
+      throw createSSOAuthNetworkError(error, fallbackMessage);
+    }
+
+    if (!response.ok) throw await createSSOAuthResponseError(response, fallbackMessage);
+
+    try {
+      return await response.json() as unknown;
+    } catch (error) {
+      throw new SSOAuthError(`${fallbackMessage}: invalid JSON response`, 502, {
+        code: 'invalid_token_response',
+        retryable: true,
+        cause: error,
+      });
     }
   }
 
-  // ── Token Exchange ───────────────────────────────────────
+  async function performRefresh(current: SSOSession): Promise<SSOSession> {
+    if (!current.refresh_token) {
+      throw new SSOAuthError('Refresh token is unavailable', 401, {
+        code: 'session_not_found',
+      });
+    }
 
-  async function exchangeCode(code: string): Promise<TokenSet> {
-    const cfg = await discover();
-    const verifier = storage.getItem(`${STORAGE_PREFIX}pkce_verifier`);
+    const endpoints = await discover();
+    const response = await requestToken(
+      endpoints.token_endpoint,
+      new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: config.clientId,
+        refresh_token: current.refresh_token,
+      }),
+      'Token refresh failed',
+    );
+    return normalizeTokenResponse(response, {
+      idToken: current.id_token,
+      refreshToken: current.refresh_token,
+      tokenType: current.token_type,
+    }, 'Token refresh failed');
+  }
+
+  const sessions = createSessionManager({
+    storage,
+    storageKey,
+    autoRefresh: config.autoRefresh ?? true,
+    refreshBuffer,
+    refreshLock: config.refreshLock,
+    refresh: performRefresh,
+    legacyStorageKey: config.storageKey ? undefined : DEFAULT_STORAGE_KEY,
+  });
+
+  async function exchangeCode(code: string): Promise<SSOSession> {
+    const endpoints = await discover();
+    const verifier = sessions.getPKCEVerifier();
     const body = new URLSearchParams({
       grant_type: 'authorization_code',
       client_id: config.clientId,
@@ -252,54 +409,31 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
       redirect_uri: config.redirectUri,
       ...(verifier ? { code_verifier: verifier } : {}),
     });
-    const res = await fetch(cfg.token_endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body,
-    });
-    if (!res.ok) throw new Error(`Token exchange failed: ${res.status}`);
-    const data = await res.json();
-    if (!data.access_token) throw new Error('Token exchange failed: missing access_token');
-    const tokens: TokenSet = {
-      access_token: data.access_token,
-      id_token: data.id_token,
-      refresh_token: data.refresh_token,
-      expires_at: data.expires_in ? Math.floor(Date.now() / 1000) + data.expires_in : undefined,
-      token_type: data.token_type ?? 'Bearer',
-    };
-    setTokens(tokens);
-    storage.removeItem(`${STORAGE_PREFIX}pkce_verifier`);
-    storage.removeItem(`${STORAGE_PREFIX}state`);
-    return tokens;
+    const response = await requestToken(endpoints.token_endpoint, body, 'Token exchange failed');
+    const session = normalizeTokenResponse(response, { tokenType: 'Bearer' }, 'Token exchange failed');
+    sessions.saveSession(session);
+    sessions.clearLoginState();
+    return session;
   }
 
-  // ── Default Identity Mapper ──────────────────────────────
+  const mapIdentity = config.mapIdentity ?? ((userinfo: Record<string, unknown>): Identity => ({
+    id: (userinfo.sub as string) ?? '',
+    name: (userinfo.name as string) ?? (userinfo.preferred_username as string) ?? '',
+    avatar: (userinfo.picture as string) ?? undefined,
+    email: (userinfo.email as string) ?? undefined,
+  }));
 
-  function defaultMapIdentity(userinfo: Record<string, unknown>): Identity {
-    return {
-      id: (userinfo.sub as string) ?? '',
-      name: (userinfo.name as string) ?? (userinfo.preferred_username as string) ?? '',
-      avatar: (userinfo.picture as string) ?? undefined,
-      email: (userinfo.email as string) ?? undefined,
-    };
-  }
-
-  const mapIdentity = config.mapIdentity ?? defaultMapIdentity;
-
-  // ── AuthProvider Implementation ──────────────────────────
-
-  return {
+  const provider: SSOAuthProvider = {
     async login() {
       if (typeof window === 'undefined') {
         return { success: false, error: { message: 'SSO login requires a browser environment' } };
       }
+
       try {
-        const cfg = await discover();
+        const endpoints = await discover();
         const { verifier, challenge } = await createPKCEChallenge();
         const state = generateRandomString(32);
-
-        storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, verifier);
-        storage.setItem(`${STORAGE_PREFIX}state`, state);
+        sessions.setLoginState(verifier, state);
 
         const params = new URLSearchParams({
           response_type: 'code',
@@ -311,31 +445,31 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
           code_challenge_method: 'S256',
           ...config.authorizationParams,
         });
-
-        // Redirect to authorization endpoint
-        window.location.href = `${cfg.authorization_endpoint}?${params}`;
-
-        // Won't actually reach here due to redirect
+        window.location.href = `${endpoints.authorization_endpoint}?${params}`;
         return { success: true };
-      } catch (err) {
-        return { success: false, error: { message: err instanceof Error ? err.message : 'SSO login failed' } };
+      } catch (error) {
+        return { success: false, error: getErrorResult(error) };
       }
     },
 
     async logout() {
-      const cfg = await discover();
-      const tokens = getTokens();
-      clearTokens();
+      const session = sessions.getSession();
+      sessions.clearSession();
 
-      if (typeof window !== 'undefined' && cfg.end_session_endpoint && tokens?.id_token) {
-        const params = new URLSearchParams({
-          id_token_hint: tokens.id_token,
-          ...(config.postLogoutRedirectUri
-            ? { post_logout_redirect_uri: config.postLogoutRedirectUri }
-            : {}),
-        });
-        window.location.href = `${cfg.end_session_endpoint}?${params}`;
-        return { success: true };
+      try {
+        const endpoints = await discover();
+        if (typeof window !== 'undefined' && endpoints.end_session_endpoint && session?.id_token) {
+          const params = new URLSearchParams({
+            id_token_hint: session.id_token,
+            ...(config.postLogoutRedirectUri
+              ? { post_logout_redirect_uri: config.postLogoutRedirectUri }
+              : {}),
+          });
+          window.location.href = `${endpoints.end_session_endpoint}?${params}`;
+          return { success: true };
+        }
+      } catch {
+        // 本地会话已清理，发现或跳转失败不能恢复为登录态。
       }
 
       return {
@@ -345,20 +479,20 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     },
 
     async check() {
-      // SSR: no tokens, no callback — return unauthenticated
+      const existingSession = sessions.getSession();
       if (typeof window === 'undefined') {
-        const tokens = getTokens();
-        if (tokens && (!tokens.expires_at || tokens.expires_at > Math.floor(Date.now() / 1000))) {
-          return { authenticated: true };
-        }
-        return { authenticated: false, logout: true };
+        const now = Math.floor(Date.now() / 1000);
+        return existingSession && (
+          existingSession.expires_at === undefined || existingSession.expires_at > now
+        )
+          ? { authenticated: true }
+          : { authenticated: false, logout: true };
       }
 
-      // Handle callback — exchange authorization code for tokens
       const url = new URL(window.location.href);
       const callbackError = url.searchParams.get('error');
       if (callbackError) {
-        clearTokens();
+        sessions.clearSession();
         return {
           authenticated: false,
           error: {
@@ -371,115 +505,109 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
 
       const code = url.searchParams.get('code');
       const state = url.searchParams.get('state');
-
       if (code) {
-        const savedState = storage.getItem(`${STORAGE_PREFIX}state`);
+        const savedState = sessions.getLoginState();
         if (!state || !savedState || state !== savedState) {
-          clearTokens();
+          sessions.clearSession();
           return { authenticated: false, error: { message: 'State mismatch' } };
         }
+
         try {
           await exchangeCode(code);
-          // Clean URL
           url.searchParams.delete('code');
           url.searchParams.delete('state');
           window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
           return { authenticated: true };
-        } catch (err) {
-          return { authenticated: false, error: { message: String(err) } };
+        } catch (error) {
+          sessions.clearLoginState();
+          return { authenticated: false, error: getErrorResult(error) };
         }
       }
 
-      // Check existing tokens
-      const tokens = getTokens();
-      if (!tokens) {
-        return { authenticated: false, logout: true };
-      }
+      const session = sessions.getSession();
+      if (!session) return { authenticated: false, logout: true };
 
-      // Check expiry
-      if (tokens.expires_at && tokens.expires_at < Math.floor(Date.now() / 1000)) {
-        if (tokens.refresh_token) {
-          await refreshAccessToken(tokens.refresh_token);
-          const refreshed = getTokens();
-          if (refreshed) return { authenticated: true };
+      const now = Math.floor(Date.now() / 1000);
+      if (session.expires_at !== undefined && session.expires_at <= now) {
+        if (!session.refresh_token) {
+          sessions.clearSession();
+          return { authenticated: false, logout: true };
         }
-        clearTokens();
-        return { authenticated: false, logout: true };
-      }
 
-      // Schedule refresh if not already done
-      if (autoRefresh && tokens.refresh_token && tokens.expires_at) {
-        scheduleRefresh(tokens);
+        try {
+          return await sessions.refreshSession()
+            ? { authenticated: true }
+            : { authenticated: false, logout: true };
+        } catch (error) {
+          return {
+            authenticated: false,
+            error: getErrorResult(error),
+            ...(isTerminalSessionError(error) ? { logout: true } : {}),
+          };
+        }
       }
 
       return { authenticated: true };
     },
 
     async getIdentity(): Promise<Identity | null> {
-      const tokens = getTokens();
-      if (!tokens) return null;
-
       try {
-        const cfg = await discover();
-        const res = await fetch(cfg.userinfo_endpoint, {
-          headers: { Authorization: `${tokens.token_type} ${tokens.access_token}` },
-        });
-        if (!res.ok) return null;
-        const userinfo = await res.json();
-        return mapIdentity(userinfo);
+        const endpoints = await discover();
+        const response = await provider.createAuthenticatedFetch()(endpoints.userinfo_endpoint);
+        if (!response.ok) return null;
+        return mapIdentity(await response.json() as Record<string, unknown>);
       } catch {
         return null;
       }
     },
 
     async getPermissions() {
-      const tokens = getTokens();
-      if (!tokens) return null;
+      const idToken = sessions.getSession()?.id_token;
+      if (!idToken) return null;
 
-      // Try to extract roles/permissions from the ID token
-      if (tokens.id_token) {
-        try {
-          const payload = decodeJwtPayload(tokens.id_token);
-          if (!payload) return null;
-          return payload.roles ?? payload.groups ?? payload.permissions ?? null;
-        } catch {
-          return null;
-        }
+      try {
+        const payload = decodeJwtPayload(idToken);
+        return payload?.roles ?? payload?.groups ?? payload?.permissions ?? null;
+      } catch {
+        return null;
       }
-
-      return null;
     },
 
-    async getAccessToken() {
-      const tokens = getTokens();
-      if (!tokens) return null;
-
-      if (tokens.expires_at && tokens.expires_at < Math.floor(Date.now() / 1000)) {
-        if (!tokens.refresh_token) {
-          clearTokens();
-          return null;
-        }
-        await refreshAccessToken(tokens.refresh_token);
-        return getTokens()?.access_token ?? null;
-      }
-
-      return tokens.access_token;
-    },
+    getSession: async () => sessions.getSession(),
+    refreshSession: () => sessions.refreshSession(),
+    getAccessToken: (options) => sessions.getAccessToken(options),
+    onAuthStateChange: (callback) => sessions.onAuthStateChange(callback),
+    createAuthenticatedFetch: (fetcher) => buildAuthenticatedFetch(provider, fetcher ?? getFetcher()),
+    destroy: () => sessions.destroy(),
 
     async onError(error) {
-      if (typeof error === 'object' && error !== null && 'statusCode' in error) {
-        const statusCode = (error as { statusCode: number }).statusCode;
-        if (statusCode === 401 || statusCode === 403) {
-          return { logout: true, redirectTo: '/login' };
-        }
+      const status = getErrorStatus(error);
+      if (status === 403) return {};
+      if (isTerminalSessionError(error)) return { logout: true, redirectTo: '/login' };
+      if (status !== 401) return {};
+
+      const session = sessions.getSession();
+      if (!session?.refresh_token) return { logout: true, redirectTo: '/login' };
+
+      try {
+        return await sessions.getAccessToken({ forceRefresh: true })
+          ? {}
+          : { logout: true, redirectTo: '/login' };
+      } catch (refreshError) {
+        return isTerminalSessionError(refreshError)
+          ? { logout: true, redirectTo: '/login' }
+          : {};
       }
-      if (typeof error === 'object' && error !== null && 'status' in error) {
-        const status = (error as { status: number }).status;
-        if (status === 401 || status === 403) {
-          return { logout: true, redirectTo: '/login' };
-        }
-      }
-      return {};
     },
   };
+
+  return provider;
 }
+
+export type {
+  AuthStateChangeCallback,
+  AuthStateChangeEvent,
+  GetAccessTokenOptions,
+  RefreshLock,
+  SSOSession,
+} from './session-manager';

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -420,6 +420,17 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     });
   }
 
+  async function clearOwnedLoginState(expectedState: string): Promise<void> {
+    try {
+      await sessions.runAuthMutation(async () => {
+        sessions.clearLoginState(expectedState);
+      });
+    } catch (error) {
+      if (!(error instanceof SSOAuthError) || error.code !== 'auth_lock_failed') throw error;
+      sessions.clearLoginState(expectedState);
+    }
+  }
+
   async function exchangeCode(code: string, expectedState: string): Promise<SSOSession> {
     const authGeneration = sessions.getAuthGeneration();
     const verifier = sessions.getPKCEVerifier();
@@ -497,7 +508,11 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
         window.location.href = `${endpoints.authorization_endpoint}?${params}`;
         return { success: true };
       } catch (error) {
-        sessions.clearLoginState(state);
+        try {
+          await clearOwnedLoginState(state);
+        } catch {
+          // 保留触发失败的原始认证错误；清理失败不能掩盖根因。
+        }
         return { success: false, error: getErrorResult(error) };
       }
     },
@@ -551,14 +566,21 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
       const url = new URL(window.location.href);
       const callbackError = url.searchParams.get('error');
       if (callbackError) {
-        sessions.clearSession();
+        const callbackState = url.searchParams.get('state');
+        const savedState = sessions.getLoginState();
+        if (callbackState && savedState && callbackState === savedState) {
+          try {
+            await clearOwnedLoginState(savedState);
+          } catch {
+            // 错误回调仍返回 IdP 的原始错误；清理失败不掩盖它。
+          }
+        }
         return {
           authenticated: false,
           error: {
             message: url.searchParams.get('error_description') ?? callbackError,
             name: callbackError,
           },
-          logout: true,
         };
       }
 
@@ -577,7 +599,11 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
           window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
           return { authenticated: true };
         } catch (error) {
-          sessions.clearLoginState(savedState);
+          try {
+            await clearOwnedLoginState(savedState);
+          } catch {
+            // 保留 token exchange 的原始错误。
+          }
           return { authenticated: false, error: getErrorResult(error) };
         }
       }

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -405,6 +405,7 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
   });
 
   async function exchangeCode(code: string): Promise<SSOSession> {
+    const revision = sessions.getRevision();
     const endpoints = await discover();
     const verifier = sessions.getPKCEVerifier();
     const body = new URLSearchParams({
@@ -416,6 +417,12 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     });
     const response = await requestToken(endpoints.token_endpoint, body, 'Token exchange failed');
     const session = normalizeTokenResponse(response, { tokenType: 'Bearer' }, 'Token exchange failed');
+    if (sessions.getRevision() !== revision) {
+      throw new SSOAuthError('Authorization exchange was cancelled by a newer session action', 409, {
+        code: 'authorization_exchange_cancelled',
+        retryable: false,
+      });
+    }
     sessions.saveSession(session);
     sessions.clearLoginState();
     return session;
@@ -567,6 +574,7 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
 
     async getIdentity(): Promise<Identity | null> {
       if (!sessions.getSession()) return null;
+      const revision = sessions.getRevision();
       try {
         const endpoints = await discover();
         const response = await buildAuthenticatedFetch(
@@ -575,7 +583,9 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
           { requireAuthorization: true },
         )(endpoints.userinfo_endpoint);
         if (!response.ok) return null;
-        return mapIdentity(await response.json() as Record<string, unknown>);
+        const userinfo = await response.json() as Record<string, unknown>;
+        if (sessions.getRevision() !== revision || !sessions.getSession()) return null;
+        return mapIdentity(userinfo);
       } catch {
         return null;
       }

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -36,8 +36,10 @@ export interface SSOConfig {
   postLogoutRedirectUri?: string;
   /** Token storage backend. Default: 'local' (localStorage) */
   storage?: 'local' | 'session' | TokenStorage;
-  /** Storage namespace. Default keeps compatibility with svadmin_sso_* keys. */
+  /** Storage namespace. Defaults to an issuer/client-specific key. */
   storageKey?: string;
+  /** Explicit legacy namespace to migrate after confirming it belongs to this provider. */
+  legacyStorageKey?: string;
   /** Custom identity mapper — transform OIDC userinfo to svadmin Identity */
   mapIdentity?: (userinfo: Record<string, unknown>) => Identity;
   /** Auto-refresh tokens before expiry. Default: true */
@@ -46,7 +48,7 @@ export interface SSOConfig {
   refreshBuffer?: number;
   /** Additional authorization request parameters, e.g. audience or prompt. */
   authorizationParams?: Record<string, string>;
-  /** Injectable lock used for refresh coordination. Defaults to navigator.locks. */
+  /** Optional extra lock; shared storage still provides the final refresh lease. */
   refreshLock?: RefreshLock;
   /** Injectable fetch implementation for testing and SSR runtimes. */
   fetcher?: typeof fetch;
@@ -396,7 +398,7 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     refreshBuffer,
     refreshLock: config.refreshLock,
     refresh: performRefresh,
-    legacyStorageKey: config.storageKey ? undefined : DEFAULT_STORAGE_KEY,
+    legacyStorageKey: config.legacyStorageKey,
   });
 
   async function exchangeCode(code: string): Promise<SSOSession> {
@@ -551,6 +553,7 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     },
 
     async getIdentity(): Promise<Identity | null> {
+      if (!sessions.getSession()) return null;
       try {
         const endpoints = await discover();
         const response = await provider.createAuthenticatedFetch()(endpoints.userinfo_endpoint);
@@ -577,7 +580,15 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     refreshSession: () => sessions.refreshSession(),
     getAccessToken: (options) => sessions.getAccessToken(options),
     onAuthStateChange: (callback) => sessions.onAuthStateChange(callback),
-    createAuthenticatedFetch: (fetcher) => buildAuthenticatedFetch(provider, fetcher ?? getFetcher()),
+    createAuthenticatedFetch: (fetcher) => buildAuthenticatedFetch({
+      getAuthorizationHeader: async (options) => {
+        const accessToken = await sessions.getAccessToken(options);
+        const session = sessions.getSession();
+        return accessToken && session?.access_token === accessToken
+          ? `${session.token_type} ${accessToken}`
+          : null;
+      },
+    }, fetcher ?? getFetcher()),
     destroy: () => sessions.destroy(),
 
     async onError(error) {

--- a/packages/sso/src/authenticated-fetch.ts
+++ b/packages/sso/src/authenticated-fetch.ts
@@ -2,7 +2,7 @@ import { SSOAuthError } from './errors';
 import type { GetAccessTokenOptions } from './session-manager';
 
 interface AccessTokenSource {
-  getAccessToken: (options?: GetAccessTokenOptions) => Promise<string | null>;
+  getAuthorizationHeader: (options?: GetAccessTokenOptions) => Promise<string | null>;
 }
 
 function cloneReplayableRequest(request: Request): Request {
@@ -17,11 +17,11 @@ function cloneReplayableRequest(request: Request): Request {
   }
 }
 
-function withAccessToken(request: Request, accessToken: string | null): Request {
-  if (!accessToken) return request;
+function withAuthorization(request: Request, authorization: string | null): Request {
+  if (!authorization) return request;
 
   const headers = new Headers(request.headers);
-  headers.set('Authorization', `Bearer ${accessToken}`);
+  headers.set('Authorization', authorization);
   return new Request(request, { headers });
 }
 
@@ -61,18 +61,18 @@ export function createAuthenticatedFetch(
     // 两份副本都在首次发送前创建，避免流式 body 被消费后静默丢失。
     const firstAttempt = cloneReplayableRequest(request);
     const retryAttempt = cloneReplayableRequest(request);
-    const accessToken = await source.getAccessToken();
-    const response = await fetcher(withAccessToken(firstAttempt, accessToken));
+    const authorization = await source.getAuthorizationHeader();
+    const response = await fetcher(withAuthorization(firstAttempt, authorization));
 
     if (response.status !== 401) return response;
 
-    const currentAccessToken = await source.getAccessToken();
-    const refreshedAccessToken = currentAccessToken && currentAccessToken !== accessToken
-      ? currentAccessToken
-      : await source.getAccessToken({ forceRefresh: true });
-    if (!refreshedAccessToken) return response;
+    const currentAuthorization = await source.getAuthorizationHeader();
+    const refreshedAuthorization = currentAuthorization && currentAuthorization !== authorization
+      ? currentAuthorization
+      : await source.getAuthorizationHeader({ forceRefresh: true });
+    if (!refreshedAuthorization) return response;
 
-    const retryResponse = await fetcher(withAccessToken(retryAttempt, refreshedAccessToken));
+    const retryResponse = await fetcher(withAuthorization(retryAttempt, refreshedAuthorization));
     return retryResponse.status === 401 ? markRetryExhausted(retryResponse) : retryResponse;
   }) as typeof fetch;
 }

--- a/packages/sso/src/authenticated-fetch.ts
+++ b/packages/sso/src/authenticated-fetch.ts
@@ -1,0 +1,78 @@
+import { SSOAuthError } from './errors';
+import type { GetAccessTokenOptions } from './session-manager';
+
+interface AccessTokenSource {
+  getAccessToken: (options?: GetAccessTokenOptions) => Promise<string | null>;
+}
+
+function cloneReplayableRequest(request: Request): Request {
+  try {
+    return request.clone();
+  } catch (error) {
+    throw new SSOAuthError('Authenticated request body cannot be safely replayed', 0, {
+      code: 'request_not_replayable',
+      retryable: false,
+      cause: error,
+    });
+  }
+}
+
+function withAccessToken(request: Request, accessToken: string | null): Request {
+  if (!accessToken) return request;
+
+  const headers = new Headers(request.headers);
+  headers.set('Authorization', `Bearer ${accessToken}`);
+  return new Request(request, { headers });
+}
+
+function markRetryExhausted(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('X-Svadmin-Auth-Retry', 'exhausted');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export function createAuthenticatedFetch(
+  source: AccessTokenSource,
+  fetcher: typeof fetch,
+): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    if (input instanceof Request && input.bodyUsed) {
+      throw new SSOAuthError('Authenticated request body cannot be safely replayed', 0, {
+        code: 'request_not_replayable',
+        retryable: false,
+      });
+    }
+
+    let request: Request;
+    try {
+      request = new Request(input, init);
+    } catch (error) {
+      throw new SSOAuthError('Authenticated request could not be constructed', 0, {
+        code: 'request_not_replayable',
+        retryable: false,
+        cause: error,
+      });
+    }
+
+    // 两份副本都在首次发送前创建，避免流式 body 被消费后静默丢失。
+    const firstAttempt = cloneReplayableRequest(request);
+    const retryAttempt = cloneReplayableRequest(request);
+    const accessToken = await source.getAccessToken();
+    const response = await fetcher(withAccessToken(firstAttempt, accessToken));
+
+    if (response.status !== 401) return response;
+
+    const currentAccessToken = await source.getAccessToken();
+    const refreshedAccessToken = currentAccessToken && currentAccessToken !== accessToken
+      ? currentAccessToken
+      : await source.getAccessToken({ forceRefresh: true });
+    if (!refreshedAccessToken) return response;
+
+    const retryResponse = await fetcher(withAccessToken(retryAttempt, refreshedAccessToken));
+    return retryResponse.status === 401 ? markRetryExhausted(retryResponse) : retryResponse;
+  }) as typeof fetch;
+}

--- a/packages/sso/src/authenticated-fetch.ts
+++ b/packages/sso/src/authenticated-fetch.ts
@@ -5,6 +5,10 @@ interface AccessTokenSource {
   getAuthorizationHeader: (options?: GetAccessTokenOptions) => Promise<string | null>;
 }
 
+interface AuthenticatedFetchOptions {
+  requireAuthorization?: boolean;
+}
+
 function cloneReplayableRequest(request: Request): Request {
   try {
     return request.clone();
@@ -38,6 +42,7 @@ function markRetryExhausted(response: Response): Response {
 export function createAuthenticatedFetch(
   source: AccessTokenSource,
   fetcher: typeof fetch,
+  options: AuthenticatedFetchOptions = {},
 ): typeof fetch {
   return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     if (input instanceof Request && input.bodyUsed) {
@@ -62,6 +67,12 @@ export function createAuthenticatedFetch(
     const firstAttempt = cloneReplayableRequest(request);
     const retryAttempt = cloneReplayableRequest(request);
     const authorization = await source.getAuthorizationHeader();
+    if (options.requireAuthorization && !authorization) {
+      throw new SSOAuthError('Authenticated request requires an active session', 401, {
+        code: 'session_not_found',
+        retryable: false,
+      });
+    }
     const response = await fetcher(withAuthorization(firstAttempt, authorization));
 
     if (response.status !== 401) return response;

--- a/packages/sso/src/errors.ts
+++ b/packages/sso/src/errors.ts
@@ -1,0 +1,131 @@
+export interface SSOAuthErrorOptions {
+  code?: string;
+  details?: unknown;
+  body?: unknown;
+  retryable?: boolean;
+  cause?: unknown;
+}
+
+const RETRYABLE_STATUS_CODES = new Set([0, 408, 429, 502, 503, 504]);
+const TERMINAL_OAUTH_CODES = new Set([
+  'invalid_grant',
+  'invalid_token',
+  'session_not_found',
+  'refresh_token_not_found',
+  'refresh_token_already_used',
+  'refresh_token_reuse_detected',
+  'invalid_refresh_token',
+  'session_expired',
+  'session_persistence_failed',
+  'auth_retry_exhausted',
+  'session_refresh_failed',
+]);
+
+export class SSOAuthError extends Error {
+  readonly statusCode: number;
+  readonly code?: string;
+  readonly details?: unknown;
+  readonly body?: unknown;
+  readonly retryable: boolean;
+  override readonly cause?: unknown;
+
+  constructor(message: string, statusCode: number, options: SSOAuthErrorOptions = {}) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'SSOAuthError';
+    this.statusCode = statusCode;
+    this.code = options.code;
+    this.details = options.details;
+    this.body = options.body;
+    this.retryable = options.retryable ?? RETRYABLE_STATUS_CODES.has(statusCode);
+    this.cause = options.cause;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === 'string');
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return undefined;
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+export async function createSSOAuthResponseError(
+  response: Response,
+  fallbackMessage: string,
+): Promise<SSOAuthError> {
+  const body = await readResponseBody(response);
+  const record = asRecord(body);
+  const nestedError = asRecord(record?.error);
+  const code = firstString(
+    record?.code,
+    record?.error_code,
+    nestedError?.code,
+    nestedError?.error_code,
+    record?.error,
+  );
+  const description = firstString(
+    record?.error_description,
+    nestedError?.error_description,
+  );
+  const responseMessage = firstString(record?.message, nestedError?.message);
+  const textMessage = typeof body === 'string' ? body : undefined;
+  const statusMessage = response.statusText || `HTTP ${response.status}`;
+
+  return new SSOAuthError(
+    description ?? responseMessage ?? textMessage ?? `${fallbackMessage}: ${statusMessage}`,
+    response.status,
+    {
+      code,
+      details: record?.details ?? nestedError?.details,
+      body,
+    },
+  );
+}
+
+export function createSSOAuthNetworkError(error: unknown, fallbackMessage: string): SSOAuthError {
+  if (error instanceof SSOAuthError) return error;
+
+  const isAbort = (
+    typeof DOMException !== 'undefined'
+    && error instanceof DOMException
+    && error.name === 'AbortError'
+  ) || (
+    typeof error === 'object'
+    && error !== null
+    && 'name' in error
+    && error.name === 'AbortError'
+  );
+  return new SSOAuthError(
+    error instanceof Error ? error.message : fallbackMessage,
+    0,
+    {
+      code: isAbort ? 'request_aborted' : 'network_error',
+      retryable: !isAbort,
+      cause: error,
+    },
+  );
+}
+
+export function isTerminalSessionError(error: unknown): boolean {
+  const record = asRecord(error);
+  const code = firstString(
+    record?.code,
+    record?.error_code,
+    asRecord(record?.error)?.code,
+    asRecord(record?.error)?.error_code,
+  );
+  return code !== undefined && TERMINAL_OAUTH_CODES.has(code);
+}

--- a/packages/sso/src/errors.ts
+++ b/packages/sso/src/errors.ts
@@ -6,7 +6,7 @@ export interface SSOAuthErrorOptions {
   cause?: unknown;
 }
 
-const RETRYABLE_STATUS_CODES = new Set([0, 408, 429, 502, 503, 504]);
+const RETRYABLE_STATUS_CODES = new Set([0, 408, 429, 500, 502, 503, 504]);
 const TERMINAL_OAUTH_CODES = new Set([
   'invalid_grant',
   'invalid_token',

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -8,7 +8,17 @@
  */
 
 export { createSSOAuthProvider } from './auth-provider';
-export type { SSOAuthProvider, SSOConfig, TokenStorage } from './auth-provider';
+export type {
+  AuthStateChangeCallback,
+  AuthStateChangeEvent,
+  GetAccessTokenOptions,
+  RefreshLock,
+  SSOAuthProvider,
+  SSOConfig,
+  SSOSession,
+  TokenStorage,
+} from './auth-provider';
+export { SSOAuthError } from './errors';
 
 // Social login presets
 export {

--- a/packages/sso/src/presets.test.ts
+++ b/packages/sso/src/presets.test.ts
@@ -24,6 +24,7 @@ describe('SSO presets', () => {
     expect(typeof presets.createGitLabAuth).toBe('function');
     expect(typeof presets.createKeycloakAuth).toBe('function');
     expect(typeof presets.createAuth0Auth).toBe('function');
+    expect(typeof presets.createSupauthAuth).toBe('function');
   });
 
   test('createGoogleAuth returns AuthProvider', async () => {
@@ -88,5 +89,62 @@ describe('SSO presets', () => {
     });
     expect(provider).toBeTruthy();
     expect(typeof provider.login).toBe('function');
+  });
+
+  test('derives isolated storage namespaces for Supauth clients', async () => {
+    const { createSupauthAuth } = await import('./presets');
+    const storage = createMemoryStorage();
+    const issuer = 'https://auth.example.test';
+    const firstKey = `svadmin_sso:${encodeURIComponent(issuer)}:${encodeURIComponent('client-a')}_tokens`;
+    const secondKey = `svadmin_sso:${encodeURIComponent(issuer)}:${encodeURIComponent('client-b')}_tokens`;
+    storage.setItem(firstKey, JSON.stringify({
+      access_token: 'access-a',
+      token_type: 'Bearer',
+    }));
+    storage.setItem(secondKey, JSON.stringify({
+      access_token: 'access-b',
+      token_type: 'Bearer',
+    }));
+
+    const first = createSupauthAuth('client-a', {
+      issuer,
+      redirectUri: 'http://localhost/callback',
+      storage,
+      autoRefresh: false,
+    });
+    const second = createSupauthAuth('client-b', {
+      issuer,
+      redirectUri: 'http://localhost/callback',
+      storage,
+      autoRefresh: false,
+    });
+
+    expect((await first.getSession())?.access_token).toBe('access-a');
+    expect((await second.getSession())?.access_token).toBe('access-b');
+    first.destroy();
+    second.destroy();
+  });
+
+  test('migrates a legacy preset session only when the new namespace is empty', async () => {
+    const { createGoogleAuth } = await import('./presets');
+    const storage = createMemoryStorage();
+    storage.setItem('svadmin_sso_tokens', JSON.stringify({
+      access_token: 'legacy-access',
+      refresh_token: 'legacy-refresh',
+      token_type: 'Bearer',
+    }));
+
+    const provider = createGoogleAuth('legacy-client', {
+      redirectUri: 'http://localhost/callback',
+      storage,
+      autoRefresh: false,
+    });
+
+    expect((await provider.getSession())?.access_token).toBe('legacy-access');
+    expect(storage.getItem('svadmin_sso_tokens')).toBeNull();
+    expect(storage.getItem(
+      `svadmin_sso:${encodeURIComponent('https://accounts.google.com')}:${encodeURIComponent('legacy-client')}_tokens`,
+    )).toContain('legacy-access');
+    provider.destroy();
   });
 });

--- a/packages/sso/src/presets.test.ts
+++ b/packages/sso/src/presets.test.ts
@@ -137,6 +137,7 @@ describe('SSO presets', () => {
     const provider = createGoogleAuth('legacy-client', {
       redirectUri: 'http://localhost/callback',
       storage,
+      legacyStorageKey: 'svadmin_sso',
       autoRefresh: false,
     });
 
@@ -145,6 +146,26 @@ describe('SSO presets', () => {
     expect(storage.getItem(
       `svadmin_sso:${encodeURIComponent('https://accounts.google.com')}:${encodeURIComponent('legacy-client')}_tokens`,
     )).toContain('legacy-access');
+    provider.destroy();
+  });
+
+  test('does not claim an ambiguous legacy session by default', async () => {
+    const { createGoogleAuth } = await import('./presets');
+    const storage = createMemoryStorage();
+    storage.setItem('svadmin_sso_tokens', JSON.stringify({
+      access_token: 'legacy-access',
+      refresh_token: 'legacy-refresh',
+      token_type: 'Bearer',
+    }));
+
+    const provider = createGoogleAuth('new-client', {
+      redirectUri: 'http://localhost/callback',
+      storage,
+      autoRefresh: false,
+    });
+
+    expect(await provider.getSession()).toBeNull();
+    expect(storage.getItem('svadmin_sso_tokens')).toContain('legacy-access');
     provider.destroy();
   });
 });

--- a/packages/sso/src/presets.ts
+++ b/packages/sso/src/presets.ts
@@ -35,8 +35,9 @@ function resolveRedirectUri(opts?: PresetOptions): string {
  * @param clientId - Google OAuth2 Client ID
  */
 export function createGoogleAuth(clientId: string, opts?: PresetOptions) {
+  const issuer = 'https://accounts.google.com';
   return createSSOAuthProvider({
-    issuer: 'https://accounts.google.com',
+    issuer,
     clientId,
     scopes: ['openid', 'profile', 'email'],
     redirectUri: resolveRedirectUri(opts),
@@ -57,8 +58,9 @@ export function createMicrosoftAuth(
   tenantId = 'common',
   opts?: PresetOptions,
 ) {
+  const issuer = `https://login.microsoftonline.com/${tenantId}/v2.0`;
   return createSSOAuthProvider({
-    issuer: `https://login.microsoftonline.com/${tenantId}/v2.0`,
+    issuer,
     clientId,
     scopes: ['openid', 'profile', 'email'],
     redirectUri: resolveRedirectUri(opts),
@@ -84,9 +86,10 @@ export function createGitHubAuth(clientId: string, opts?: PresetOptions) {
   // GitHub uses standard OAuth2, not OIDC — requires manual endpoint config.
   // We leverage the SSO provider but override the discovery with manual endpoints.
   const redirectUri = resolveRedirectUri(opts);
+  const issuer = 'https://github.com';
 
   return createSSOAuthProvider({
-    issuer: 'https://github.com',
+    issuer,
     clientId,
     scopes: ['read:user', 'user:email'],
     redirectUri,
@@ -119,8 +122,9 @@ export function createGitLabAuth(
   instanceUrl = 'https://gitlab.com',
   opts?: PresetOptions,
 ) {
+  const issuer = instanceUrl;
   return createSSOAuthProvider({
-    issuer: instanceUrl,
+    issuer,
     clientId,
     scopes: ['openid', 'profile', 'email'],
     redirectUri: resolveRedirectUri(opts),
@@ -143,8 +147,9 @@ export function createKeycloakAuth(
   clientId: string,
   opts?: PresetOptions,
 ) {
+  const issuer = `${baseUrl.replace(/\/$/, '')}/realms/${realm}`;
   return createSSOAuthProvider({
-    issuer: `${baseUrl.replace(/\/$/, '')}/realms/${realm}`,
+    issuer,
     clientId,
     scopes: ['openid', 'profile', 'email'],
     redirectUri: resolveRedirectUri(opts),
@@ -165,8 +170,9 @@ export function createAuth0Auth(
   clientId: string,
   opts?: PresetOptions,
 ) {
+  const issuer = `https://${domain.replace(/^https?:\/\//, '').replace(/\/$/, '')}`;
   return createSSOAuthProvider({
-    issuer: `https://${domain.replace(/^https?:\/\//, '').replace(/\/$/, '')}`,
+    issuer,
     clientId,
     scopes: ['openid', 'profile', 'email'],
     redirectUri: resolveRedirectUri(opts),

--- a/packages/sso/src/session-lifecycle.test.ts
+++ b/packages/sso/src/session-lifecycle.test.ts
@@ -371,9 +371,8 @@ describe('rotation-safe session lifecycle', () => {
         message: 'Refresh token already used',
       }, 400);
     });
-    const noOpLock = (): RefreshLock => ({ request: async (_name, operation) => operation() });
-    const first = createProvider({ storage, storageKey, fetcher, refreshLock: noOpLock() });
-    const second = createProvider({ storage, storageKey, fetcher, refreshLock: noOpLock() });
+    const first = createProvider({ storage, storageKey, fetcher });
+    const second = createProvider({ storage, storageKey, fetcher });
 
     const firstRefresh = first.refreshSession();
     await winnerStarted.promise;
@@ -393,6 +392,47 @@ describe('rotation-safe session lifecycle', () => {
     expect(refreshCalls).toBe(1);
     first.destroy();
     second.destroy();
+  });
+
+  test('fails closed in browsers without an atomic cross-context refresh lock', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        document: {},
+        navigator: {},
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+      } as unknown as Window,
+      configurable: true,
+    });
+    const storage = createMemoryStorage();
+    const storageKey = 'missing-browser-lock';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    let refreshCalls = 0;
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => {
+        refreshCalls += 1;
+        return jsonResponse({
+          access_token: 'unexpected-access',
+          refresh_token: 'unexpected-refresh',
+          expires_in: 3600,
+        });
+      }),
+    });
+
+    await expect(provider.refreshSession()).rejects.toMatchObject({
+      code: 'refresh_lock_failed',
+      retryable: true,
+    });
+    expect(refreshCalls).toBe(0);
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-1');
+    provider.destroy();
   });
 
   test('broadcasts refreshed sessions to another same-origin provider', async () => {
@@ -1101,6 +1141,59 @@ describe('logout and SSR behavior', () => {
       code: 'session_persistence_failed',
       retryable: false,
     });
+    expect(await provider.getSession()).toBeNull();
+    provider.destroy();
+  });
+
+  test('does not revive a failed local logout from a remote refresh event', async () => {
+    let storageListener: ((event: StorageEvent) => void) | undefined;
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        navigator: {},
+        addEventListener: (type: string, listener: (event: StorageEvent) => void) => {
+          if (type === 'storage') storageListener = listener;
+        },
+        removeEventListener: () => undefined,
+      } as unknown as Window,
+      configurable: true,
+    });
+    const storage = createMemoryStorage();
+    const storageKey = 'logout-no-revival';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'old-refresh',
+      token_type: 'Bearer',
+    });
+    const originalSetItem = storage.setItem;
+    const originalRemoveItem = storage.removeItem;
+    storage.setItem = (key, value) => {
+      if (key === sessionKey(storageKey) && value === '') {
+        throw new DOMException('blocked', 'SecurityError');
+      }
+      originalSetItem(key, value);
+    };
+    storage.removeItem = (key) => {
+      if (key === sessionKey(storageKey)) throw new DOMException('blocked', 'SecurityError');
+      originalRemoveItem(key);
+    };
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => { throw new TypeError('offline'); }),
+    });
+
+    await expect(provider.logout()).rejects.toMatchObject({ code: 'session_persistence_failed' });
+    const remoteRaw = JSON.stringify({
+      access_token: 'remote-access',
+      refresh_token: 'remote-refresh',
+      token_type: 'Bearer',
+    });
+    originalSetItem(sessionKey(storageKey), remoteRaw);
+    storageListener?.({
+      key: sessionKey(storageKey),
+      newValue: remoteRaw,
+    } as StorageEvent);
+
     expect(await provider.getSession()).toBeNull();
     provider.destroy();
   });

--- a/packages/sso/src/session-lifecycle.test.ts
+++ b/packages/sso/src/session-lifecycle.test.ts
@@ -348,53 +348,49 @@ describe('rotation-safe session lifecycle', () => {
     provider.destroy();
   });
 
-  test('a losing refresh does not clear a session already rotated by another tab', async () => {
+  test('serializes shared-storage refreshes before a loser can clear the winner', async () => {
     const storage = createMemoryStorage();
-    const storageKey = 'rotation-race';
+    const storageKey = 'rotation-race-loser-first';
     saveSession(storage, storageKey, {
       access_token: 'old-access',
       refresh_token: 'refresh-1',
       expires_at: 1,
       token_type: 'Bearer',
     });
+    const winnerStarted = createSignal();
+    const winnerResponse = createDeferred<Response>();
     let refreshCalls = 0;
-    let releaseWinner!: () => void;
-    const loserStarted = new Promise<void>((resolve) => {
-      releaseWinner = resolve;
-    });
-    let winnerSaved!: () => void;
-    const winnerPersisted = new Promise<void>((resolve) => {
-      winnerSaved = resolve;
-    });
     const fetcher = asFetcher(async () => {
       refreshCalls += 1;
       if (refreshCalls === 1) {
-        await loserStarted;
-        return jsonResponse({
-          access_token: 'new-access',
-          refresh_token: 'refresh-2',
-          expires_in: 3600,
-        });
+        winnerStarted.resolve();
+        return winnerResponse.promise;
       }
-      releaseWinner();
-      await winnerPersisted;
       return jsonResponse({
-        error_code: 'refresh_token_already_used',
+        error: 'invalid_grant',
         message: 'Refresh token already used',
       }, 400);
     });
     const noOpLock = (): RefreshLock => ({ request: async (_name, operation) => operation() });
     const first = createProvider({ storage, storageKey, fetcher, refreshLock: noOpLock() });
     const second = createProvider({ storage, storageKey, fetcher, refreshLock: noOpLock() });
-    first.onAuthStateChange((event) => {
-      if (event === 'TOKEN_REFRESHED') winnerSaved();
-    });
 
-    const sessions = await Promise.all([first.refreshSession(), second.refreshSession()]);
+    const firstRefresh = first.refreshSession();
+    await winnerStarted.promise;
+    const secondRefresh = second.refreshSession();
+    await Promise.resolve();
+    await Promise.resolve();
+    winnerResponse.resolve(jsonResponse({
+      access_token: 'new-access',
+      refresh_token: 'refresh-2',
+      expires_in: 3600,
+    }));
+
+    const sessions = await Promise.all([firstRefresh, secondRefresh]);
 
     expect(sessions.map((session) => session?.access_token)).toEqual(['new-access', 'new-access']);
     expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-2');
-    expect(refreshCalls).toBe(2);
+    expect(refreshCalls).toBe(1);
     first.destroy();
     second.destroy();
   });
@@ -692,6 +688,29 @@ describe('rotation-safe session lifecycle', () => {
     provider.destroy();
   });
 
+  test('retains the session on retryable 500 refresh failures', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'retryable-500';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({ message: 'server unavailable' }, 500)),
+    });
+
+    await expect(provider.refreshSession()).rejects.toMatchObject({
+      statusCode: 500,
+      retryable: true,
+    });
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-1');
+    provider.destroy();
+  });
+
   test('clears the session for GoTrue refresh_token_not_found error_code responses', async () => {
     const storage = createMemoryStorage();
     const storageKey = 'terminal';
@@ -830,6 +849,29 @@ describe('rotation-safe session lifecycle', () => {
 });
 
 describe('authenticated fetch recovery', () => {
+  test('preserves the session token type in the authorization header', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'token-type';
+    saveSession(storage, storageKey, {
+      access_token: 'proof-token',
+      token_type: 'DPoP',
+    });
+    let authorization = '';
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher((input) => {
+        authorization = requestHeaders(input).get('Authorization') ?? '';
+        return new Response(null, { status: 200 });
+      }),
+    });
+
+    await provider.createAuthenticatedFetch()('https://api.test/private');
+
+    expect(authorization).toBe('DPoP proof-token');
+    provider.destroy();
+  });
+
   test('replays one POST after 401 with the rotated token and intact body', async () => {
     const storage = createMemoryStorage();
     const storageKey = 'fetch-recovery';
@@ -1004,6 +1046,65 @@ describe('authenticated fetch recovery', () => {
 });
 
 describe('logout and SSR behavior', () => {
+  test('overwrites persisted tokens when storage removal fails', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'logout-remove-failure';
+    saveSession(storage, storageKey, {
+      access_token: 'access',
+      refresh_token: 'refresh',
+      token_type: 'Bearer',
+    });
+    const originalRemoveItem = storage.removeItem;
+    storage.removeItem = (key) => {
+      if (key === sessionKey(storageKey)) throw new DOMException('blocked', 'SecurityError');
+      originalRemoveItem(key);
+    };
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => { throw new TypeError('offline'); }),
+    });
+
+    const result = await provider.logout();
+
+    expect(result.success).toBe(true);
+    expect(storage.getItem(sessionKey(storageKey))).toBe('');
+    expect(await provider.getSession()).toBeNull();
+    provider.destroy();
+  });
+
+  test('fails closed in memory when storage cannot remove or overwrite tokens', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'logout-persistence-failure';
+    saveSession(storage, storageKey, {
+      access_token: 'access',
+      refresh_token: 'refresh',
+      token_type: 'Bearer',
+    });
+    const originalSetItem = storage.setItem;
+    const originalRemoveItem = storage.removeItem;
+    storage.setItem = (key, value) => {
+      if (key === sessionKey(storageKey) && value === '') throw new DOMException('blocked', 'SecurityError');
+      originalSetItem(key, value);
+    };
+    storage.removeItem = (key) => {
+      if (key === sessionKey(storageKey)) throw new DOMException('blocked', 'SecurityError');
+      originalRemoveItem(key);
+    };
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => { throw new TypeError('offline'); }),
+    });
+
+    await expect(provider.logout()).rejects.toMatchObject({
+      code: 'session_persistence_failed',
+      retryable: false,
+    });
+    expect(await provider.getSession()).toBeNull();
+    provider.destroy();
+  });
+
   test('clears local state before best-effort discovery failure', async () => {
     const storage = createMemoryStorage();
     const storageKey = 'logout';

--- a/packages/sso/src/session-lifecycle.test.ts
+++ b/packages/sso/src/session-lifecycle.test.ts
@@ -1,0 +1,1054 @@
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
+import {
+  createSSOAuthProvider,
+  type RefreshLock,
+  type SSOSession,
+  type TokenStorage,
+} from './auth-provider';
+import { SSOAuthError } from './errors';
+
+const endpoints = {
+  authorization_endpoint: 'https://idp.test/oauth2/authorize',
+  token_endpoint: 'https://idp.test/oauth2/token',
+  userinfo_endpoint: 'https://idp.test/oauth2/userinfo',
+  end_session_endpoint: 'https://idp.test/oauth2/logout',
+};
+
+function createMemoryStorage(): TokenStorage & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => { store.set(key, value); },
+    removeItem: (key) => { store.delete(key); },
+  };
+}
+
+function sessionKey(storageKey: string): string {
+  return `${storageKey}_tokens`;
+}
+
+function saveSession(storage: TokenStorage, storageKey: string, session: SSOSession): void {
+  storage.setItem(sessionKey(storageKey), JSON.stringify(session));
+}
+
+function readSession(storage: TokenStorage, storageKey: string): SSOSession | null {
+  const raw = storage.getItem(sessionKey(storageKey));
+  return raw ? JSON.parse(raw) as SSOSession : null;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  return input instanceof Request ? input.url : String(input);
+}
+
+function requestHeaders(input: RequestInfo | URL, init?: RequestInit): Headers {
+  return input instanceof Request ? input.headers : new Headers(init?.headers);
+}
+
+function asFetcher(
+  handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> | Response,
+): typeof fetch {
+  return handler as typeof fetch;
+}
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => { resolve = complete; });
+  return { promise, resolve };
+}
+
+function createSignal(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((complete) => { resolve = complete; });
+  return { promise, resolve };
+}
+
+function createSerialLock(): RefreshLock {
+  const tails = new Map<string, Promise<unknown>>();
+  return {
+    async request<T>(name: string, operation: () => Promise<T>): Promise<T> {
+      const previous = tails.get(name) ?? Promise.resolve();
+      const current = previous.catch(() => undefined).then(operation);
+      tails.set(name, current);
+      try {
+        return await current;
+      } finally {
+        if (tails.get(name) === current) tails.delete(name);
+      }
+    },
+  };
+}
+
+class FakeBroadcastChannel {
+  static readonly channels = new Map<string, Set<FakeBroadcastChannel>>();
+
+  private readonly listeners = new Set<(event: MessageEvent) => void>();
+
+  constructor(private readonly name: string) {
+    const peers = FakeBroadcastChannel.channels.get(name) ?? new Set();
+    peers.add(this);
+    FakeBroadcastChannel.channels.set(name, peers);
+  }
+
+  addEventListener(_type: string, listener: (event: MessageEvent) => void): void {
+    this.listeners.add(listener);
+  }
+
+  removeEventListener(_type: string, listener: (event: MessageEvent) => void): void {
+    this.listeners.delete(listener);
+  }
+
+  postMessage(data: unknown): void {
+    for (const peer of FakeBroadcastChannel.channels.get(this.name) ?? []) {
+      if (peer === this) continue;
+      for (const listener of peer.listeners) listener({ data } as MessageEvent);
+    }
+  }
+
+  close(): void {
+    FakeBroadcastChannel.channels.get(this.name)?.delete(this);
+  }
+}
+
+function createProvider(options: {
+  storage: TokenStorage;
+  storageKey: string;
+  fetcher: typeof fetch;
+  refreshLock?: RefreshLock;
+  autoRefresh?: boolean;
+}) {
+  return createSSOAuthProvider({
+    issuer: 'https://idp.test',
+    clientId: 'admin-console',
+    redirectUri: 'https://app.test/callback',
+    storage: options.storage,
+    storageKey: options.storageKey,
+    fetcher: options.fetcher,
+    refreshLock: options.refreshLock,
+    autoRefresh: options.autoRefresh ?? false,
+    manualEndpoints: endpoints,
+  });
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'window');
+  Reflect.deleteProperty(globalThis, 'document');
+  FakeBroadcastChannel.channels.clear();
+});
+
+describe('rotation-safe session lifecycle', () => {
+  test('single-flights 20 concurrent refresh requests in one provider', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'single-flight';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: Math.floor(Date.now() / 1000) - 1,
+      token_type: 'Bearer',
+    });
+    let refreshCalls = 0;
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(async () => {
+        refreshCalls += 1;
+        await Promise.resolve();
+        return jsonResponse({
+          access_token: 'new-access',
+          refresh_token: 'refresh-2',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        });
+      }),
+    });
+
+    const tokens = await Promise.all(Array.from(
+      { length: 20 },
+      () => provider.getAccessToken({ forceRefresh: true }),
+    ));
+
+    expect(new Set(tokens)).toEqual(new Set(['new-access']));
+    expect(refreshCalls).toBe(1);
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-2');
+    provider.destroy();
+  });
+
+  test('two providers sharing storage and a lock reuse the rotated session', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'two-tabs';
+    const refreshLock = createSerialLock();
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: Math.floor(Date.now() / 1000) - 1,
+      token_type: 'Bearer',
+    });
+    let refreshCalls = 0;
+    const fetcher = asFetcher(async () => {
+      refreshCalls += 1;
+      await Promise.resolve();
+      return jsonResponse({
+        access_token: 'new-access',
+        refresh_token: 'refresh-2',
+        expires_in: 3600,
+      });
+    });
+    const first = createProvider({ storage, storageKey, fetcher, refreshLock });
+    const second = createProvider({ storage, storageKey, fetcher, refreshLock });
+
+    const results = await Promise.all([first.refreshSession(), second.refreshSession()]);
+
+    expect(results.map((session) => session?.access_token)).toEqual(['new-access', 'new-access']);
+    expect(refreshCalls).toBe(1);
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-2');
+    first.destroy();
+    second.destroy();
+  });
+
+  test('does not restore a session when logout completes during refresh', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'logout-during-refresh';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const refreshStarted = createSignal();
+    const refreshResponse = createDeferred<Response>();
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => {
+        refreshStarted.resolve();
+        return refreshResponse.promise;
+      }),
+    });
+
+    const pendingRefresh = provider.refreshSession();
+    await refreshStarted.promise;
+    expect(await provider.logout()).toEqual({ success: true, redirectTo: '/' });
+    refreshResponse.resolve(jsonResponse({
+      access_token: 'rotated-access',
+      refresh_token: 'refresh-2',
+      expires_in: 3600,
+    }));
+
+    expect(await pendingRefresh).toBeNull();
+    expect(readSession(storage, storageKey)).toBeNull();
+    provider.destroy();
+  });
+
+  test('reuses a new login that wins while an older refresh is in flight', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'login-during-refresh';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const refreshStarted = createSignal();
+    const refreshResponse = createDeferred<Response>();
+    const refreshingProvider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => {
+        refreshStarted.resolve();
+        return refreshResponse.promise;
+      }),
+    });
+
+    const pendingRefresh = refreshingProvider.refreshSession();
+    await refreshStarted.promise;
+    storage.setItem(`${storageKey}_pkce_verifier`, 'new-verifier');
+    storage.setItem(`${storageKey}_state`, 'new-state');
+    const location = {
+      href: 'https://app.test/callback?code=new-code&state=new-state',
+    };
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location,
+        history: {
+          replaceState: (_state: unknown, _title: string, url: string) => {
+            location.href = new URL(url, location.href).href;
+          },
+        },
+      } as unknown as Window,
+      configurable: true,
+    });
+    const loginProvider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({
+        access_token: 'new-login-access',
+        refresh_token: 'new-login-refresh',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      })),
+    });
+
+    expect(await loginProvider.check()).toEqual({ authenticated: true });
+    refreshResponse.resolve(jsonResponse({
+      access_token: 'stale-rotated-access',
+      refresh_token: 'stale-refresh-2',
+      expires_in: 3600,
+    }));
+
+    expect((await pendingRefresh)?.access_token).toBe('new-login-access');
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('new-login-refresh');
+    refreshingProvider.destroy();
+    loginProvider.destroy();
+  });
+
+  test('fails closed when session storage becomes invalid during refresh', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'invalid-race-winner';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const refreshStarted = createSignal();
+    const refreshResponse = createDeferred<Response>();
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => {
+        refreshStarted.resolve();
+        return refreshResponse.promise;
+      }),
+    });
+
+    const pendingRefresh = provider.refreshSession();
+    await refreshStarted.promise;
+    storage.setItem(sessionKey(storageKey), JSON.stringify({
+      access_token: 'invalid-session',
+      token_type: '',
+    }));
+    refreshResponse.resolve(jsonResponse({
+      access_token: 'stale-rotated-access',
+      refresh_token: 'stale-refresh-2',
+      expires_in: 3600,
+    }));
+
+    await expect(pendingRefresh).rejects.toMatchObject({
+      code: 'session_refresh_failed',
+      retryable: false,
+    });
+    expect(readSession(storage, storageKey)).toBeNull();
+    provider.destroy();
+  });
+
+  test('a losing refresh does not clear a session already rotated by another tab', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'rotation-race';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    let refreshCalls = 0;
+    let releaseWinner!: () => void;
+    const loserStarted = new Promise<void>((resolve) => {
+      releaseWinner = resolve;
+    });
+    let winnerSaved!: () => void;
+    const winnerPersisted = new Promise<void>((resolve) => {
+      winnerSaved = resolve;
+    });
+    const fetcher = asFetcher(async () => {
+      refreshCalls += 1;
+      if (refreshCalls === 1) {
+        await loserStarted;
+        return jsonResponse({
+          access_token: 'new-access',
+          refresh_token: 'refresh-2',
+          expires_in: 3600,
+        });
+      }
+      releaseWinner();
+      await winnerPersisted;
+      return jsonResponse({
+        error_code: 'refresh_token_already_used',
+        message: 'Refresh token already used',
+      }, 400);
+    });
+    const noOpLock = (): RefreshLock => ({ request: async (_name, operation) => operation() });
+    const first = createProvider({ storage, storageKey, fetcher, refreshLock: noOpLock() });
+    const second = createProvider({ storage, storageKey, fetcher, refreshLock: noOpLock() });
+    first.onAuthStateChange((event) => {
+      if (event === 'TOKEN_REFRESHED') winnerSaved();
+    });
+
+    const sessions = await Promise.all([first.refreshSession(), second.refreshSession()]);
+
+    expect(sessions.map((session) => session?.access_token)).toEqual(['new-access', 'new-access']);
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-2');
+    expect(refreshCalls).toBe(2);
+    first.destroy();
+    second.destroy();
+  });
+
+  test('broadcasts refreshed sessions to another same-origin provider', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        navigator: {},
+        BroadcastChannel: FakeBroadcastChannel,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+      } as unknown as Window,
+      configurable: true,
+    });
+    const sharedStorage = createMemoryStorage();
+    const storageKey = 'broadcast';
+    const initialSession: SSOSession = {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    };
+    saveSession(sharedStorage, storageKey, initialSession);
+    const fetcher = asFetcher(() => jsonResponse({
+      access_token: 'new-access',
+      refresh_token: 'refresh-2',
+      expires_in: 3600,
+    }));
+    const first = createProvider({ storage: sharedStorage, storageKey, fetcher });
+    const second = createProvider({ storage: sharedStorage, storageKey, fetcher });
+    const events: string[] = [];
+    second.onAuthStateChange((event) => { events.push(event); });
+
+    await first.refreshSession();
+
+    expect((await second.getSession())?.access_token).toBe('new-access');
+    expect((await second.getSession())?.refresh_token).toBe('refresh-2');
+    expect(events).toEqual(['TOKEN_REFRESHED']);
+    first.destroy();
+    second.destroy();
+  });
+
+  test('does not copy refreshed tokens into an isolated storage through BroadcastChannel', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        navigator: {},
+        BroadcastChannel: FakeBroadcastChannel,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+      } as unknown as Window,
+      configurable: true,
+    });
+    const firstStorage = createMemoryStorage();
+    const secondStorage = createMemoryStorage();
+    const storageKey = 'isolated-broadcast';
+    const initialSession: SSOSession = {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    };
+    saveSession(firstStorage, storageKey, initialSession);
+    saveSession(secondStorage, storageKey, initialSession);
+    const first = createProvider({
+      storage: firstStorage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({
+        access_token: 'new-access',
+        refresh_token: 'refresh-2',
+        expires_in: 3600,
+      })),
+    });
+    const second = createProvider({
+      storage: secondStorage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({ access_token: 'unexpected' })),
+    });
+    const events: string[] = [];
+    second.onAuthStateChange((event) => { events.push(event); });
+
+    await first.refreshSession();
+
+    expect((await second.getSession())?.access_token).toBe('old-access');
+    expect(events).toEqual([]);
+    first.destroy();
+    second.destroy();
+  });
+
+  test('preserves id_token when a rotation response omits it', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'preserve-id-token';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      id_token: 'original-id-token',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({
+        access_token: 'new-access',
+        refresh_token: 'refresh-2',
+        expires_in: 3600,
+      })),
+    });
+
+    const session = await provider.refreshSession();
+
+    expect(session?.id_token).toBe('original-id-token');
+    expect(session?.refresh_token).toBe('refresh-2');
+    provider.destroy();
+  });
+
+  test('rejects refresh responses with an empty token_type', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'empty-refresh-token-type';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({
+        access_token: 'new-access',
+        refresh_token: 'refresh-2',
+        token_type: '',
+      })),
+    });
+
+    await expect(provider.refreshSession()).rejects.toMatchObject({
+      code: 'invalid_token_response',
+    });
+    expect(readSession(storage, storageKey)?.access_token).toBe('old-access');
+    provider.destroy();
+  });
+
+  test('rejects refresh responses with an empty refresh_token', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'empty-rotated-refresh-token';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({
+        access_token: 'new-access',
+        refresh_token: '',
+      })),
+    });
+
+    await expect(provider.refreshSession()).rejects.toMatchObject({
+      code: 'invalid_token_response',
+    });
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-1');
+    provider.destroy();
+  });
+
+  test('isolates subscriber failures from persistence and refresh completion', async () => {
+    const warning = spyOn(console, 'warn').mockImplementation(() => undefined);
+    const storage = createMemoryStorage();
+    const storageKey = 'listener-failure';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({
+        access_token: 'new-access',
+        refresh_token: 'refresh-2',
+        expires_in: 3600,
+      })),
+    });
+    const events: string[] = [];
+    provider.onAuthStateChange(() => { throw new Error('subscriber failed'); });
+    provider.onAuthStateChange((event) => { events.push(event); });
+
+    expect(await provider.getAccessToken({ forceRefresh: true })).toBe('new-access');
+    expect(events).toEqual(['TOKEN_REFRESHED']);
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-2');
+    expect(warning).toHaveBeenCalledWith(
+      '[svadmin/sso] auth state listener failed: subscriber failed',
+    );
+    warning.mockRestore();
+    provider.destroy();
+  });
+
+  test('isolates rejected async subscribers from persistence and refresh completion', async () => {
+    const warning = spyOn(console, 'warn').mockImplementation(() => undefined);
+    const storage = createMemoryStorage();
+    const storageKey = 'async-listener-failure';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({
+        access_token: 'new-access',
+        refresh_token: 'refresh-2',
+        expires_in: 3600,
+      })),
+    });
+    provider.onAuthStateChange(async () => {
+      throw new Error('async subscriber failed');
+    });
+
+    expect(await provider.getAccessToken({ forceRefresh: true })).toBe('new-access');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(warning).toHaveBeenCalledWith(
+      '[svadmin/sso] async auth state listener failed: async subscriber failed',
+    );
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-2');
+    warning.mockRestore();
+    provider.destroy();
+  });
+
+  test('fails closed when a rotated token set cannot be persisted', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'persistence-failure';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const originalSetItem = storage.setItem;
+    storage.setItem = (key, value) => {
+      if (key === sessionKey(storageKey)) throw new DOMException('Quota exceeded', 'QuotaExceededError');
+      originalSetItem(key, value);
+    };
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({
+        access_token: 'new-access',
+        refresh_token: 'refresh-2',
+        expires_in: 3600,
+      })),
+    });
+
+    let persistenceError: unknown;
+    try {
+      await provider.refreshSession();
+    } catch (error) {
+      persistenceError = error;
+    }
+
+    expect(persistenceError).toMatchObject({ code: 'session_persistence_failed', retryable: false });
+    expect(readSession(storage, storageKey)).toBeNull();
+    expect(await provider.onError?.(persistenceError)).toEqual({ logout: true, redirectTo: '/login' });
+    provider.destroy();
+  });
+
+  test('retains the session on retryable 503 refresh failures', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'retryable';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({ message: 'temporarily unavailable' }, 503)),
+    });
+
+    try {
+      await provider.refreshSession();
+      throw new Error('Expected refresh to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SSOAuthError);
+      expect((error as SSOAuthError).statusCode).toBe(503);
+      expect((error as SSOAuthError).retryable).toBe(true);
+    }
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-1');
+    provider.destroy();
+  });
+
+  test('clears the session for GoTrue refresh_token_not_found error_code responses', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'terminal';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => jsonResponse({
+        error_code: 'refresh_token_not_found',
+        message: 'Invalid Refresh Token: Refresh Token Not Found',
+      }, 400)),
+    });
+    const events: string[] = [];
+    provider.onAuthStateChange((event) => { events.push(event); });
+
+    await expect(provider.refreshSession()).rejects.toMatchObject({ code: 'refresh_token_not_found' });
+
+    expect(storage.getItem(sessionKey(storageKey))).toBeNull();
+    expect(events).toEqual(['SIGNED_OUT']);
+    provider.destroy();
+  });
+
+  test('retains the session for caller aborts and marks them non-retryable', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'aborted';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => { throw new DOMException('aborted', 'AbortError'); }),
+    });
+
+    try {
+      await provider.refreshSession();
+      throw new Error('Expected refresh to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SSOAuthError);
+      expect((error as SSOAuthError).code).toBe('request_aborted');
+      expect((error as SSOAuthError).retryable).toBe(false);
+    }
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-1');
+    provider.destroy();
+  });
+
+  test('does not refresh without a lock when lock acquisition fails', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'lock-failure';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    let refreshCalls = 0;
+    const provider = createProvider({
+      storage,
+      storageKey,
+      refreshLock: {
+        request: async () => { throw new Error('locks unavailable'); },
+      },
+      fetcher: asFetcher(() => {
+        refreshCalls += 1;
+        return jsonResponse({ access_token: 'unexpected' });
+      }),
+    });
+
+    await expect(provider.refreshSession()).rejects.toMatchObject({
+      code: 'refresh_lock_failed',
+      retryable: true,
+    });
+    expect(refreshCalls).toBe(0);
+    expect(readSession(storage, storageKey)?.refresh_token).toBe('refresh-1');
+    provider.destroy();
+  });
+
+  test('refreshes an expired session when the document returns to the foreground', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'visibility';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+    });
+    let visibilityState: DocumentVisibilityState = 'hidden';
+    let visibilityListener: EventListener | undefined;
+    Object.defineProperty(globalThis, 'document', {
+      value: {
+        get visibilityState() { return visibilityState; },
+        addEventListener: (type: string, listener: EventListener) => {
+          if (type === 'visibilitychange') visibilityListener = listener;
+        },
+        removeEventListener: () => { visibilityListener = undefined; },
+      } as unknown as Document,
+      configurable: true,
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      autoRefresh: true,
+      fetcher: asFetcher(() => jsonResponse({
+        access_token: 'new-access',
+        refresh_token: 'refresh-2',
+        expires_in: 3600,
+      })),
+    });
+    const refreshed = new Promise<void>((resolve) => {
+      provider.onAuthStateChange((event) => {
+        if (event === 'TOKEN_REFRESHED') resolve();
+      });
+    });
+    saveSession(storage, storageKey, {
+      access_token: 'expired-access',
+      refresh_token: 'refresh-1',
+      expires_at: Math.floor(Date.now() / 1000) - 1,
+      token_type: 'Bearer',
+    });
+
+    visibilityState = 'visible';
+    visibilityListener?.(new Event('visibilitychange'));
+    await refreshed;
+
+    expect(readSession(storage, storageKey)?.access_token).toBe('new-access');
+    provider.destroy();
+  });
+});
+
+describe('authenticated fetch recovery', () => {
+  test('replays one POST after 401 with the rotated token and intact body', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'fetch-recovery';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+    });
+    let refreshCalls = 0;
+    const apiBodies: string[] = [];
+    const apiTokens: string[] = [];
+    const fetcher = asFetcher(async (input) => {
+      const url = requestUrl(input);
+      if (url === endpoints.token_endpoint) {
+        refreshCalls += 1;
+        return jsonResponse({
+          access_token: 'new-access',
+          refresh_token: 'refresh-2',
+          expires_in: 3600,
+        });
+      }
+
+      const request = input as Request;
+      apiTokens.push(request.headers.get('Authorization') ?? '');
+      apiBodies.push(await request.text());
+      return new Response(null, { status: apiTokens.length === 1 ? 401 : 200 });
+    });
+    const provider = createProvider({ storage, storageKey, fetcher });
+    const authFetch = provider.createAuthenticatedFetch();
+
+    const response = await authFetch('https://api.test/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'demo' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(refreshCalls).toBe(1);
+    expect(apiTokens).toEqual(['Bearer old-access', 'Bearer new-access']);
+    expect(apiBodies).toEqual(['{"name":"demo"}', '{"name":"demo"}']);
+    provider.destroy();
+  });
+
+  test('does not loop when the replay also returns 401', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'second-401';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+    });
+    let refreshCalls = 0;
+    let apiCalls = 0;
+    const fetcher = asFetcher((input) => {
+      if (requestUrl(input) === endpoints.token_endpoint) {
+        refreshCalls += 1;
+        return jsonResponse({
+          access_token: 'new-access',
+          refresh_token: 'refresh-2',
+          expires_in: 3600,
+        });
+      }
+      apiCalls += 1;
+      return new Response(null, { status: 401 });
+    });
+    const provider = createProvider({ storage, storageKey, fetcher });
+
+    const response = await provider.createAuthenticatedFetch()('https://api.test/private');
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('X-Svadmin-Auth-Retry')).toBe('exhausted');
+    expect(apiCalls).toBe(2);
+    expect(refreshCalls).toBe(1);
+    expect(await provider.onError?.({
+      statusCode: 401,
+      code: response.headers.get('X-Svadmin-Auth-Retry') === 'exhausted'
+        ? 'auth_retry_exhausted'
+        : undefined,
+    })).toEqual({ logout: true, redirectTo: '/login' });
+    expect(refreshCalls).toBe(1);
+    provider.destroy();
+  });
+
+  test('does not refresh or sign out on 403', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'forbidden';
+    saveSession(storage, storageKey, {
+      access_token: 'access',
+      refresh_token: 'refresh',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+    });
+    let refreshCalls = 0;
+    const fetcher = asFetcher((input) => {
+      if (requestUrl(input) === endpoints.token_endpoint) refreshCalls += 1;
+      return new Response(null, { status: 403 });
+    });
+    const provider = createProvider({ storage, storageKey, fetcher });
+
+    const response = await provider.createAuthenticatedFetch()('https://api.test/admin');
+
+    expect(response.status).toBe(403);
+    expect(refreshCalls).toBe(0);
+    expect(await provider.getSession()).not.toBeNull();
+    expect(await provider.onError?.({ statusCode: 403 })).toEqual({});
+    expect(await provider.onError?.({ statusCode: 403, code: 'invalid_token' })).toEqual({});
+    provider.destroy();
+  });
+
+  test('20 concurrent 401 responses share one refresh result', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'concurrent-401';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+    });
+    let refreshCalls = 0;
+    const fetcher = asFetcher(async (input, init) => {
+      if (requestUrl(input) === endpoints.token_endpoint) {
+        refreshCalls += 1;
+        await Promise.resolve();
+        return jsonResponse({
+          access_token: 'new-access',
+          refresh_token: 'refresh-2',
+          expires_in: 3600,
+        });
+      }
+      const token = requestHeaders(input, init).get('Authorization');
+      return new Response(null, { status: token === 'Bearer old-access' ? 401 : 200 });
+    });
+    const provider = createProvider({ storage, storageKey, fetcher });
+    const authFetch = provider.createAuthenticatedFetch();
+
+    const responses = await Promise.all(Array.from(
+      { length: 20 },
+      (_, index) => authFetch(`https://api.test/items/${index}`),
+    ));
+
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    expect(refreshCalls).toBe(1);
+    provider.destroy();
+  });
+
+  test('fails explicitly when the original Request body is already consumed', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'used-body';
+    saveSession(storage, storageKey, {
+      access_token: 'access',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => new Response(null, { status: 200 })),
+    });
+    const request = new Request('https://api.test/items', {
+      method: 'POST',
+      body: 'already-used',
+    });
+    await request.text();
+
+    await expect(provider.createAuthenticatedFetch()(request)).rejects.toMatchObject({
+      code: 'request_not_replayable',
+    });
+    provider.destroy();
+  });
+});
+
+describe('logout and SSR behavior', () => {
+  test('clears local state before best-effort discovery failure', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'logout';
+    saveSession(storage, storageKey, {
+      access_token: 'access',
+      id_token: 'id-token',
+      refresh_token: 'refresh',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+    });
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'https://app.test/callback',
+      postLogoutRedirectUri: '/signed-out',
+      storage,
+      storageKey,
+      autoRefresh: false,
+      fetcher: asFetcher(() => { throw new TypeError('offline'); }),
+    });
+
+    const result = await provider.logout();
+
+    expect(result).toEqual({ success: true, redirectTo: '/signed-out' });
+    expect(storage.getItem(sessionKey(storageKey))).toBeNull();
+    provider.destroy();
+  });
+
+  test('supports SSR with injected storage and no window', async () => {
+    Reflect.deleteProperty(globalThis, 'window');
+    const storage = createMemoryStorage();
+    const storageKey = 'ssr';
+    saveSession(storage, storageKey, {
+      access_token: 'access',
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => new Response(null, { status: 200 })),
+    });
+
+    expect(await provider.check()).toEqual({ authenticated: true });
+    expect(await provider.getAccessToken()).toBe('access');
+    provider.destroy();
+  });
+});

--- a/packages/sso/src/session-lifecycle.test.ts
+++ b/packages/sso/src/session-lifecycle.test.ts
@@ -466,6 +466,168 @@ describe('rotation-safe session lifecycle', () => {
     newerProvider.destroy();
   });
 
+  test('does not let a terminal refresh broadcast cancel an in-flight callback', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'terminal-refresh-vs-callback';
+    const stateKey = `${storageKey}_state`;
+    const verifierKey = `${storageKey}_pkce_verifier`;
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    storage.setItem(stateKey, 'callback-state');
+    storage.setItem(verifierKey, 'callback-verifier');
+    const location = {
+      href: 'https://app.test/callback?code=new-code&state=callback-state',
+    };
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location,
+        navigator: {},
+        BroadcastChannel: FakeBroadcastChannel,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        history: {
+          replaceState: (_state: unknown, _title: string, url: string) => {
+            location.href = new URL(url, location.href).href;
+          },
+        },
+      } as unknown as Window,
+      configurable: true,
+    });
+    const lock = createImmediateSerialLock();
+    const refreshStarted = createSignal();
+    const refreshResponse = createDeferred<Response>();
+    const refreshingProvider = createProvider({
+      storage,
+      storageKey,
+      refreshLock: lock,
+      fetcher: asFetcher(() => {
+        refreshStarted.resolve();
+        return refreshResponse.promise;
+      }),
+    });
+    const callbackStarted = createSignal();
+    const callbackResponse = createDeferred<Response>();
+    const callbackProvider = createProvider({
+      storage,
+      storageKey,
+      refreshLock: lock,
+      fetcher: asFetcher(() => {
+        callbackStarted.resolve();
+        return callbackResponse.promise;
+      }),
+    });
+
+    const refresh = refreshingProvider.refreshSession();
+    await refreshStarted.promise;
+    const callback = callbackProvider.check();
+    await callbackStarted.promise;
+    refreshResponse.resolve(jsonResponse({
+      error: 'invalid_grant',
+      message: 'Refresh token already used',
+    }, 400));
+    await expect(refresh).rejects.toMatchObject({ code: 'invalid_grant' });
+
+    callbackResponse.resolve(jsonResponse({
+      access_token: 'new-login-access',
+      refresh_token: 'new-login-refresh',
+      expires_in: 3600,
+    }));
+
+    expect(await callback).toEqual({ authenticated: true });
+    expect(readSession(storage, storageKey)?.access_token).toBe('new-login-access');
+    expect(storage.getItem(stateKey)).toBeNull();
+    expect(storage.getItem(verifierKey)).toBeNull();
+    refreshingProvider.destroy();
+    callbackProvider.destroy();
+  });
+
+  test('does not let an expired check erase a concurrent login attempt', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'expired-check-vs-login';
+    const tokenKey = sessionKey(storageKey);
+    const stateKey = `${storageKey}_state`;
+    const verifierKey = `${storageKey}_pkce_verifier`;
+    saveSession(storage, storageKey, {
+      access_token: 'expired-access',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const location = { href: 'https://app.test/' };
+    Object.defineProperty(globalThis, 'window', {
+      value: { location } as unknown as Window,
+      configurable: true,
+    });
+    const lock = createImmediateSerialLock();
+    const staleProvider = createProvider({
+      storage,
+      storageKey,
+      refreshLock: lock,
+      fetcher: asFetcher(() => { throw new TypeError('unexpected request'); }),
+    });
+    const newerProvider = createProvider({
+      storage,
+      storageKey,
+      refreshLock: lock,
+      fetcher: asFetcher(() => { throw new TypeError('unexpected request'); }),
+    });
+    const originalGetItem = storage.getItem;
+    let tokenReads = 0;
+    let newerLogin: ReturnType<typeof newerProvider.login> | undefined;
+    storage.getItem = (key) => {
+      const value = originalGetItem(key);
+      if (key === tokenKey && ++tokenReads === 2) {
+        newerLogin = newerProvider.login({});
+      }
+      return value;
+    };
+
+    expect(await staleProvider.check()).toEqual({ authenticated: false });
+    expect((await newerLogin)?.success).toBe(true);
+    expect(originalGetItem(tokenKey)).toBeNull();
+    expect(originalGetItem(stateKey)).not.toBeNull();
+    expect(originalGetItem(verifierKey)).not.toBe('');
+    staleProvider.destroy();
+    newerProvider.destroy();
+  });
+
+  test('does not let a stale access-token read clear a newer session', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'expired-token-read-vs-new-session';
+    const tokenKey = sessionKey(storageKey);
+    saveSession(storage, storageKey, {
+      access_token: 'expired-access',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher(() => { throw new TypeError('unexpected request'); }),
+    });
+    const originalGetItem = storage.getItem;
+    let replaced = false;
+    storage.getItem = (key) => {
+      const value = originalGetItem(key);
+      if (!replaced && key === tokenKey) {
+        replaced = true;
+        saveSession(storage, storageKey, {
+          access_token: 'new-access',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          token_type: 'Bearer',
+        });
+      }
+      return value;
+    };
+
+    expect(await provider.getAccessToken()).toBe('new-access');
+    expect(readSession(storage, storageKey)?.access_token).toBe('new-access');
+    provider.destroy();
+  });
+
   test('reuses a new login that wins while an older refresh is in flight', async () => {
     const storage = createMemoryStorage();
     const storageKey = 'login-during-refresh';

--- a/packages/sso/src/session-lifecycle.test.ts
+++ b/packages/sso/src/session-lifecycle.test.ts
@@ -86,6 +86,33 @@ function createSerialLock(): RefreshLock {
   };
 }
 
+function createImmediateSerialLock(): RefreshLock {
+  const tails = new Map<string, Promise<void>>();
+  return {
+    request<T>(name: string, operation: () => Promise<T>): Promise<T> {
+      const previous = tails.get(name);
+      if (previous) {
+        return previous.catch(() => undefined).then(() => this.request(name, operation));
+      }
+
+      let release!: () => void;
+      const tail = new Promise<void>((resolve) => { release = resolve; });
+      tails.set(name, tail);
+      let result: Promise<T>;
+      try {
+        result = Promise.resolve(operation());
+      } catch (error) {
+        result = Promise.reject(error);
+      }
+      void result.finally(() => {
+        release();
+        if (tails.get(name) === tail) tails.delete(name);
+      });
+      return result;
+    },
+  };
+}
+
 class FakeBroadcastChannel {
   static readonly channels = new Map<string, Set<FakeBroadcastChannel>>();
 
@@ -244,6 +271,61 @@ describe('rotation-safe session lifecycle', () => {
     expect(await pendingRefresh).toBeNull();
     expect(readSession(storage, storageKey)).toBeNull();
     provider.destroy();
+  });
+
+  test('serializes refresh commit with a cross-provider logout', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'cross-provider-logout-during-refresh-commit';
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const lock = createImmediateSerialLock();
+    const refreshStarted = createSignal();
+    const refreshResponse = createDeferred<Response>();
+    const refreshingProvider = createProvider({
+      storage,
+      storageKey,
+      refreshLock: lock,
+      fetcher: asFetcher(() => {
+        refreshStarted.resolve();
+        return refreshResponse.promise;
+      }),
+    });
+    const logoutProvider = createProvider({
+      storage,
+      storageKey,
+      refreshLock: lock,
+      fetcher: asFetcher(() => { throw new TypeError('offline'); }),
+    });
+    const originalGetItem = storage.getItem;
+    let triggerLogout = false;
+    let logout: Promise<unknown> | undefined;
+    storage.getItem = (key) => {
+      const value = originalGetItem(key);
+      if (triggerLogout && key === sessionKey(storageKey)) {
+        triggerLogout = false;
+        logout = logoutProvider.logout();
+      }
+      return value;
+    };
+
+    const refresh = refreshingProvider.refreshSession();
+    await refreshStarted.promise;
+    triggerLogout = true;
+    refreshResponse.resolve(jsonResponse({
+      access_token: 'rotated-access',
+      refresh_token: 'refresh-2',
+      expires_in: 3600,
+    }));
+
+    await refresh;
+    await logout;
+    expect(readSession(storage, storageKey)).toBeNull();
+    refreshingProvider.destroy();
+    logoutProvider.destroy();
   });
 
   test('reuses a new login that wins while an older refresh is in flight', async () => {

--- a/packages/sso/src/session-lifecycle.test.ts
+++ b/packages/sso/src/session-lifecycle.test.ts
@@ -104,10 +104,11 @@ function createImmediateSerialLock(): RefreshLock {
       } catch (error) {
         result = Promise.reject(error);
       }
-      void result.finally(() => {
+      const finish = () => {
         release();
         if (tails.get(name) === tail) tails.delete(name);
-      });
+      };
+      void result.then(finish, finish);
       return result;
     },
   };
@@ -326,6 +327,143 @@ describe('rotation-safe session lifecycle', () => {
     expect(readSession(storage, storageKey)).toBeNull();
     refreshingProvider.destroy();
     logoutProvider.destroy();
+  });
+
+  test('does not let failed callback cleanup erase a newer login attempt', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'callback-cleanup-vs-new-login';
+    const stateKey = `${storageKey}_state`;
+    const verifierKey = `${storageKey}_pkce_verifier`;
+    storage.setItem(stateKey, 'old-state');
+    storage.setItem(verifierKey, 'old-verifier');
+    const location = { href: 'https://app.test/callback?code=old-code&state=old-state' };
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location,
+        history: {
+          replaceState: (_state: unknown, _title: string, url: string) => {
+            location.href = new URL(url, location.href).href;
+          },
+        },
+      } as unknown as Window,
+      configurable: true,
+    });
+    const lock = createImmediateSerialLock();
+    const discoveryStarted = createSignal();
+    const discoveryResponse = createDeferred<Response>();
+    const newerProvider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'https://app.test/callback',
+      storage,
+      storageKey,
+      refreshLock: lock,
+      autoRefresh: false,
+      fetcher: asFetcher(() => {
+        discoveryStarted.resolve();
+        return discoveryResponse.promise;
+      }),
+    });
+    let triggerNewLogin = false;
+    let newerLogin: ReturnType<typeof newerProvider.login> | undefined;
+    const originalGetItem = storage.getItem;
+    storage.getItem = (key) => {
+      const value = originalGetItem(key);
+      if (triggerNewLogin && key === stateKey) {
+        triggerNewLogin = false;
+        newerLogin = newerProvider.login({});
+      }
+      return value;
+    };
+    const staleProvider = createProvider({
+      storage,
+      storageKey,
+      refreshLock: lock,
+      fetcher: asFetcher(() => {
+        triggerNewLogin = true;
+        return jsonResponse({ access_token: 'invalid-access', token_type: '' });
+      }),
+    });
+
+    expect((await staleProvider.check()).authenticated).toBe(false);
+    await discoveryStarted.promise;
+    const pendingState = originalGetItem(stateKey);
+    expect(pendingState).not.toBeNull();
+    expect(pendingState).not.toBe('old-state');
+    discoveryResponse.resolve(jsonResponse(endpoints));
+
+    expect((await newerLogin)?.success).toBe(true);
+    expect(originalGetItem(stateKey)).toBe(pendingState);
+    expect(originalGetItem(verifierKey)).not.toBe('');
+    staleProvider.destroy();
+    newerProvider.destroy();
+  });
+
+  test('does not let a terminal refresh clear a newer login attempt', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'terminal-refresh-vs-new-login';
+    const stateKey = `${storageKey}_state`;
+    const verifierKey = `${storageKey}_pkce_verifier`;
+    saveSession(storage, storageKey, {
+      access_token: 'old-access',
+      refresh_token: 'refresh-1',
+      expires_at: 1,
+      token_type: 'Bearer',
+    });
+    const location = { href: 'https://app.test/' };
+    Object.defineProperty(globalThis, 'window', {
+      value: { location } as unknown as Window,
+      configurable: true,
+    });
+    const lock = createImmediateSerialLock();
+    const refreshStarted = createSignal();
+    const refreshResponse = createDeferred<Response>();
+    const refreshingProvider = createProvider({
+      storage,
+      storageKey,
+      refreshLock: lock,
+      fetcher: asFetcher(() => {
+        refreshStarted.resolve();
+        return refreshResponse.promise;
+      }),
+    });
+    const discoveryStarted = createSignal();
+    const discoveryResponse = createDeferred<Response>();
+    const newerProvider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'https://app.test/callback',
+      storage,
+      storageKey,
+      refreshLock: lock,
+      autoRefresh: false,
+      fetcher: asFetcher(() => {
+        discoveryStarted.resolve();
+        return discoveryResponse.promise;
+      }),
+    });
+
+    const refresh = refreshingProvider.refreshSession();
+    await refreshStarted.promise;
+    const login = newerProvider.login({});
+    await discoveryStarted.promise;
+    const pendingState = storage.getItem(stateKey);
+    expect(pendingState).not.toBeNull();
+    refreshResponse.resolve(jsonResponse({
+      error: 'invalid_grant',
+      message: 'Refresh token already used',
+    }, 400));
+
+    await expect(refresh).rejects.toMatchObject({ code: 'invalid_grant' });
+    expect(storage.getItem(stateKey)).toBe(pendingState);
+    discoveryResponse.resolve(jsonResponse(endpoints));
+
+    expect((await login).success).toBe(true);
+    expect(storage.getItem(stateKey)).toBe(pendingState);
+    expect(storage.getItem(verifierKey)).not.toBe('');
+    expect(readSession(storage, storageKey)).toBeNull();
+    refreshingProvider.destroy();
+    newerProvider.destroy();
   });
 
   test('reuses a new login that wins while an older refresh is in flight', async () => {

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -50,6 +50,7 @@ export interface TokenStorageLike {
 interface SessionBroadcastMessage {
   storageKey: string;
   event: AuthStateChangeEvent;
+  preserveAuthAttempt?: boolean;
 }
 
 interface StorageKeys {
@@ -226,6 +227,16 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   let destroyed = false;
   let locallySignedOut = false;
   let authGeneration = 0;
+
+  function hasPendingAuthAttempt(): boolean {
+    return options.storage.getItem(keys.state) !== null;
+  }
+
+  function getSessionSnapshot(): { raw: string | null; session: SSOSession | null } {
+    const raw = locallySignedOut ? null : options.storage.getItem(keys.tokens);
+    return { raw, session: parseSession(raw) };
+  }
+
   function migrateLegacyStorage(): void {
     if (!legacyKeys || options.storage.getItem(keys.tokens)) return;
 
@@ -250,8 +261,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   let lastObservedRaw = options.storage.getItem(keys.tokens);
 
   function getSession(): SSOSession | null {
-    if (locallySignedOut) return null;
-    return parseSession(options.storage.getItem(keys.tokens));
+    return getSessionSnapshot().session;
   }
 
   function emit(event: AuthStateChangeEvent, session: SSOSession | null): void {
@@ -272,12 +282,13 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     }
   }
 
-  function broadcast(event: AuthStateChangeEvent): void {
+  function broadcast(event: AuthStateChangeEvent, preserveAuthAttempt = false): void {
     if (destroyed) return;
     try {
       channel?.postMessage({
         storageKey: options.storageKey,
         event,
+        ...(preserveAuthAttempt ? { preserveAuthAttempt: true } : {}),
       } satisfies SessionBroadcastMessage);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -377,12 +388,17 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
 
   function clearTokenSession(): void {
     const persistenceFailure = clearStorageValue(options.storage, keys.tokens);
-    authGeneration += 1;
-    locallySignedOut = true;
+    // 仅 token 失效不能取消已经持有 PKCE/state 的新认证尝试。
+    // 显式 logout 会走 clearSession()，仍会清理完整状态并推进 generation。
+    const preservesAuthAttempt = hasPendingAuthAttempt();
+    if (!preservesAuthAttempt) {
+      authGeneration += 1;
+      locallySignedOut = true;
+    }
     lastObservedRaw = null;
     clearRefreshTimer();
-    emit('SIGNED_OUT', null);
-    broadcast('SIGNED_OUT');
+    if (!preservesAuthAttempt) emit('SIGNED_OUT', null);
+    broadcast('SIGNED_OUT', preservesAuthAttempt);
     if (persistenceFailure !== null) {
       throw new SSOAuthError('Session could not be cleared', 0, {
         code: 'session_persistence_failed',
@@ -485,6 +501,15 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     throw normalizeTerminalRefreshError(error);
   }
 
+  function clearTokenSessionIfCurrent(expectedRaw: string): Promise<SSOSession | null> {
+    return runAuthMutation(async () => {
+      const race = resolveRefreshRace(expectedRaw);
+      if (race.changed) return race.session;
+      clearTokenSession();
+      return null;
+    });
+  }
+
   async function executeRefresh(initialRaw: string): Promise<SSOSession | null> {
     return runWithRefreshLock(async () => {
       const lockRace = resolveRefreshRace(initialRaw);
@@ -533,8 +558,9 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   async function getAccessToken(
     accessOptions: GetAccessTokenOptions = {},
   ): Promise<string | null> {
-    const session = getSession();
-    if (!session) return null;
+    const snapshot = getSessionSnapshot();
+    if (!snapshot.raw || !snapshot.session) return null;
+    const { raw: initialRaw, session } = snapshot;
 
     const minValiditySeconds = Math.max(0, accessOptions.minValiditySeconds ?? 0);
     const now = Math.floor(Date.now() / 1000);
@@ -546,8 +572,18 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     }
 
     if (!session.refresh_token) {
-      if (expiresSoon) clearTokenSession();
-      return null;
+      if (!expiresSoon) return null;
+
+      const latestSession = await clearTokenSessionIfCurrent(initialRaw);
+      if (!latestSession) return null;
+
+      const latestExpiresSoon = latestSession.expires_at !== undefined
+        && latestSession.expires_at <= now + minValiditySeconds;
+      if (!accessOptions.forceRefresh && !latestExpiresSoon) {
+        return latestSession.access_token;
+      }
+      if (!latestSession.refresh_token) return null;
+      return (await refreshSession())?.access_token ?? null;
     }
 
     return (await refreshSession())?.access_token ?? null;
@@ -557,15 +593,20 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     event: AuthStateChangeEvent,
     raw: string | null,
     force = false,
+    preserveAuthAttempt = false,
   ): void {
     if (!force && raw === lastObservedRaw) return;
 
     if (raw === null) {
-      authGeneration += 1;
-      locallySignedOut = true;
+      // token-only 失效可与新 callback 并发；共享 state 存在时不能把它误判为 logout。
+      const shouldPreserveAuthAttempt = preserveAuthAttempt && hasPendingAuthAttempt();
+      if (!shouldPreserveAuthAttempt) {
+        authGeneration += 1;
+        locallySignedOut = true;
+      }
       lastObservedRaw = null;
       clearRefreshTimer();
-      emit('SIGNED_OUT', null);
+      if (!shouldPreserveAuthAttempt) emit('SIGNED_OUT', null);
       return;
     }
 
@@ -590,7 +631,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     const currentRaw = options.storage.getItem(keys.tokens);
     if (data.event === 'SIGNED_OUT') {
       if (parseSession(currentRaw)) return;
-      syncRemoteChange('SIGNED_OUT', null, true);
+      syncRemoteChange('SIGNED_OUT', null, true, data.preserveAuthAttempt === true);
       return;
     }
     if (data.event === 'TOKEN_REFRESHED' && currentRaw === null) return;
@@ -603,6 +644,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     syncRemoteChange(
       remoteSession ? 'TOKEN_REFRESHED' : 'SIGNED_OUT',
       remoteSession ? event.newValue : null,
+      !remoteSession,
       !remoteSession,
     );
   }

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -481,17 +481,20 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
         refreshedSession = await options.refresh(latestSession);
       } catch (error) {
         if (isTerminalRefreshError(error)) {
-          return resolveTerminalRefreshFailure(initialRaw, error);
+          return runAuthMutation(async () => resolveTerminalRefreshFailure(initialRaw, error));
         }
         throw error;
       }
 
-      // 刷新请求在锁内也可能与登出或新登录并发，写入前必须再次比较原始会话。
-      const writeRace = resolveRefreshRace(initialRaw);
-      if (writeRace.changed) return writeRace.session;
+      // 网络请求只持有 refresh 锁；最终 CAS 与写入再短暂持有 auth 锁，
+      // 使跨标签页 logout/callback commit 与 token rotation 线性化。
+      return runAuthMutation(async () => {
+        const writeRace = resolveRefreshRace(initialRaw);
+        if (writeRace.changed) return writeRace.session;
 
-      saveSession(refreshedSession, 'TOKEN_REFRESHED');
-      return refreshedSession;
+        saveSession(refreshedSession, 'TOKEN_REFRESHED');
+        return refreshedSession;
+      });
     });
   }
 

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -1,10 +1,11 @@
 import { isTerminalSessionError, SSOAuthError } from './errors';
 
 const AUTO_REFRESH_RETRY_DELAY_MS = 30_000;
-const STORAGE_LOCK_LEASE_MS = 30_000;
-const STORAGE_LOCK_RENEW_MS = 10_000;
-const STORAGE_LOCK_RETRY_MS = 20;
-const STORAGE_LOCK_TIMEOUT_MS = 10_000;
+
+const processRefreshLockTails = new WeakMap<
+  TokenStorageLike,
+  Map<string, Promise<void>>
+>();
 
 export interface SSOSession {
   access_token: string;
@@ -55,11 +56,6 @@ interface StorageKeys {
   tokens: string;
   pkceVerifier: string;
   state: string;
-}
-
-interface StorageRefreshLease {
-  owner: string;
-  expiresAt: number;
 }
 
 type RefreshRaceResolution =
@@ -172,94 +168,38 @@ function clearStorageValue(storage: TokenStorageLike, key: string): unknown | nu
   }
 }
 
-function parseStorageLease(raw: string | null): StorageRefreshLease | null {
-  if (!raw) return null;
-  try {
-    const lease = JSON.parse(raw) as Partial<StorageRefreshLease>;
-    return typeof lease.owner === 'string'
-      && typeof lease.expiresAt === 'number'
-      && Number.isFinite(lease.expiresAt)
-      ? lease as StorageRefreshLease
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-function createLockOwner(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `${Date.now()}:${Math.random()}`;
-}
-
-function waitForLockRetry(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, STORAGE_LOCK_RETRY_MS));
-}
-
-function ownsStorageLease(storage: TokenStorageLike, key: string, owner: string): boolean {
-  return parseStorageLease(storage.getItem(key))?.owner === owner;
-}
-
-function tryAcquireStorageLease(storage: TokenStorageLike, key: string, owner: string): boolean {
-  const now = Date.now();
-  const current = parseStorageLease(storage.getItem(key));
-  if (current && current.owner !== owner && current.expiresAt > now) return false;
-  storage.setItem(key, JSON.stringify({ owner, expiresAt: now + STORAGE_LOCK_LEASE_MS }));
-  return ownsStorageLease(storage, key, owner);
-}
-
-async function acquireStorageLease(storage: TokenStorageLike, key: string, owner: string): Promise<void> {
-  const deadline = Date.now() + STORAGE_LOCK_TIMEOUT_MS;
-  while (!tryAcquireStorageLease(storage, key, owner)) {
-    if (Date.now() >= deadline) throw new Error('Shared refresh lock timed out');
-    await waitForLockRetry();
-  }
-}
-
-function renewStorageLease(storage: TokenStorageLike, key: string, owner: string): void {
-  try {
-    if (!ownsStorageLease(storage, key, owner)) return;
-    storage.setItem(key, JSON.stringify({ owner, expiresAt: Date.now() + STORAGE_LOCK_LEASE_MS }));
-  } catch {
-    // The in-flight operation will still run its storage CAS before persistence.
-  }
-}
-
-function releaseStorageLease(storage: TokenStorageLike, key: string, owner: string): void {
-  try {
-    if (ownsStorageLease(storage, key, owner)) storage.removeItem(key);
-  } catch {
-    try { storage.setItem(key, JSON.stringify({ owner, expiresAt: 0 })); } catch { /* lease expires */ }
-  }
-}
-
-function createStorageRefreshLock(storage: TokenStorageLike, storageKey: string): RefreshLock {
-  const leaseKey = `${storageKey}_refresh_lock`;
+function createProcessRefreshLock(storage: TokenStorageLike): RefreshLock {
   return {
-    async request<T>(_name: string, operation: () => Promise<T>): Promise<T> {
-      const owner = createLockOwner();
-      await acquireStorageLease(storage, leaseKey, owner);
-      const renewal = setInterval(
-        () => renewStorageLease(storage, leaseKey, owner),
-        STORAGE_LOCK_RENEW_MS,
-      );
+    async request<T>(name: string, operation: () => Promise<T>): Promise<T> {
+      const tails = processRefreshLockTails.get(storage) ?? new Map<string, Promise<void>>();
+      processRefreshLockTails.set(storage, tails);
+      const previous = tails.get(name) ?? Promise.resolve();
+      let release!: () => void;
+      const current = new Promise<void>((resolve) => { release = resolve; });
+      tails.set(name, current);
+      await previous.catch(() => undefined);
       try {
         return await operation();
       } finally {
-        clearInterval(renewal);
-        releaseStorageLease(storage, leaseKey, owner);
+        release();
+        if (tails.get(name) === current) tails.delete(name);
       }
     },
   };
 }
 
-function combineRefreshLocks(outer: RefreshLock, inner: RefreshLock): RefreshLock {
+function createUnavailableBrowserRefreshLock(): RefreshLock {
   return {
-    request<T>(name: string, operation: () => Promise<T>): Promise<T> {
-      return outer.request(name, () => inner.request(name, operation));
+    request<T>(): Promise<T> {
+      return Promise.reject(new Error(
+        'This browser does not provide Web Locks; configure an atomic cross-context refreshLock',
+      ));
     },
   };
+}
+
+function isBrowserRuntime(): boolean {
+  return typeof window !== 'undefined' && typeof window.document !== 'undefined';
 }
 
 export function createSessionManager(options: SessionManagerOptions): SessionManager {
@@ -268,9 +208,11 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     ? createStorageKeys(options.legacyStorageKey)
     : null;
   const lockName = `${options.storageKey}:refresh`;
-  const storageLock = createStorageRefreshLock(options.storage, options.storageKey);
-  const configuredLock = options.refreshLock ?? getBrowserRefreshLock();
-  const lock = configuredLock ? combineRefreshLocks(configuredLock, storageLock) : storageLock;
+  const lock = options.refreshLock
+    ?? getBrowserRefreshLock()
+    ?? (isBrowserRuntime()
+      ? createUnavailableBrowserRefreshLock()
+      : createProcessRefreshLock(options.storage));
   const listeners = new Set<AuthStateChangeCallback>();
   const channel = getBroadcastChannel(`${options.storageKey}:auth`);
 
@@ -561,7 +503,9 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
       return;
     }
 
-    locallySignedOut = false;
+    // 一次明确的本地登出只有当前上下文的新登录才能撤销；远端刷新不能复活它。
+    if (locallySignedOut) return;
+
     lastObservedRaw = raw;
     scheduleRefresh(session);
     emit(event, session);

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -68,10 +68,12 @@ export interface SessionManager {
   saveSession: (session: SSOSession, event?: AuthStateChangeEvent) => void;
   clearSession: () => void;
   beginAuthAttempt: () => void;
+  beginSignOut: () => void;
   setLoginState: (verifier: string, state: string) => void;
   getPKCEVerifier: () => string | null;
   getLoginState: () => string | null;
   clearLoginState: (expectedState?: string) => void;
+  runAuthMutation: <T>(operation: () => Promise<T>) => Promise<T>;
   refreshSession: () => Promise<SSOSession | null>;
   getAccessToken: (options?: GetAccessTokenOptions) => Promise<string | null>;
   onAuthStateChange: (callback: AuthStateChangeCallback) => () => void;
@@ -209,7 +211,8 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   const legacyKeys = options.legacyStorageKey && options.legacyStorageKey !== options.storageKey
     ? createStorageKeys(options.legacyStorageKey)
     : null;
-  const lockName = `${options.storageKey}:refresh`;
+  const refreshLockName = `${options.storageKey}:refresh`;
+  const authLockName = `${options.storageKey}:auth`;
   const lock = options.refreshLock
     ?? getBrowserRefreshLock()
     ?? (isBrowserRuntime()
@@ -400,6 +403,12 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     authGeneration += 1;
   }
 
+  function beginSignOut(): void {
+    authGeneration += 1;
+    locallySignedOut = true;
+    clearRefreshTimer();
+  }
+
   function clearLoginState(expectedState?: string): void {
     if (expectedState !== undefined && options.storage.getItem(keys.state) !== expectedState) {
       return;
@@ -408,21 +417,45 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     options.storage.removeItem(keys.state);
   }
 
-  async function runWithRefreshLock<T>(operation: () => Promise<T>): Promise<T> {
+  async function runWithLock<T>(
+    name: string,
+    operation: () => Promise<T>,
+    createLockError: (cause: unknown) => SSOAuthError,
+  ): Promise<T> {
     let operationStarted = false;
     try {
-      return await lock.request(lockName, async () => {
+      return await lock.request(name, async () => {
         operationStarted = true;
         return operation();
       });
     } catch (error) {
       if (operationStarted) throw error;
-      throw new SSOAuthError('Token refresh lock could not be acquired', 0, {
+      throw createLockError(error);
+    }
+  }
+
+  function runWithRefreshLock<T>(operation: () => Promise<T>): Promise<T> {
+    return runWithLock(refreshLockName, operation, (cause) => new SSOAuthError(
+      'Token refresh lock could not be acquired',
+      0,
+      {
         code: 'refresh_lock_failed',
         retryable: true,
-        cause: error,
-      });
-    }
+        cause,
+      },
+    ));
+  }
+
+  function runAuthMutation<T>(operation: () => Promise<T>): Promise<T> {
+    return runWithLock(authLockName, operation, (cause) => new SSOAuthError(
+      'Authentication coordination lock could not be acquired',
+      0,
+      {
+        code: 'auth_lock_failed',
+        retryable: false,
+        cause,
+      },
+    ));
   }
 
   function resolveTerminalRefreshFailure(
@@ -580,10 +613,12 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     saveSession,
     clearSession,
     beginAuthAttempt,
+    beginSignOut,
     setLoginState,
     getPKCEVerifier: () => options.storage.getItem(keys.pkceVerifier),
     getLoginState: () => options.storage.getItem(keys.state),
     clearLoginState,
+    runAuthMutation,
     refreshSession,
     getAccessToken,
     onAuthStateChange(callback) {

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -64,6 +64,7 @@ type RefreshRaceResolution =
 
 export interface SessionManager {
   getSession: () => SSOSession | null;
+  getRevision: () => number;
   saveSession: (session: SSOSession, event?: AuthStateChangeEvent) => void;
   clearSession: () => void;
   setLoginState: (verifier: string, state: string) => void;
@@ -220,6 +221,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   let refreshingPromise: Promise<SSOSession | null> | null = null;
   let destroyed = false;
   let locallySignedOut = false;
+  let revision = 0;
   function migrateLegacyStorage(): void {
     if (!legacyKeys || options.storage.getItem(keys.tokens)) return;
 
@@ -327,6 +329,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
       options.storage.setItem(keys.tokens, raw);
     } catch (error) {
       clearStorageValue(options.storage, keys.tokens);
+      revision += 1;
       locallySignedOut = true;
       lastObservedRaw = null;
       clearRefreshTimer();
@@ -338,6 +341,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
         cause: error,
       });
     }
+    revision += 1;
     locallySignedOut = false;
     lastObservedRaw = raw;
     scheduleRefresh(session);
@@ -352,6 +356,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     const failures = [keys.tokens, keys.pkceVerifier, keys.state]
       .map((key) => clearStorageValue(options.storage, key));
     const persistenceFailure = failures.find((error) => error !== null);
+    revision += 1;
     locallySignedOut = true;
     lastObservedRaw = null;
     clearRefreshTimer();
@@ -490,6 +495,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     if (raw === lastObservedRaw) return;
 
     if (raw === null) {
+      revision += 1;
       locallySignedOut = true;
       lastObservedRaw = null;
       clearRefreshTimer();
@@ -506,6 +512,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     // 一次明确的本地登出只有当前上下文的新登录才能撤销；远端刷新不能复活它。
     if (locallySignedOut) return;
 
+    revision += 1;
     lastObservedRaw = raw;
     scheduleRefresh(session);
     emit(event, session);
@@ -552,6 +559,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
 
   return {
     getSession,
+    getRevision: () => revision,
     saveSession,
     clearSession,
     setLoginState,

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -1,7 +1,10 @@
 import { isTerminalSessionError, SSOAuthError } from './errors';
 
 const AUTO_REFRESH_RETRY_DELAY_MS = 30_000;
-const processLockTails = new Map<string, Promise<unknown>>();
+const STORAGE_LOCK_LEASE_MS = 30_000;
+const STORAGE_LOCK_RENEW_MS = 10_000;
+const STORAGE_LOCK_RETRY_MS = 20;
+const STORAGE_LOCK_TIMEOUT_MS = 10_000;
 
 export interface SSOSession {
   access_token: string;
@@ -23,22 +26,9 @@ export type AuthStateChangeCallback = (
 ) => void | Promise<void>;
 
 export interface RefreshLock {
+  /** Serialize every context that shares the same token storage. */
   request<T>(name: string, operation: () => Promise<T>): Promise<T>;
 }
-
-const PROCESS_LOCAL_REFRESH_LOCK: RefreshLock = {
-  async request<T>(name: string, operation: () => Promise<T>): Promise<T> {
-    const previous = processLockTails.get(name) ?? Promise.resolve();
-    const current = previous.catch(() => undefined).then(operation);
-    processLockTails.set(name, current);
-
-    try {
-      return await current;
-    } finally {
-      if (processLockTails.get(name) === current) processLockTails.delete(name);
-    }
-  },
-};
 
 interface SessionManagerOptions {
   storage: TokenStorageLike;
@@ -65,6 +55,11 @@ interface StorageKeys {
   tokens: string;
   pkceVerifier: string;
   state: string;
+}
+
+interface StorageRefreshLease {
+  owner: string;
+  expiresAt: number;
 }
 
 type RefreshRaceResolution =
@@ -163,19 +158,126 @@ function hasStorageEvents(): boolean {
     && typeof window.removeEventListener === 'function';
 }
 
+function clearStorageValue(storage: TokenStorageLike, key: string): unknown | null {
+  try {
+    storage.removeItem(key);
+    return null;
+  } catch (removeError) {
+    try {
+      storage.setItem(key, '');
+      return null;
+    } catch {
+      return removeError;
+    }
+  }
+}
+
+function parseStorageLease(raw: string | null): StorageRefreshLease | null {
+  if (!raw) return null;
+  try {
+    const lease = JSON.parse(raw) as Partial<StorageRefreshLease>;
+    return typeof lease.owner === 'string'
+      && typeof lease.expiresAt === 'number'
+      && Number.isFinite(lease.expiresAt)
+      ? lease as StorageRefreshLease
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function createLockOwner(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}:${Math.random()}`;
+}
+
+function waitForLockRetry(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, STORAGE_LOCK_RETRY_MS));
+}
+
+function ownsStorageLease(storage: TokenStorageLike, key: string, owner: string): boolean {
+  return parseStorageLease(storage.getItem(key))?.owner === owner;
+}
+
+function tryAcquireStorageLease(storage: TokenStorageLike, key: string, owner: string): boolean {
+  const now = Date.now();
+  const current = parseStorageLease(storage.getItem(key));
+  if (current && current.owner !== owner && current.expiresAt > now) return false;
+  storage.setItem(key, JSON.stringify({ owner, expiresAt: now + STORAGE_LOCK_LEASE_MS }));
+  return ownsStorageLease(storage, key, owner);
+}
+
+async function acquireStorageLease(storage: TokenStorageLike, key: string, owner: string): Promise<void> {
+  const deadline = Date.now() + STORAGE_LOCK_TIMEOUT_MS;
+  while (!tryAcquireStorageLease(storage, key, owner)) {
+    if (Date.now() >= deadline) throw new Error('Shared refresh lock timed out');
+    await waitForLockRetry();
+  }
+}
+
+function renewStorageLease(storage: TokenStorageLike, key: string, owner: string): void {
+  try {
+    if (!ownsStorageLease(storage, key, owner)) return;
+    storage.setItem(key, JSON.stringify({ owner, expiresAt: Date.now() + STORAGE_LOCK_LEASE_MS }));
+  } catch {
+    // The in-flight operation will still run its storage CAS before persistence.
+  }
+}
+
+function releaseStorageLease(storage: TokenStorageLike, key: string, owner: string): void {
+  try {
+    if (ownsStorageLease(storage, key, owner)) storage.removeItem(key);
+  } catch {
+    try { storage.setItem(key, JSON.stringify({ owner, expiresAt: 0 })); } catch { /* lease expires */ }
+  }
+}
+
+function createStorageRefreshLock(storage: TokenStorageLike, storageKey: string): RefreshLock {
+  const leaseKey = `${storageKey}_refresh_lock`;
+  return {
+    async request<T>(_name: string, operation: () => Promise<T>): Promise<T> {
+      const owner = createLockOwner();
+      await acquireStorageLease(storage, leaseKey, owner);
+      const renewal = setInterval(
+        () => renewStorageLease(storage, leaseKey, owner),
+        STORAGE_LOCK_RENEW_MS,
+      );
+      try {
+        return await operation();
+      } finally {
+        clearInterval(renewal);
+        releaseStorageLease(storage, leaseKey, owner);
+      }
+    },
+  };
+}
+
+function combineRefreshLocks(outer: RefreshLock, inner: RefreshLock): RefreshLock {
+  return {
+    request<T>(name: string, operation: () => Promise<T>): Promise<T> {
+      return outer.request(name, () => inner.request(name, operation));
+    },
+  };
+}
+
 export function createSessionManager(options: SessionManagerOptions): SessionManager {
   const keys = createStorageKeys(options.storageKey);
   const legacyKeys = options.legacyStorageKey && options.legacyStorageKey !== options.storageKey
     ? createStorageKeys(options.legacyStorageKey)
     : null;
-  const listeners = new Set<AuthStateChangeCallback>();
-  const lock = options.refreshLock ?? getBrowserRefreshLock() ?? PROCESS_LOCAL_REFRESH_LOCK;
   const lockName = `${options.storageKey}:refresh`;
+  const storageLock = createStorageRefreshLock(options.storage, options.storageKey);
+  const configuredLock = options.refreshLock ?? getBrowserRefreshLock();
+  const lock = configuredLock ? combineRefreshLocks(configuredLock, storageLock) : storageLock;
+  const listeners = new Set<AuthStateChangeCallback>();
   const channel = getBroadcastChannel(`${options.storageKey}:auth`);
 
   let refreshTimer: ReturnType<typeof setTimeout> | null = null;
   let refreshingPromise: Promise<SSOSession | null> | null = null;
   let destroyed = false;
+  let locallySignedOut = false;
   function migrateLegacyStorage(): void {
     if (!legacyKeys || options.storage.getItem(keys.tokens)) return;
 
@@ -200,6 +302,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   let lastObservedRaw = options.storage.getItem(keys.tokens);
 
   function getSession(): SSOSession | null {
+    if (locallySignedOut) return null;
     return parseSession(options.storage.getItem(keys.tokens));
   }
 
@@ -281,11 +384,8 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
       // 单次 setItem 写入完整 token set，避免轮换只落盘一半。
       options.storage.setItem(keys.tokens, raw);
     } catch (error) {
-      try {
-        options.storage.removeItem(keys.tokens);
-      } catch {
-        // 尽力清理；原始持久化错误仍需返回给调用方。
-      }
+      clearStorageValue(options.storage, keys.tokens);
+      locallySignedOut = true;
       lastObservedRaw = null;
       clearRefreshTimer();
       emit('SIGNED_OUT', null);
@@ -296,6 +396,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
         cause: error,
       });
     }
+    locallySignedOut = false;
     lastObservedRaw = raw;
     scheduleRefresh(session);
 
@@ -306,17 +407,25 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   }
 
   function clearSession(): void {
-    options.storage.removeItem(keys.tokens);
-    options.storage.removeItem(keys.pkceVerifier);
-    options.storage.removeItem(keys.state);
+    const failures = [keys.tokens, keys.pkceVerifier, keys.state]
+      .map((key) => clearStorageValue(options.storage, key));
+    const persistenceFailure = failures.find((error) => error !== null);
+    locallySignedOut = true;
     lastObservedRaw = null;
     clearRefreshTimer();
     emit('SIGNED_OUT', null);
     broadcast('SIGNED_OUT');
+    if (persistenceFailure !== undefined && persistenceFailure !== null) {
+      throw new SSOAuthError('Session could not be cleared', 0, {
+        code: 'session_persistence_failed',
+        retryable: false,
+        cause: persistenceFailure,
+      });
+    }
   }
 
   function resolveRefreshRace(expectedRaw: string): RefreshRaceResolution {
-    const currentRaw = options.storage.getItem(keys.tokens);
+    const currentRaw = locallySignedOut ? null : options.storage.getItem(keys.tokens);
     if (currentRaw === expectedRaw) return { changed: false };
     if (currentRaw === null) return { changed: true, session: null };
 
@@ -400,7 +509,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   function refreshSession(): Promise<SSOSession | null> {
     if (refreshingPromise) return refreshingPromise;
 
-    const initialRaw = options.storage.getItem(keys.tokens);
+    const initialRaw = locallySignedOut ? null : options.storage.getItem(keys.tokens);
     const initialSession = parseSession(initialRaw);
     if (!initialRaw || !initialSession?.refresh_token) {
       return Promise.resolve(null);
@@ -439,6 +548,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     if (raw === lastObservedRaw) return;
 
     if (raw === null) {
+      locallySignedOut = true;
       lastObservedRaw = null;
       clearRefreshTimer();
       emit('SIGNED_OUT', null);
@@ -446,8 +556,12 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     }
 
     const session = parseSession(raw);
-    if (!session) return;
+    if (!session) {
+      syncRemoteChange('SIGNED_OUT', null);
+      return;
+    }
 
+    locallySignedOut = false;
     lastObservedRaw = raw;
     scheduleRefresh(session);
     emit(event, session);
@@ -457,14 +571,19 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     const data = message.data;
     if (!data || data.storageKey !== options.storageKey) return;
     const currentRaw = options.storage.getItem(keys.tokens);
-    if (data.event === 'SIGNED_OUT' && currentRaw !== null) return;
+    if (data.event === 'SIGNED_OUT') {
+      if (parseSession(currentRaw)) return;
+      syncRemoteChange('SIGNED_OUT', null);
+      return;
+    }
     if (data.event === 'TOKEN_REFRESHED' && currentRaw === null) return;
     syncRemoteChange(data.event, currentRaw);
   }
 
   function onStorage(event: StorageEvent): void {
     if (event.key !== keys.tokens) return;
-    syncRemoteChange(event.newValue === null ? 'SIGNED_OUT' : 'TOKEN_REFRESHED', event.newValue);
+    const remoteSession = parseSession(event.newValue);
+    syncRemoteChange(remoteSession ? 'TOKEN_REFRESHED' : 'SIGNED_OUT', remoteSession ? event.newValue : null);
   }
 
   function onVisibilityChange(): void {

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -375,6 +375,23 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     }
   }
 
+  function clearTokenSession(): void {
+    const persistenceFailure = clearStorageValue(options.storage, keys.tokens);
+    authGeneration += 1;
+    locallySignedOut = true;
+    lastObservedRaw = null;
+    clearRefreshTimer();
+    emit('SIGNED_OUT', null);
+    broadcast('SIGNED_OUT');
+    if (persistenceFailure !== null) {
+      throw new SSOAuthError('Session could not be cleared', 0, {
+        code: 'session_persistence_failed',
+        retryable: false,
+        cause: persistenceFailure,
+      });
+    }
+  }
+
   function resolveRefreshRace(expectedRaw: string): RefreshRaceResolution {
     const currentRaw = locallySignedOut ? null : options.storage.getItem(keys.tokens);
     if (currentRaw === expectedRaw) return { changed: false };
@@ -382,7 +399,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
 
     const currentSession = parseSession(currentRaw);
     if (!currentSession) {
-      clearSession();
+      clearTokenSession();
       throw new SSOAuthError('Stored session became invalid during token refresh', 0, {
         code: 'session_refresh_failed',
         retryable: false,
@@ -464,7 +481,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   ): SSOSession {
     const race = resolveRefreshRace(expectedRaw);
     if (race.changed && race.session) return race.session;
-    if (!race.changed) clearSession();
+    if (!race.changed) clearTokenSession();
     throw normalizeTerminalRefreshError(error);
   }
 
@@ -529,7 +546,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     }
 
     if (!session.refresh_token) {
-      if (expiresSoon) clearSession();
+      if (expiresSoon) clearTokenSession();
       return null;
     }
 

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -64,13 +64,14 @@ type RefreshRaceResolution =
 
 export interface SessionManager {
   getSession: () => SSOSession | null;
-  getRevision: () => number;
+  getAuthGeneration: () => number;
   saveSession: (session: SSOSession, event?: AuthStateChangeEvent) => void;
   clearSession: () => void;
+  beginAuthAttempt: () => void;
   setLoginState: (verifier: string, state: string) => void;
   getPKCEVerifier: () => string | null;
   getLoginState: () => string | null;
-  clearLoginState: () => void;
+  clearLoginState: (expectedState?: string) => void;
   refreshSession: () => Promise<SSOSession | null>;
   getAccessToken: (options?: GetAccessTokenOptions) => Promise<string | null>;
   onAuthStateChange: (callback: AuthStateChangeCallback) => () => void;
@@ -221,7 +222,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   let refreshingPromise: Promise<SSOSession | null> | null = null;
   let destroyed = false;
   let locallySignedOut = false;
-  let revision = 0;
+  let authGeneration = 0;
   function migrateLegacyStorage(): void {
     if (!legacyKeys || options.storage.getItem(keys.tokens)) return;
 
@@ -329,7 +330,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
       options.storage.setItem(keys.tokens, raw);
     } catch (error) {
       clearStorageValue(options.storage, keys.tokens);
-      revision += 1;
+      authGeneration += 1;
       locallySignedOut = true;
       lastObservedRaw = null;
       clearRefreshTimer();
@@ -341,7 +342,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
         cause: error,
       });
     }
-    revision += 1;
+    if (event !== 'TOKEN_REFRESHED') authGeneration += 1;
     locallySignedOut = false;
     lastObservedRaw = raw;
     scheduleRefresh(session);
@@ -356,7 +357,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     const failures = [keys.tokens, keys.pkceVerifier, keys.state]
       .map((key) => clearStorageValue(options.storage, key));
     const persistenceFailure = failures.find((error) => error !== null);
-    revision += 1;
+    authGeneration += 1;
     locallySignedOut = true;
     lastObservedRaw = null;
     clearRefreshTimer();
@@ -392,9 +393,17 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   function setLoginState(verifier: string, state: string): void {
     options.storage.setItem(keys.pkceVerifier, verifier);
     options.storage.setItem(keys.state, state);
+    authGeneration += 1;
   }
 
-  function clearLoginState(): void {
+  function beginAuthAttempt(): void {
+    authGeneration += 1;
+  }
+
+  function clearLoginState(expectedState?: string): void {
+    if (expectedState !== undefined && options.storage.getItem(keys.state) !== expectedState) {
+      return;
+    }
     options.storage.removeItem(keys.pkceVerifier);
     options.storage.removeItem(keys.state);
   }
@@ -491,11 +500,15 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     return (await refreshSession())?.access_token ?? null;
   }
 
-  function syncRemoteChange(event: AuthStateChangeEvent, raw: string | null): void {
-    if (raw === lastObservedRaw) return;
+  function syncRemoteChange(
+    event: AuthStateChangeEvent,
+    raw: string | null,
+    force = false,
+  ): void {
+    if (!force && raw === lastObservedRaw) return;
 
     if (raw === null) {
-      revision += 1;
+      authGeneration += 1;
       locallySignedOut = true;
       lastObservedRaw = null;
       clearRefreshTimer();
@@ -512,7 +525,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     // 一次明确的本地登出只有当前上下文的新登录才能撤销；远端刷新不能复活它。
     if (locallySignedOut) return;
 
-    revision += 1;
+    authGeneration += 1;
     lastObservedRaw = raw;
     scheduleRefresh(session);
     emit(event, session);
@@ -524,7 +537,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     const currentRaw = options.storage.getItem(keys.tokens);
     if (data.event === 'SIGNED_OUT') {
       if (parseSession(currentRaw)) return;
-      syncRemoteChange('SIGNED_OUT', null);
+      syncRemoteChange('SIGNED_OUT', null, true);
       return;
     }
     if (data.event === 'TOKEN_REFRESHED' && currentRaw === null) return;
@@ -534,7 +547,11 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
   function onStorage(event: StorageEvent): void {
     if (event.key !== keys.tokens) return;
     const remoteSession = parseSession(event.newValue);
-    syncRemoteChange(remoteSession ? 'TOKEN_REFRESHED' : 'SIGNED_OUT', remoteSession ? event.newValue : null);
+    syncRemoteChange(
+      remoteSession ? 'TOKEN_REFRESHED' : 'SIGNED_OUT',
+      remoteSession ? event.newValue : null,
+      !remoteSession,
+    );
   }
 
   function onVisibilityChange(): void {
@@ -559,9 +576,10 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
 
   return {
     getSession,
-    getRevision: () => revision,
+    getAuthGeneration: () => authGeneration,
     saveSession,
     clearSession,
+    beginAuthAttempt,
     setLoginState,
     getPKCEVerifier: () => options.storage.getItem(keys.pkceVerifier),
     getLoginState: () => options.storage.getItem(keys.state),

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -1,0 +1,517 @@
+import { isTerminalSessionError, SSOAuthError } from './errors';
+
+const AUTO_REFRESH_RETRY_DELAY_MS = 30_000;
+const processLockTails = new Map<string, Promise<unknown>>();
+
+export interface SSOSession {
+  access_token: string;
+  id_token?: string;
+  refresh_token?: string;
+  expires_at?: number;
+  token_type: string;
+}
+
+export interface GetAccessTokenOptions {
+  minValiditySeconds?: number;
+  forceRefresh?: boolean;
+}
+
+export type AuthStateChangeEvent = 'TOKEN_REFRESHED' | 'SIGNED_OUT';
+export type AuthStateChangeCallback = (
+  event: AuthStateChangeEvent,
+  session: SSOSession | null,
+) => void | Promise<void>;
+
+export interface RefreshLock {
+  request<T>(name: string, operation: () => Promise<T>): Promise<T>;
+}
+
+const PROCESS_LOCAL_REFRESH_LOCK: RefreshLock = {
+  async request<T>(name: string, operation: () => Promise<T>): Promise<T> {
+    const previous = processLockTails.get(name) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(operation);
+    processLockTails.set(name, current);
+
+    try {
+      return await current;
+    } finally {
+      if (processLockTails.get(name) === current) processLockTails.delete(name);
+    }
+  },
+};
+
+interface SessionManagerOptions {
+  storage: TokenStorageLike;
+  storageKey: string;
+  autoRefresh: boolean;
+  refreshBuffer: number;
+  refreshLock?: RefreshLock;
+  refresh: (session: SSOSession) => Promise<SSOSession>;
+  legacyStorageKey?: string;
+}
+
+export interface TokenStorageLike {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+}
+
+interface SessionBroadcastMessage {
+  storageKey: string;
+  event: AuthStateChangeEvent;
+}
+
+interface StorageKeys {
+  tokens: string;
+  pkceVerifier: string;
+  state: string;
+}
+
+type RefreshRaceResolution =
+  | { changed: false }
+  | { changed: true; session: SSOSession | null };
+
+export interface SessionManager {
+  getSession: () => SSOSession | null;
+  saveSession: (session: SSOSession, event?: AuthStateChangeEvent) => void;
+  clearSession: () => void;
+  setLoginState: (verifier: string, state: string) => void;
+  getPKCEVerifier: () => string | null;
+  getLoginState: () => string | null;
+  clearLoginState: () => void;
+  refreshSession: () => Promise<SSOSession | null>;
+  getAccessToken: (options?: GetAccessTokenOptions) => Promise<string | null>;
+  onAuthStateChange: (callback: AuthStateChangeCallback) => () => void;
+  destroy: () => void;
+}
+
+function createStorageKeys(storageKey: string): StorageKeys {
+  return {
+    tokens: `${storageKey}_tokens`,
+    pkceVerifier: `${storageKey}_pkce_verifier`,
+    state: `${storageKey}_state`,
+  };
+}
+
+function parseSession(raw: string | null): SSOSession | null {
+  if (!raw) return null;
+
+  try {
+    const value = JSON.parse(raw) as Partial<SSOSession>;
+    if (
+      typeof value.access_token !== 'string'
+      || !value.access_token
+      || typeof value.token_type !== 'string'
+      || !value.token_type
+      || (value.id_token !== undefined && typeof value.id_token !== 'string')
+      || (value.refresh_token !== undefined && typeof value.refresh_token !== 'string')
+      || (value.expires_at !== undefined
+        && (typeof value.expires_at !== 'number' || !Number.isFinite(value.expires_at)))
+    ) {
+      return null;
+    }
+    return value as SSOSession;
+  } catch {
+    return null;
+  }
+}
+
+function isTerminalRefreshError(error: unknown): boolean {
+  if (isTerminalSessionError(error)) return true;
+  return error instanceof SSOAuthError
+    && error.statusCode >= 400
+    && error.statusCode < 500
+    && !error.retryable;
+}
+
+function normalizeTerminalRefreshError(error: unknown): unknown {
+  if (!(error instanceof SSOAuthError) || isTerminalSessionError(error)) return error;
+  return new SSOAuthError(error.message, error.statusCode, {
+    code: 'session_refresh_failed',
+    details: error.details,
+    body: error.body,
+    retryable: false,
+    cause: error,
+  });
+}
+
+function getBrowserRefreshLock(): RefreshLock | undefined {
+  if (typeof window === 'undefined' || !window.navigator?.locks) return undefined;
+
+  return {
+    request<T>(name: string, operation: () => Promise<T>): Promise<T> {
+      return window.navigator.locks.request(name, operation);
+    },
+  };
+}
+
+function getBroadcastChannel(name: string): BroadcastChannel | null {
+  if (typeof window === 'undefined' || typeof window.BroadcastChannel !== 'function') {
+    return null;
+  }
+
+  try {
+    return new window.BroadcastChannel(name);
+  } catch {
+    return null;
+  }
+}
+
+function hasStorageEvents(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.addEventListener === 'function'
+    && typeof window.removeEventListener === 'function';
+}
+
+export function createSessionManager(options: SessionManagerOptions): SessionManager {
+  const keys = createStorageKeys(options.storageKey);
+  const legacyKeys = options.legacyStorageKey && options.legacyStorageKey !== options.storageKey
+    ? createStorageKeys(options.legacyStorageKey)
+    : null;
+  const listeners = new Set<AuthStateChangeCallback>();
+  const lock = options.refreshLock ?? getBrowserRefreshLock() ?? PROCESS_LOCAL_REFRESH_LOCK;
+  const lockName = `${options.storageKey}:refresh`;
+  const channel = getBroadcastChannel(`${options.storageKey}:auth`);
+
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  let refreshingPromise: Promise<SSOSession | null> | null = null;
+  let destroyed = false;
+  function migrateLegacyStorage(): void {
+    if (!legacyKeys || options.storage.getItem(keys.tokens)) return;
+
+    const legacySession = options.storage.getItem(legacyKeys.tokens);
+    if (legacySession && parseSession(legacySession)) {
+      options.storage.setItem(keys.tokens, legacySession);
+      options.storage.removeItem(legacyKeys.tokens);
+    }
+    const legacyVerifier = options.storage.getItem(legacyKeys.pkceVerifier);
+    if (legacyVerifier && !options.storage.getItem(keys.pkceVerifier)) {
+      options.storage.setItem(keys.pkceVerifier, legacyVerifier);
+      options.storage.removeItem(legacyKeys.pkceVerifier);
+    }
+    const legacyState = options.storage.getItem(legacyKeys.state);
+    if (legacyState && !options.storage.getItem(keys.state)) {
+      options.storage.setItem(keys.state, legacyState);
+      options.storage.removeItem(legacyKeys.state);
+    }
+  }
+
+  migrateLegacyStorage();
+  let lastObservedRaw = options.storage.getItem(keys.tokens);
+
+  function getSession(): SSOSession | null {
+    return parseSession(options.storage.getItem(keys.tokens));
+  }
+
+  function emit(event: AuthStateChangeEvent, session: SSOSession | null): void {
+    if (destroyed) return;
+    for (const listener of listeners) {
+      try {
+        const result = listener(event, session);
+        if (result && typeof result.then === 'function') {
+          void Promise.resolve(result).catch((error: unknown) => {
+            const message = error instanceof Error ? error.message : String(error);
+            console.warn(`[svadmin/sso] async auth state listener failed: ${message}`);
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[svadmin/sso] auth state listener failed: ${message}`);
+      }
+    }
+  }
+
+  function broadcast(event: AuthStateChangeEvent): void {
+    if (destroyed) return;
+    try {
+      channel?.postMessage({
+        storageKey: options.storageKey,
+        event,
+      } satisfies SessionBroadcastMessage);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[svadmin/sso] auth state broadcast failed: ${message}`);
+    }
+  }
+
+  function clearRefreshTimer(): void {
+    if (refreshTimer) {
+      clearTimeout(refreshTimer);
+      refreshTimer = null;
+    }
+  }
+
+  function scheduleRefresh(session: SSOSession | null): void {
+    clearRefreshTimer();
+    if (
+      destroyed
+      || !options.autoRefresh
+      || !session?.refresh_token
+      || session.expires_at === undefined
+    ) {
+      return;
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const delay = Math.max(0, session.expires_at - now - options.refreshBuffer) * 1000;
+    refreshTimer = setTimeout(runScheduledRefresh, delay);
+  }
+
+  function runScheduledRefresh(): void {
+    if (refreshTimer) clearTimeout(refreshTimer);
+    refreshTimer = null;
+    void refreshSession().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[svadmin/sso] automatic token refresh failed; session retained: ${message}`);
+
+      if (
+        !destroyed
+        && error instanceof SSOAuthError
+        && error.retryable
+        && getSession()?.refresh_token
+      ) {
+        refreshTimer = setTimeout(runScheduledRefresh, AUTO_REFRESH_RETRY_DELAY_MS);
+      }
+    });
+  }
+
+  function saveSession(session: SSOSession, event?: AuthStateChangeEvent): void {
+    const raw = JSON.stringify(session);
+    try {
+      // 单次 setItem 写入完整 token set，避免轮换只落盘一半。
+      options.storage.setItem(keys.tokens, raw);
+    } catch (error) {
+      try {
+        options.storage.removeItem(keys.tokens);
+      } catch {
+        // 尽力清理；原始持久化错误仍需返回给调用方。
+      }
+      lastObservedRaw = null;
+      clearRefreshTimer();
+      emit('SIGNED_OUT', null);
+      broadcast('SIGNED_OUT');
+      throw new SSOAuthError('Session could not be persisted', 0, {
+        code: 'session_persistence_failed',
+        retryable: false,
+        cause: error,
+      });
+    }
+    lastObservedRaw = raw;
+    scheduleRefresh(session);
+
+    if (event) {
+      emit(event, session);
+      broadcast(event);
+    }
+  }
+
+  function clearSession(): void {
+    options.storage.removeItem(keys.tokens);
+    options.storage.removeItem(keys.pkceVerifier);
+    options.storage.removeItem(keys.state);
+    lastObservedRaw = null;
+    clearRefreshTimer();
+    emit('SIGNED_OUT', null);
+    broadcast('SIGNED_OUT');
+  }
+
+  function resolveRefreshRace(expectedRaw: string): RefreshRaceResolution {
+    const currentRaw = options.storage.getItem(keys.tokens);
+    if (currentRaw === expectedRaw) return { changed: false };
+    if (currentRaw === null) return { changed: true, session: null };
+
+    const currentSession = parseSession(currentRaw);
+    if (!currentSession) {
+      clearSession();
+      throw new SSOAuthError('Stored session became invalid during token refresh', 0, {
+        code: 'session_refresh_failed',
+        retryable: false,
+      });
+    }
+
+    scheduleRefresh(currentSession);
+    return { changed: true, session: currentSession };
+  }
+
+  function setLoginState(verifier: string, state: string): void {
+    options.storage.setItem(keys.pkceVerifier, verifier);
+    options.storage.setItem(keys.state, state);
+  }
+
+  function clearLoginState(): void {
+    options.storage.removeItem(keys.pkceVerifier);
+    options.storage.removeItem(keys.state);
+  }
+
+  async function runWithRefreshLock<T>(operation: () => Promise<T>): Promise<T> {
+    let operationStarted = false;
+    try {
+      return await lock.request(lockName, async () => {
+        operationStarted = true;
+        return operation();
+      });
+    } catch (error) {
+      if (operationStarted) throw error;
+      throw new SSOAuthError('Token refresh lock could not be acquired', 0, {
+        code: 'refresh_lock_failed',
+        retryable: true,
+        cause: error,
+      });
+    }
+  }
+
+  function resolveTerminalRefreshFailure(
+    expectedRaw: string,
+    error: unknown,
+  ): SSOSession {
+    const race = resolveRefreshRace(expectedRaw);
+    if (race.changed && race.session) return race.session;
+    if (!race.changed) clearSession();
+    throw normalizeTerminalRefreshError(error);
+  }
+
+  async function executeRefresh(initialRaw: string): Promise<SSOSession | null> {
+    return runWithRefreshLock(async () => {
+      const lockRace = resolveRefreshRace(initialRaw);
+      if (lockRace.changed) return lockRace.session;
+
+      const latestSession = parseSession(initialRaw);
+      if (!latestSession?.refresh_token) return null;
+
+      let refreshedSession: SSOSession;
+      try {
+        refreshedSession = await options.refresh(latestSession);
+      } catch (error) {
+        if (isTerminalRefreshError(error)) {
+          return resolveTerminalRefreshFailure(initialRaw, error);
+        }
+        throw error;
+      }
+
+      // 刷新请求在锁内也可能与登出或新登录并发，写入前必须再次比较原始会话。
+      const writeRace = resolveRefreshRace(initialRaw);
+      if (writeRace.changed) return writeRace.session;
+
+      saveSession(refreshedSession, 'TOKEN_REFRESHED');
+      return refreshedSession;
+    });
+  }
+
+  function refreshSession(): Promise<SSOSession | null> {
+    if (refreshingPromise) return refreshingPromise;
+
+    const initialRaw = options.storage.getItem(keys.tokens);
+    const initialSession = parseSession(initialRaw);
+    if (!initialRaw || !initialSession?.refresh_token) {
+      return Promise.resolve(null);
+    }
+
+    refreshingPromise = executeRefresh(initialRaw).finally(() => {
+      refreshingPromise = null;
+    });
+    return refreshingPromise;
+  }
+
+  async function getAccessToken(
+    accessOptions: GetAccessTokenOptions = {},
+  ): Promise<string | null> {
+    const session = getSession();
+    if (!session) return null;
+
+    const minValiditySeconds = Math.max(0, accessOptions.minValiditySeconds ?? 0);
+    const now = Math.floor(Date.now() / 1000);
+    const expiresSoon = session.expires_at !== undefined
+      && session.expires_at <= now + minValiditySeconds;
+
+    if (!accessOptions.forceRefresh && !expiresSoon) {
+      return session.access_token;
+    }
+
+    if (!session.refresh_token) {
+      if (expiresSoon) clearSession();
+      return null;
+    }
+
+    return (await refreshSession())?.access_token ?? null;
+  }
+
+  function syncRemoteChange(event: AuthStateChangeEvent, raw: string | null): void {
+    if (raw === lastObservedRaw) return;
+
+    if (raw === null) {
+      lastObservedRaw = null;
+      clearRefreshTimer();
+      emit('SIGNED_OUT', null);
+      return;
+    }
+
+    const session = parseSession(raw);
+    if (!session) return;
+
+    lastObservedRaw = raw;
+    scheduleRefresh(session);
+    emit(event, session);
+  }
+
+  function onBroadcastMessage(message: MessageEvent<SessionBroadcastMessage>): void {
+    const data = message.data;
+    if (!data || data.storageKey !== options.storageKey) return;
+    const currentRaw = options.storage.getItem(keys.tokens);
+    if (data.event === 'SIGNED_OUT' && currentRaw !== null) return;
+    if (data.event === 'TOKEN_REFRESHED' && currentRaw === null) return;
+    syncRemoteChange(data.event, currentRaw);
+  }
+
+  function onStorage(event: StorageEvent): void {
+    if (event.key !== keys.tokens) return;
+    syncRemoteChange(event.newValue === null ? 'SIGNED_OUT' : 'TOKEN_REFRESHED', event.newValue);
+  }
+
+  function onVisibilityChange(): void {
+    if (!options.autoRefresh || document.visibilityState !== 'visible') return;
+
+    const session = getSession();
+    if (!session?.refresh_token || session.expires_at === undefined) return;
+    const now = Math.floor(Date.now() / 1000);
+    if (session.expires_at <= now + options.refreshBuffer) {
+      runScheduledRefresh();
+    } else {
+      scheduleRefresh(session);
+    }
+  }
+
+  channel?.addEventListener('message', onBroadcastMessage);
+  if (hasStorageEvents()) window.addEventListener('storage', onStorage);
+  if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('visibilitychange', onVisibilityChange);
+  }
+  scheduleRefresh(parseSession(lastObservedRaw));
+
+  return {
+    getSession,
+    saveSession,
+    clearSession,
+    setLoginState,
+    getPKCEVerifier: () => options.storage.getItem(keys.pkceVerifier),
+    getLoginState: () => options.storage.getItem(keys.state),
+    clearLoginState,
+    refreshSession,
+    getAccessToken,
+    onAuthStateChange(callback) {
+      listeners.add(callback);
+      return () => listeners.delete(callback);
+    },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      clearRefreshTimer();
+      listeners.clear();
+      channel?.removeEventListener('message', onBroadcastMessage);
+      channel?.close();
+      if (hasStorageEvents()) window.removeEventListener('storage', onStorage);
+      if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') {
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+      }
+    },
+  };
+}

--- a/scripts/check-package-packs.ts
+++ b/scripts/check-package-packs.ts
@@ -457,6 +457,35 @@ if (typeof session.createSessionManager !== 'function' || typeof totp.generateTO
 if (typeof sso.createSSOAuthProvider !== 'function' || typeof sso.generateChallenge !== 'function') {
   throw new Error('@svadmin/sso exports are incomplete');
 }
+if (typeof sso.SSOAuthError !== 'function') {
+  throw new Error('@svadmin/sso error export is missing');
+}
+
+const ssoStorageValues = new Map();
+const ssoProvider = sso.createSSOAuthProvider({
+  issuer: 'https://idp.example',
+  clientId: 'pack-check',
+  redirectUri: 'https://app.example/callback',
+  autoRefresh: false,
+  storage: {
+    getItem: (key) => ssoStorageValues.get(key) ?? null,
+    setItem: (key, value) => { ssoStorageValues.set(key, value); },
+    removeItem: (key) => { ssoStorageValues.delete(key); },
+  },
+});
+for (const method of [
+  'getSession',
+  'refreshSession',
+  'getAccessToken',
+  'onAuthStateChange',
+  'createAuthenticatedFetch',
+  'destroy',
+]) {
+  if (typeof ssoProvider[method] !== 'function') {
+    throw new Error(\`@svadmin/sso provider is missing \${method}\`);
+  }
+}
+ssoProvider.destroy();
 
 console.info('consumer imports passed');
 `,
@@ -468,14 +497,30 @@ console.info('consumer imports passed');
     join(consumerDirectory, 'smoke.ts'),
     `import { createSessionManager } from '@svadmin/auth-utils';
 import type { PasswordOptions } from '@svadmin/auth-utils/password';
-import { createGoogleAuth } from '@svadmin/sso';
-import type { SSOConfig } from '@svadmin/sso';
+import { createGoogleAuth, SSOAuthError } from '@svadmin/sso';
+import type {
+  GetAccessTokenOptions,
+  RefreshLock,
+  SSOAuthProvider,
+  SSOConfig,
+  SSOSession,
+} from '@svadmin/sso';
 
-type PublishedTypes = PasswordOptions | SSOConfig;
+type PublishedTypes = PasswordOptions | SSOConfig | SSOSession | GetAccessTokenOptions;
 
 void createSessionManager;
-void createGoogleAuth;
+const provider: SSOAuthProvider = createGoogleAuth('pack-check', {
+  redirectUri: 'https://app.example/callback',
+  autoRefresh: false,
+});
+const refreshLock: RefreshLock = {
+  request: async (_name, operation) => operation(),
+};
+const authError = new SSOAuthError('pack check', 401);
 const publishedTypes: PublishedTypes | undefined = undefined;
+void provider;
+void refreshLock;
+void authError;
 void publishedTypes;
 `,
   );


### PR DESCRIPTION
## Summary

- preserve structured authentication failures in Core, including status, code, details, response body, and cause
- add a rotation-safe SSO session lifecycle with single-flight refresh, atomic Web Locks, cross-tab synchronization, and fail-closed persistence
- expose session helpers and `createAuthenticatedFetch()` with one 401 refresh/replay attempt while keeping 403 non-terminal and preserving the session token type
- normalize authorization-code and refresh token responses through the same validation boundary
- document storage, refresh, authenticated fetch, and session event behavior; add packed runtime/type API gates

## Independent review fixes

- prevent ambiguous legacy `svadmin_sso_*` sessions from being assigned to the wrong issuer/client; migration now requires explicit `legacyStorageKey`
- remove the non-atomic local-storage lease: browsers use atomic Web Locks, and browsers without them fail refresh closed unless an atomic cross-context `refreshLock` is configured
- overwrite failed storage removals with an invalid tombstone, keep the current provider signed out when persistence is impossible, and prevent remote refresh events from reviving that explicit logout intent
- require a final authorization header for the internal userinfo request, so logout during endpoint discovery cannot send an ambient-cookie identity request
- track authentication generations so logout/new login/cross-tab sign-out invalidate stale userinfo and authorization-code exchanges without treating normal token rotation as an identity change
- serialize login-state writes, callback session commits, and logout persistence with the same cross-context auth lock; stale callback state mismatches no longer erase a valid session or a newer PKCE attempt
- serialize failed-login cleanup through the auth lock and clear only the state owned by that attempt, so cleanup cannot erase a newer concurrent login
- keep refresh network requests on the refresh lock, then acquire the auth lock for the final comparison and persistence so logout cannot be followed by token resurrection
- clear only token material after terminal refresh failures, preserving a newer PKCE/state attempt; stale OAuth error callbacks likewise preserve valid sessions and newer login state
- distinguish token-only invalidation from explicit logout during cross-context propagation, so a terminal refresh cannot cancel an already in-flight authorization callback
- serialize expired sessions without refresh tokens through an expected-token CAS, preventing stale `check()` or access-token reads from erasing a concurrent login or newer session
- preserve non-Bearer token schemes such as `DPoP`
- treat HTTP 500 refresh failures as retryable while retaining the session

## Concurrency and error semantics

- browser refresh holds the Web Lock across token rotation and persistence; non-browser runtimes serialize providers sharing the same storage instance within the process
- refresh re-reads storage before rotation and again before persistence, so logout or a newer login is not overwritten by an older in-flight refresh
- a missing browser-wide atomic lock fails before the token request instead of risking duplicate refresh-token use
- terminal GoTrue refresh errors clear the local session; retryable server failures retain it
- 401 is refreshed and replayed at most once, with `auth_retry_exhausted` on a second 401
- 403 is returned as a structured error without refresh or logout
- `sessionStorage` remains tab-isolated; cross-tab convergence requires shared storage and Web Locks or a custom atomic lock

## Verification

- `bun run test`: 550 Bun tests plus all 140 Vitest tests passed (690 total)
- focused SSO regression suites: 66 passed
- `bun run typecheck`: 0 errors, 0 warnings
- `bun run lint`: passed
- `bun run build`: passed, including package build, example production build, and bundle gate
- `bun run pack:check`: passed, including SSO packed runtime/type consumer smoke and strict npm/pnpm Svelte 5 peer trees
- `git diff --check`: passed
- independent standards, security/concurrency, and release panel rerun after fixes

## Release and rollout

- no package versions or changelogs are changed; release-please remains authoritative
- Core and SSO should be released together, or Core first
- this PR does not publish packages or deploy an application

Before production rollout, run conformance against a real GoTrue/Supabase Auth service for refresh-token rotation, reuse interval, replay detection, and revocation. Also verify native Web Locks, BroadcastChannel/storage synchronization, background visibility recovery, and authenticated request replay in two real browser tabs.
