### PR TITLE
[codex] harden export and sso validation

### DIFF
--- a/.agents/workflows/dev.md
+++ b/.agents/workflows/dev.md
@@ -32,11 +32,20 @@ If the task creates, expands, or materially depends on a technical stack, fullst
 - For high-risk changes (auth, data migration, production): consider `/deep-review` first
 
 ## 2.5 Delegation Gate
-Use subagents when the task is medium/high risk, spans multiple subsystems, touches architecture/API/data/state/security/production behavior, needs independent research, or requires review of your own completion claim.
+Resolve `orchestration.mode` before dispatch:
+
+- `adaptive` becomes `native` only when the six native capabilities are explicitly overridden by Task Contract/project config or evidenced by the model-catalog and current host/runtime intersection; otherwise use `managed`.
+- `native`: one owner/writer, low risk external=0, medium risk at most one risk-triggered verifier.
+- `managed`: dispatch only the explorer/executor/verifier lanes actually needed, inside the configured external-agent, round, and wall-clock budget.
+- `panel`: high-risk, review-high, or explicit reviewer-disagreement work uses one writer plus at most three isolated read-only reviewers and normally at most two rounds; ordinary review status alone does not escalate.
+- `human-loop`: do not auto-start execution/review lanes for product direction, aesthetics/taste, business choices, or irreversible judgement.
+
+Explicit legacy `collaboration.mode` remains compatible and resolves to managed. Every mode still requires deterministic tests/build/typecheck/diff evidence, approvals, and recovery evidence where applicable.
 
 Default model mapping:
-- Use `gpt-5.3-codex` for implementation and normal explorer/critic/verifier sidecars.
-- Use `gpt-5.5` only for arbitration, high-risk review, and unresolved reviewer disagreement; record `escalation_reason`.
+- Use the routine profile for implementation and explorer work; balanced/pro prefer `gpt-5.3-codex-spark`.
+- Use the verification/review-loop profile for normal critic/verifier work; balanced/pro default to `glm-5.2`.
+- Use `review_class: review-high` only for arbitration, high-risk review, and unresolved reviewer disagreement; record `escalation_reason`. The default OpenAI fallback is `gpt-5.6-sol`; legacy `needs_model: gpt-5.5` remains compatible.
 
 Useful roles:
 - `explorer`: read-only codebase or external-source research
@@ -44,7 +53,7 @@ Useful roles:
 - `verifier`: independently check the implemented result and evidence
 - `browser`: visual/runtime verification for UI work
 
-Skip subagents for low-risk single-file fixes, simple commands, or cases where secrets/destructive operations require staying in the current session. Record the skip reason.
+Low-risk native work normally needs no external agent. Record `safe_skip_reason` only when Delegation Gate itself is skipped, not merely because the resolver chose native ownership.
 
 Subagent requests must include role, exact scope, read/write ownership, allowed files/directories, verification command, output schema, and whether the result must be persisted in `.mailbox/`. Do not run multiple writers unless file ownership is explicitly disjoint.
 
@@ -92,5 +101,5 @@ critic/verifier 子智能体应把以上作为标准审查项。发现过度设�
 ## Notes
 - For complex tasks: decompose into sub-tasks and use focused subagents for independent work
 - For simple tasks: just do it directly, don't over-engineer the process
-- Always check `progress.md` at project root if working in multi-agent mode
+- In coordination DB v2 projects, use `agmesh context` / `agmesh automation status`; check `progress.md` only for legacy multi-agent projects
 - Apply Reasoning Effort tiers: LOW for simple lookups, STANDARD for features, HIGH for architecture

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ tasks.md
 .agents/goal-forge/runs/
 CODEBUDDY.md
 HERMES.md
+.agents/docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,80 +1,47 @@
 # Agent Configuration Template
 
-> Auto-deployed by [agent-team-config](https://github.com/zuohuadong/agent-team-config) and mirrored to compatible agent entry files.
-> This file is overwritten by `agmesh deploy`. Put project-specific additions in `.agents/AGENTS.local.md`; deploy merges them into the overlay block below.
+> Auto-deployed by [agent-team-config](https://github.com/zuohuadong/agent-team-config).
+> This file is overwritten by `agmesh deploy`. Put project-specific additions in `.agents/AGENTS.local.md`.
+> Detailed rules live in `.agents/docs/AGMESH.md`; load that file only when the task needs the expanded workflow.
 
 ## Language
 
 - Reply to the user in Simplified Chinese.
-- Use Chinese for important code comments or code explanations added during a fix when it fits the surrounding codebase.
-- Keep user-facing status concise. Avoid dumping large raw logs or files into chat.
+- Use Chinese for important code comments or code explanations when it fits the surrounding codebase.
+- Keep status concise; do not paste large raw logs, files, base64, or screenshots into chat.
 
-## Operating Loop
+## Startup Loop
 
-- Start with repo truth: inspect `git status` and targeted files. If `.agents/state/coordination.json` exists, use `agmesh context . --task <id>` / coordination DB status for the active task, recent events, and pending mailbox queue; only fall back to `tasks.md`, `progress.md`, and `.mailbox/` in legacy projects that have not been upgraded.
-- Read only the slices needed for the task. Prefer `rg`, `sed`, focused file ranges, and `agmesh memory recall "<query>" --token-budget <n>` over full-file dumps.
-- Keep the live context under budget: if `agmesh automation doctor .` reports coordination context warnings, run the suggested archive/prune command before broad exploration.
-- Keep visual evidence path-based by default. Save screenshots, traces, videos, and large binary evidence as files and cite their paths plus a short text observation; do not paste base64/data URLs or large image payloads into chat, mailbox, progress, or Task Contract fields.
-- Use `view_image`, browser screenshot output, or other image-returning tools only when visual inspection is essential. Inspect the fewest images needed, summarize the observation immediately, and continue from the file path summary instead of carrying raw image payloads forward. If a Codex session hits a context-window error, run `agmesh automation inspect-session-context <session-id|session-file>` and fork/start a fresh thread with a concise handoff summary.
-- Make small, scoped edits that follow the existing framework, naming, tests, and directory layout.
-- Verify with the narrowest meaningful test first, then broaden when the change touches shared CLI behavior, templates, automation, data, security, deployment, or user-facing workflows.
-- Explain material design, deletion, migration, or rollback decisions with a concise rationale. Do not expose raw chain-of-thought.
+- Start with repo truth: inspect `git status` and targeted files.
+- If `.agents/state/coordination.json` exists, use `agmesh context . --task <id>` or `agmesh automation status .` for bounded task, event, and mailbox context.
+- Legacy projects only: read the smallest needed slices of `tasks.md`, `progress.md`, and `.mailbox/`.
+- Prefer `rg`, focused `sed` ranges, `jq`, `git diff --stat`, `agmesh memory recall "<query>" --token-budget <n>`, and `agmesh automation context-pack . --type <kind>` over loading broad files.
+- If `agmesh automation doctor .` reports context warnings, run the suggested archive/prune command before broad exploration.
 
-## Required Context
+## Task Rules
 
-- In coordination DB v2 projects, `.agents/state/coordination.db` is the execution and coordination source. Use bounded DB queries through `agmesh context`, `agmesh automation status`, and task-specific evidence references; do not read historical logs wholesale.
-- In legacy projects only, `progress.md`, `.mailbox/`, and `tasks.md` remain the fallback coordination files. Read only the active task row/contract, newest relevant progress entries, and pending/conflicting mailbox frontmatter; archive old history before broad work.
-- `.agents/state/` contains machine-readable state, run records, and archives.
-- `.agents/workflows/` and `.agents/prompts/` hold detailed procedures. Load only the workflow or role prompt needed by the current assignment.
+- Do not silently shrink scope. Stop and state the tradeoff if the work exceeds the request.
+- Never hardcode secrets, tokens, API keys, credentials, or sensitive URLs in code, logs, templates, or durable memory.
+- Do not auto-commit, push, publish, deploy, or write production state unless the user explicitly requested it.
+- Verify with the narrowest meaningful test first, then broaden for shared CLI behavior, templates, automation, data, security, deployment, or user-facing workflows.
 
 ## Delegation Gate
 
 - For implementation, fix, test, deploy, refactor, PR/MR, or automation work, make a Delegation Decision before editing.
-- Use the full `explorer -> executor -> verifier -> orchestrator` flow for medium/high risk work, multi-file or multi-subsystem changes, architecture/API/data/state/migration/security/permission/billing/production changes, unclear root cause, unfamiliar code, UI/E2E behavior, external fact checking, or review of the orchestrator's own completion claim.
-- Low-risk, single-file work with clear acceptance criteria may be implemented by the main process directly after recording the safe skip reason and running local verification. Add an independent verifier when the result is broad, user-visible, unfamiliar, or explicitly requested.
-- Pure explanation, read-only review, simple shell queries, formatting-only edits, and documentation-only tasks may skip subagents; record `safe_skip_reason`.
-- Host tool policy is not a valid `safe_skip_reason`. Agent-team delegation is enabled by default for action-oriented tasks and does not require per-task user authorization. If the current runtime can spawn subagents, dispatch the required subagents; if it cannot, record the runtime gap in `interruption_recovery` and mark the task `blocked` / `PARTIAL` instead of rewriting it as a safe skip.
-- Subagent requests must state role, exact scope, read/write ownership, allowed files/directories, context isolation, handoff artifacts, `verification_command` / verification commands, output schema, and mailbox persistence.
-- If a subagent is interrupted, times out, or returns incomplete output, record `interruption_recovery` before continuing.
+- Resolve `orchestration.mode` as `adaptive|native|managed|panel`. Adaptive requires an explicit Task Contract/project override or the intersection of model catalog and current host/runtime evidence for `native_delegation`, `tool_call`, `long_horizon`, `structured_output`, `context_isolation`, and `runtime_recovery`; missing evidence falls back to managed.
+- Native keeps one owner/writer (low risk external=0; medium risk exactly one verifier). Managed dispatches only needed lanes under budget. High risk, review-high, or explicit reviewer disagreement resolves to a bounded panel with one writer and at most three read-only reviewers; ordinary review status alone does not. Product direction, aesthetics/taste, and business choices resolve to human-loop, while high-risk or irreversible operations still take panel precedence.
+- Explicit legacy `collaboration.mode` remains compatible and resolves to managed. All modes share deterministic tests/build/typecheck/diff/approval/recovery evidence gates.
+- Low-risk work may be done by the current owner with deterministic verification. A native plan with external=0 is a valid resolved plan, not a `safe_skip_reason`.
+- Pure explanation, read-only review, simple shell queries, formatting-only edits, and documentation-only tasks may skip the Delegation Gate with `safe_skip_reason`.
+- Host tool policy is not a valid `safe_skip_reason`. When the resolved plan requires a lane and runtime can spawn it, dispatch it; otherwise record `interruption_recovery` and mark the result `blocked` or `PARTIAL`. Native low-risk external=0 is not a runtime gap.
+- Post-edit evidence/review gate: behavior-affecting changes require current diff inspection and deterministic verification; medium risk may add at most one independent verifier, high risk uses panel, and human-loop waits for a human decision.
 
-## Task Contract
+## Progressive Context
 
-Before execution, the Task Contract should state:
-
-- goal and non-goals
-- acceptance criteria
-- collaboration mode (`solo`, `roundtable`, `critic`, `pipeline`, `split`, or `swarm`)
-- expected files/modules
-- required skills and code conventions
-- verification plan
-- risk and rollback
-- provider/source links when applicable
-- parent/source/reason for follow-up tasks
-
-Use a minimal contract for low-risk local work. Require full Stack/Fullstack/Database/Deployment profiles only when the task creates, changes, or materially depends on those choices.
-
-## Skills
-
-- Load project prompts, workflows, `references/skills/`, project `AGENTS.md`, or installed `~/.codex/skills/agent-team/` skills only when the task needs them.
-- Use `stack-profile-selector` for stack boundary decisions, `deployment-target-selector` for hosting, and `database-profile-selector` for persistence.
-- Then load concrete skills such as `elysiajs`, `nestjs-backend`, `hono-backend`, `svelte-code-writer`, `svelte-core-bestpractices`, `vue-frontend`, `alpine-frontend`, `sveltekit-fullstack`, `nuxt-fullstack`, `sqlite-database`, `cloudflare-d1-database`, `postgres-database`, `electron-desktop`, `tauri-desktop`, `mobile-app`, `mpx-development-guides`, `supacloud-platform`, `svadmin-admin-ui`, `edgeone-deploy`, or `cloudflare-edge-hosting` as evidence requires.
-
-## Automation Rules
-
-- Executors handle one eligible `ready` task at a time, then reread the current execution source and mailbox queue (coordination DB in v2 projects, legacy files otherwise).
-- Reviewers handle `review` tasks only.
-- Health checks watch stuck tasks, auth/CI visibility, and queue drift.
-- Failed review should return to the original PR/MR when possible. Create a follow-up only when the source cannot continue or the issue was already merged; include `parent`, `source`, and `reason`.
-- Do not silently shrink scope. If the work exceeds the request, stop and state the tradeoff.
-
-## Safety
-
-- Never hardcode secrets in code, logs, templates, or durable memory.
-- Never run destructive git or filesystem commands unless the user clearly asked for them.
-- Do not use `git push -f`.
-- Do not auto-commit, push, publish, deploy, or write to production unless the user explicitly requested that action.
-- Generated code, comments, and commit messages must not mention AI authorship.
-- Commit messages, when requested, must follow Conventional Commits.
+- Load project prompts, workflows, `references/skills/`, installed skills, and `.agents/docs/AGMESH.md` only when the current task needs them.
+- For stack, deployment, or persistence choices, first select the relevant profile skill (`stack-profile-selector`, `deployment-target-selector`, or `database-profile-selector`), then load concrete framework skills.
+- Keep visual evidence path-based. Inspect images only when visual judgement is essential, summarize the observation, and continue from paths.
+- If a Codex session hits context pressure, run `agmesh automation inspect-session-context <session-id|session-file>` and continue with a concise handoff summary.
 
 <!-- AGENT:OVERLAY:START -->
 <!-- Project-specific overlay content goes here. -->

--- a/HERMES.md
+++ b/HERMES.md
@@ -1,80 +1,47 @@
 # Agent Configuration Template
 
-> Auto-deployed by [agent-team-config](https://github.com/zuohuadong/agent-team-config) and mirrored to compatible agent entry files.
-> This file is overwritten by `agmesh deploy`. Put project-specific additions in `.agents/AGENTS.local.md`; deploy merges them into the overlay block below.
+> Auto-deployed by [agent-team-config](https://github.com/zuohuadong/agent-team-config).
+> This file is overwritten by `agmesh deploy`. Put project-specific additions in `.agents/AGENTS.local.md`.
+> Detailed rules live in `.agents/docs/AGMESH.md`; load that file only when the task needs the expanded workflow.
 
 ## Language
 
 - Reply to the user in Simplified Chinese.
-- Use Chinese for important code comments or code explanations added during a fix when it fits the surrounding codebase.
-- Keep user-facing status concise. Avoid dumping large raw logs or files into chat.
+- Use Chinese for important code comments or code explanations when it fits the surrounding codebase.
+- Keep status concise; do not paste large raw logs, files, base64, or screenshots into chat.
 
-## Operating Loop
+## Startup Loop
 
-- Start with repo truth: inspect `git status` and targeted files. If `.agents/state/coordination.json` exists, use `agmesh context . --task <id>` / coordination DB status for the active task, recent events, and pending mailbox queue; only fall back to `tasks.md`, `progress.md`, and `.mailbox/` in legacy projects that have not been upgraded.
-- Read only the slices needed for the task. Prefer `rg`, `sed`, focused file ranges, and `agmesh memory recall "<query>" --token-budget <n>` over full-file dumps.
-- Keep the live context under budget: if `agmesh automation doctor .` reports coordination context warnings, run the suggested archive/prune command before broad exploration.
-- Keep visual evidence path-based by default. Save screenshots, traces, videos, and large binary evidence as files and cite their paths plus a short text observation; do not paste base64/data URLs or large image payloads into chat, mailbox, progress, or Task Contract fields.
-- Use `view_image`, browser screenshot output, or other image-returning tools only when visual inspection is essential. Inspect the fewest images needed, summarize the observation immediately, and continue from the file path summary instead of carrying raw image payloads forward. If a Codex session hits a context-window error, run `agmesh automation inspect-session-context <session-id|session-file>` and fork/start a fresh thread with a concise handoff summary.
-- Make small, scoped edits that follow the existing framework, naming, tests, and directory layout.
-- Verify with the narrowest meaningful test first, then broaden when the change touches shared CLI behavior, templates, automation, data, security, deployment, or user-facing workflows.
-- Explain material design, deletion, migration, or rollback decisions with a concise rationale. Do not expose raw chain-of-thought.
+- Start with repo truth: inspect `git status` and targeted files.
+- If `.agents/state/coordination.json` exists, use `agmesh context . --task <id>` or `agmesh automation status .` for bounded task, event, and mailbox context.
+- Legacy projects only: read the smallest needed slices of `tasks.md`, `progress.md`, and `.mailbox/`.
+- Prefer `rg`, focused `sed` ranges, `jq`, `git diff --stat`, `agmesh memory recall "<query>" --token-budget <n>`, and `agmesh automation context-pack . --type <kind>` over loading broad files.
+- If `agmesh automation doctor .` reports context warnings, run the suggested archive/prune command before broad exploration.
 
-## Required Context
+## Task Rules
 
-- In coordination DB v2 projects, `.agents/state/coordination.db` is the execution and coordination source. Use bounded DB queries through `agmesh context`, `agmesh automation status`, and task-specific evidence references; do not read historical logs wholesale.
-- In legacy projects only, `progress.md`, `.mailbox/`, and `tasks.md` remain the fallback coordination files. Read only the active task row/contract, newest relevant progress entries, and pending/conflicting mailbox frontmatter; archive old history before broad work.
-- `.agents/state/` contains machine-readable state, run records, and archives.
-- `.agents/workflows/` and `.agents/prompts/` hold detailed procedures. Load only the workflow or role prompt needed by the current assignment.
+- Do not silently shrink scope. Stop and state the tradeoff if the work exceeds the request.
+- Never hardcode secrets, tokens, API keys, credentials, or sensitive URLs in code, logs, templates, or durable memory.
+- Do not auto-commit, push, publish, deploy, or write production state unless the user explicitly requested it.
+- Verify with the narrowest meaningful test first, then broaden for shared CLI behavior, templates, automation, data, security, deployment, or user-facing workflows.
 
 ## Delegation Gate
 
 - For implementation, fix, test, deploy, refactor, PR/MR, or automation work, make a Delegation Decision before editing.
-- Use the full `explorer -> executor -> verifier -> orchestrator` flow for medium/high risk work, multi-file or multi-subsystem changes, architecture/API/data/state/migration/security/permission/billing/production changes, unclear root cause, unfamiliar code, UI/E2E behavior, external fact checking, or review of the orchestrator's own completion claim.
-- Low-risk, single-file work with clear acceptance criteria may be implemented by the main process directly after recording the safe skip reason and running local verification. Add an independent verifier when the result is broad, user-visible, unfamiliar, or explicitly requested.
-- Pure explanation, read-only review, simple shell queries, formatting-only edits, and documentation-only tasks may skip subagents; record `safe_skip_reason`.
-- Host tool policy is not a valid `safe_skip_reason`. Agent-team delegation is enabled by default for action-oriented tasks and does not require per-task user authorization. If the current runtime can spawn subagents, dispatch the required subagents; if it cannot, record the runtime gap in `interruption_recovery` and mark the task `blocked` / `PARTIAL` instead of rewriting it as a safe skip.
-- Subagent requests must state role, exact scope, read/write ownership, allowed files/directories, context isolation, handoff artifacts, `verification_command` / verification commands, output schema, and mailbox persistence.
-- If a subagent is interrupted, times out, or returns incomplete output, record `interruption_recovery` before continuing.
+- Resolve `orchestration.mode` as `adaptive|native|managed|panel`. Adaptive requires an explicit Task Contract/project override or the intersection of model catalog and current host/runtime evidence for `native_delegation`, `tool_call`, `long_horizon`, `structured_output`, `context_isolation`, and `runtime_recovery`; missing evidence falls back to managed.
+- Native keeps one owner/writer (low risk external=0; medium risk exactly one verifier). Managed dispatches only needed lanes under budget. High risk, review-high, or explicit reviewer disagreement resolves to a bounded panel with one writer and at most three read-only reviewers; ordinary review status alone does not. Product direction, aesthetics/taste, and business choices resolve to human-loop, while high-risk or irreversible operations still take panel precedence.
+- Explicit legacy `collaboration.mode` remains compatible and resolves to managed. All modes share deterministic tests/build/typecheck/diff/approval/recovery evidence gates.
+- Low-risk work may be done by the current owner with deterministic verification. A native plan with external=0 is a valid resolved plan, not a `safe_skip_reason`.
+- Pure explanation, read-only review, simple shell queries, formatting-only edits, and documentation-only tasks may skip the Delegation Gate with `safe_skip_reason`.
+- Host tool policy is not a valid `safe_skip_reason`. When the resolved plan requires a lane and runtime can spawn it, dispatch it; otherwise record `interruption_recovery` and mark the result `blocked` or `PARTIAL`. Native low-risk external=0 is not a runtime gap.
+- Post-edit evidence/review gate: behavior-affecting changes require current diff inspection and deterministic verification; medium risk may add at most one independent verifier, high risk uses panel, and human-loop waits for a human decision.
 
-## Task Contract
+## Progressive Context
 
-Before execution, the Task Contract should state:
-
-- goal and non-goals
-- acceptance criteria
-- collaboration mode (`solo`, `roundtable`, `critic`, `pipeline`, `split`, or `swarm`)
-- expected files/modules
-- required skills and code conventions
-- verification plan
-- risk and rollback
-- provider/source links when applicable
-- parent/source/reason for follow-up tasks
-
-Use a minimal contract for low-risk local work. Require full Stack/Fullstack/Database/Deployment profiles only when the task creates, changes, or materially depends on those choices.
-
-## Skills
-
-- Load project prompts, workflows, `references/skills/`, project `AGENTS.md`, or installed `~/.codex/skills/agent-team/` skills only when the task needs them.
-- Use `stack-profile-selector` for stack boundary decisions, `deployment-target-selector` for hosting, and `database-profile-selector` for persistence.
-- Then load concrete skills such as `elysiajs`, `nestjs-backend`, `hono-backend`, `svelte-code-writer`, `svelte-core-bestpractices`, `vue-frontend`, `alpine-frontend`, `sveltekit-fullstack`, `nuxt-fullstack`, `sqlite-database`, `cloudflare-d1-database`, `postgres-database`, `electron-desktop`, `tauri-desktop`, `mobile-app`, `mpx-development-guides`, `supacloud-platform`, `svadmin-admin-ui`, `edgeone-deploy`, or `cloudflare-edge-hosting` as evidence requires.
-
-## Automation Rules
-
-- Executors handle one eligible `ready` task at a time, then reread the current execution source and mailbox queue (coordination DB in v2 projects, legacy files otherwise).
-- Reviewers handle `review` tasks only.
-- Health checks watch stuck tasks, auth/CI visibility, and queue drift.
-- Failed review should return to the original PR/MR when possible. Create a follow-up only when the source cannot continue or the issue was already merged; include `parent`, `source`, and `reason`.
-- Do not silently shrink scope. If the work exceeds the request, stop and state the tradeoff.
-
-## Safety
-
-- Never hardcode secrets in code, logs, templates, or durable memory.
-- Never run destructive git or filesystem commands unless the user clearly asked for them.
-- Do not use `git push -f`.
-- Do not auto-commit, push, publish, deploy, or write to production unless the user explicitly requested that action.
-- Generated code, comments, and commit messages must not mention AI authorship.
-- Commit messages, when requested, must follow Conventional Commits.
+- Load project prompts, workflows, `references/skills/`, installed skills, and `.agents/docs/AGMESH.md` only when the current task needs them.
+- For stack, deployment, or persistence choices, first select the relevant profile skill (`stack-profile-selector`, `deployment-target-selector`, or `database-profile-selector`), then load concrete framework skills.
+- Keep visual evidence path-based. Inspect images only when visual judgement is essential, summarize the observation, and continue from paths.
+- If a Codex session hits context pressure, run `agmesh automation inspect-session-context <session-id|session-file>` and continue with a concise handoff summary.
 
 <!-- AGENT:OVERLAY:START -->
 <!-- Project-specific overlay content goes here. -->

--- a/packages/core/src/data-transfer.svelte.ts
+++ b/packages/core/src/data-transfer.svelte.ts
@@ -3,6 +3,7 @@ import { useParsed } from './useParsed.svelte';
 import type { Sort, Filter, BaseRecord } from './types';
 import { downloadData } from './export-format';
 import type { ExportFormat } from './export-format';
+import { parseCSV } from './helpers-pure';
 export { downloadData, toCsv, toJson, toXlsx, escapeCsvField } from './export-format';
 export type { ExportFormat } from './export-format';
 
@@ -69,7 +70,9 @@ export function useExport<TData extends BaseRecord = BaseRecord>(options: UseExp
 
       return allRecords;
     } catch (error) {
-      options.onError?.(error as Error);
+      const exportError = error instanceof Error ? error : new Error(String(error));
+      if (!options.onError) throw exportError;
+      options.onError(exportError);
       return [];
     } finally {
       isLoading = false;
@@ -210,62 +213,4 @@ export function useImport<TData = Record<string, unknown>>(options: UseImportOpt
     get isLoading() { return isLoading; },
     get mutationResult() { return mutationResult; },
   };
-}
-
-
-// ─── 解析工具 ────────────────────────────────────────────────────
-
-/** Parse full CSV text respecting quoted multi-line fields */
-function parseCSV(text: string): string[][] {
-  const rows: string[][] = [];
-  let currentRow: string[] = [];
-  let currentVal = '';
-  let inQuotes = false;
-  let wasQuoted = false;
-
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    if (inQuotes) {
-      if (ch === '"') {
-        if (i + 1 < text.length && text[i + 1] === '"') {
-          currentVal += '"';
-          i++;
-        } else {
-          inQuotes = false;
-        }
-      } else {
-        currentVal += ch;
-      }
-    } else {
-      if (ch === '"') {
-        inQuotes = true;
-        wasQuoted = true;
-      } else if (ch === ',') {
-        currentRow.push(wasQuoted ? currentVal : currentVal.trim());
-        currentVal = '';
-        wasQuoted = false;
-      } else if (ch === '\n' || ch === '\r') {
-        currentRow.push(wasQuoted ? currentVal : currentVal.trim());
-        if (currentRow.some(v => v !== '')) {
-          rows.push(currentRow);
-        }
-        currentRow = [];
-        currentVal = '';
-        wasQuoted = false;
-        if (ch === '\r' && i + 1 < text.length && text[i + 1] === '\n') {
-          i++;
-        }
-      } else {
-        currentVal += ch;
-      }
-    }
-  }
-  
-  if (currentVal || currentRow.length > 0) {
-    currentRow.push(wasQuoted ? currentVal : currentVal.trim());
-    if (currentRow.some(v => v !== '')) {
-      rows.push(currentRow);
-    }
-  }
-  return rows;
 }

--- a/packages/core/src/data-transfer.test.svelte.ts
+++ b/packages/core/src/data-transfer.test.svelte.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { useExport } from './data-transfer.svelte';
+
+const mocks = vi.hoisted(() => ({
+  getList: vi.fn(),
+}));
+
+vi.mock('./context.svelte', () => ({
+  captureAdminContext: () => ({
+    getDataProviderForResource: () => ({ getList: mocks.getList }),
+  }),
+}));
+
+vi.mock('./useParsed.svelte', () => ({
+  useParsed: () => ({ resource: undefined }),
+}));
+
+describe('useExport', () => {
+  it('propagates provider failures when no error handler is configured', async () => {
+    mocks.getList.mockRejectedValueOnce(new Error('provider unavailable'));
+    let exporter: ReturnType<typeof useExport> | undefined;
+    const cleanup = $effect.root(() => {
+      exporter = useExport({ resource: 'posts', download: false });
+    });
+    flushSync();
+
+    await expect(exporter?.triggerExport()).rejects.toThrow('provider unavailable');
+
+    cleanup();
+  });
+
+  it('reports provider failures through the configured error handler', async () => {
+    mocks.getList.mockRejectedValueOnce('provider unavailable');
+    const onError = vi.fn();
+    let exporter: ReturnType<typeof useExport> | undefined;
+    const cleanup = $effect.root(() => {
+      exporter = useExport({ resource: 'posts', download: false, onError });
+    });
+    flushSync();
+
+    await expect(exporter?.triggerExport()).resolves.toEqual([]);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0]?.[0]).toEqual(new Error('provider unavailable'));
+
+    cleanup();
+  });
+});

--- a/packages/core/src/data-transfer.test.ts
+++ b/packages/core/src/data-transfer.test.ts
@@ -1,124 +1,68 @@
-// Unit tests for CSV parsing and data-transfer utilities
-import { describe, test, expect } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
+import { downloadData, escapeCsvField, toCsv, toJson, toXlsx } from './export-format';
+import { parseCSV } from './helpers-pure';
 
-// We test parseCSVLine directly by re-implementing the exported logic
-// since the function is not exported. We test the CSV format contract.
-
-function parseCSVLine(line: string): string[] {
-  const result: string[] = [];
-  let current = '';
-  let inQuotes = false;
-
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (inQuotes) {
-      if (ch === '"' && line[i + 1] === '"') {
-        current += '"';
-        i++;
-      } else if (ch === '"') {
-        inQuotes = false;
-      } else {
-        current += ch;
-      }
-    } else {
-      if (ch === '"') {
-        inQuotes = true;
-      } else if (ch === ',') {
-        result.push(current.trim());
-        current = '';
-      } else {
-        current += ch;
-      }
-    }
-  }
-  result.push(current.trim());
-  return result;
-}
-
-describe('parseCSVLine', () => {
+describe('parseCSV', () => {
   test('simple comma-separated values', () => {
-    expect(parseCSVLine('a,b,c')).toEqual(['a', 'b', 'c']);
+    expect(parseCSV('a,b,c')).toEqual([['a', 'b', 'c']]);
   });
 
   test('values with whitespace are trimmed', () => {
-    expect(parseCSVLine(' hello , world , test ')).toEqual(['hello', 'world', 'test']);
+    expect(parseCSV(' hello , world , test ')).toEqual([['hello', 'world', 'test']]);
   });
 
   test('quoted values preserve commas', () => {
-    expect(parseCSVLine('"hello, world",b,c')).toEqual(['hello, world', 'b', 'c']);
+    expect(parseCSV('"hello, world",b,c')).toEqual([['hello, world', 'b', 'c']]);
   });
 
   test('escaped quotes inside quoted values', () => {
-    expect(parseCSVLine('"say ""hello""",b')).toEqual(['say "hello"', 'b']);
+    expect(parseCSV('"say ""hello""",b')).toEqual([['say "hello"', 'b']]);
   });
 
   test('empty values', () => {
-    expect(parseCSVLine('a,,c')).toEqual(['a', '', 'c']);
+    expect(parseCSV('a,,c')).toEqual([['a', '', 'c']]);
   });
 
   test('single value', () => {
-    expect(parseCSVLine('hello')).toEqual(['hello']);
+    expect(parseCSV('hello')).toEqual([['hello']]);
   });
 
-  test('empty line', () => {
-    expect(parseCSVLine('')).toEqual(['']);
+  test('empty input', () => {
+    expect(parseCSV('')).toEqual([]);
   });
 
   test('quoted value with newline character', () => {
-    expect(parseCSVLine('"line1\nline2",b')).toEqual(['line1\nline2', 'b']);
+    expect(parseCSV('"line1\nline2",b')).toEqual([['line1\nline2', 'b']]);
   });
 
   test('mixed quoted and unquoted', () => {
-    expect(parseCSVLine('1,"John Doe","admin@test.com",true')).toEqual([
-      '1', 'John Doe', 'admin@test.com', 'true'
+    expect(parseCSV('1,"John Doe","admin@test.com",true')).toEqual([
+      ['1', 'John Doe', 'admin@test.com', 'true'],
     ]);
   });
 });
 
-// CSV row formatting (escape logic from useExport)
-function escapeCSVField(val: unknown): string {
-  const str = val === null || val === undefined ? '' : String(val);
-  return str.includes(',') || str.includes('"') || str.includes('\n')
-    ? `"${str.replace(/"/g, '""')}"`
-    : str;
-}
-
-describe('escapeCSVField', () => {
+describe('escapeCsvField', () => {
   test('simple string passes through', () => {
-    expect(escapeCSVField('hello')).toBe('hello');
-  });
-
-  test('null becomes empty string', () => {
-    expect(escapeCSVField(null)).toBe('');
-  });
-
-  test('undefined becomes empty string', () => {
-    expect(escapeCSVField(undefined)).toBe('');
+    expect(escapeCsvField('hello')).toBe('hello');
   });
 
   test('string with comma is quoted', () => {
-    expect(escapeCSVField('hello, world')).toBe('"hello, world"');
+    expect(escapeCsvField('hello, world')).toBe('"hello, world"');
   });
 
   test('string with double quote is escaped', () => {
-    expect(escapeCSVField('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
   });
 
   test('string with newline is quoted', () => {
-    expect(escapeCSVField('line1\nline2')).toBe('"line1\nline2"');
+    expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
   });
 
-  test('number is converted to string', () => {
-    expect(escapeCSVField(42)).toBe('42');
-  });
-
-  test('boolean is converted to string', () => {
-    expect(escapeCSVField(true)).toBe('true');
+  test('prefixes spreadsheet formulas with an apostrophe', () => {
+    expect(escapeCsvField('=SUM(A1:A2)')).toBe("'=SUM(A1:A2)");
   });
 });
-
-// ── 多格式导出测试（测真实 export-format.ts 纯函数） ─────────────
-import { toCsv, toJson, toXlsx, downloadData } from './export-format';
 
 describe('toCsv', () => {
   test('generates valid CSV with headers', () => {

--- a/packages/core/src/export-format.ts
+++ b/packages/core/src/export-format.ts
@@ -5,24 +5,28 @@
 export type ExportFormat = 'csv' | 'json' | 'xlsx';
 
 /** CSV 转义，含公式注入防护 */
-export function escapeCsvField(s: string): string {
-  let val = s;
-  if (/^[=+@\t\r]/.test(val)) val = "'" + val;
-  return val.includes(',') || val.includes('"') || val.includes('\n') || val.includes('\r')
-    ? `"${val.replace(/"/g, '""')}"`
-    : val;
+export function escapeCsvField(fieldValue: string): string {
+  let escapedValue = fieldValue;
+  if (/^[=+@\t\r]/.test(escapedValue)) escapedValue = "'" + escapedValue;
+  return escapedValue.includes(',') || escapedValue.includes('"') || escapedValue.includes('\n') || escapedValue.includes('\r')
+    ? `"${escapedValue.replace(/"/g, '""')}"`
+    : escapedValue;
 }
 
 /** 将记录数组转为 CSV 字符串 */
 export function toCsv(records: Record<string, unknown>[]): string {
   if (records.length === 0) return '';
-  const fields = Object.keys(records[0]);
-  const header = fields.map(escapeCsvField).join(',');
+  const fieldNames = Object.keys(records[0]);
+  const header = fieldNames.map(escapeCsvField).join(',');
   const rows = records.map(record =>
-    fields.map(f => {
-      const val = record[f];
-      const str = val === null || val === undefined ? '' : typeof val === 'object' ? JSON.stringify(val) : String(val);
-      return escapeCsvField(str);
+    fieldNames.map(fieldName => {
+      const rawFieldValue = record[fieldName];
+      const serializedFieldValue = rawFieldValue === null || rawFieldValue === undefined
+        ? ''
+        : typeof rawFieldValue === 'object'
+          ? JSON.stringify(rawFieldValue)
+          : String(rawFieldValue);
+      return escapeCsvField(serializedFieldValue);
     }).join(',')
   );
   return [header, ...rows].join('\n');
@@ -34,8 +38,8 @@ export function toJson(records: Record<string, unknown>[]): string {
 }
 
 /** 转义 XML 特殊字符 */
-export function escapeXml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+export function escapeXml(xmlValue: string): string {
+  return xmlValue.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 /**
@@ -43,17 +47,17 @@ export function escapeXml(s: string): string {
  */
 export function toXlsx(records: Record<string, unknown>[]): string {
   if (records.length === 0) return '';
-  const fields = Object.keys(records[0]);
+  const fieldNames = Object.keys(records[0]);
 
-  const headerCells = fields.map(f => `<Cell><Data ss:Type="String">${escapeXml(f)}</Data></Cell>`).join('');
+  const headerCells = fieldNames.map(fieldName => `<Cell><Data ss:Type="String">${escapeXml(fieldName)}</Data></Cell>`).join('');
   const dataRows = records.map(record =>
-    `<Row>${fields.map(f => {
-      const val = record[f];
-      if (val === null || val === undefined) return '<Cell><Data ss:Type="String"></Data></Cell>';
-      if (typeof val === 'number') return `<Cell><Data ss:Type="Number">${val}</Data></Cell>`;
-      if (typeof val === 'boolean') return `<Cell><Data ss:Type="Boolean">${val ? 1 : 0}</Data></Cell>`;
-      const str = typeof val === 'object' ? JSON.stringify(val) : String(val);
-      return `<Cell><Data ss:Type="String">${escapeXml(str)}</Data></Cell>`;
+    `<Row>${fieldNames.map(fieldName => {
+      const fieldValue = record[fieldName];
+      if (fieldValue === null || fieldValue === undefined) return '<Cell><Data ss:Type="String"></Data></Cell>';
+      if (typeof fieldValue === 'number') return `<Cell><Data ss:Type="Number">${fieldValue}</Data></Cell>`;
+      if (typeof fieldValue === 'boolean') return `<Cell><Data ss:Type="Boolean">${fieldValue ? 1 : 0}</Data></Cell>`;
+      const serializedValue = typeof fieldValue === 'object' ? JSON.stringify(fieldValue) : String(fieldValue);
+      return `<Cell><Data ss:Type="String">${escapeXml(serializedValue)}</Data></Cell>`;
     }).join('')}</Row>`
   ).join('\n');
 
@@ -84,32 +88,32 @@ export function downloadData(
 
   let content: string;
   let mimeType: string;
-  let ext: string;
+  let extension: string;
 
   switch (format) {
     case 'json':
       content = toJson(records);
       mimeType = 'application/json;charset=utf-8;';
-      ext = 'json';
+      extension = 'json';
       break;
     case 'xlsx':
       content = toXlsx(records);
       mimeType = 'application/vnd.ms-excel;charset=utf-8;';
-      ext = 'xls';
+      extension = 'xls';
       break;
     case 'csv':
     default:
       content = toCsv(records);
       mimeType = 'text/csv;charset=utf-8;';
-      ext = 'csv';
+      extension = 'csv';
       break;
   }
 
   const blob = new Blob(['\uFEFF' + content], { type: mimeType });
   const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = `${resource}_export.${ext}`;
-  a.click();
+  const downloadAnchor = document.createElement('a');
+  downloadAnchor.href = url;
+  downloadAnchor.download = `${resource}_export.${extension}`;
+  downloadAnchor.click();
   setTimeout(() => URL.revokeObjectURL(url), 10000);
 }

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -203,6 +203,29 @@ describe('createSSOAuthProvider', () => {
     expect(new URL(window.location.href).origin).toBe('https://idp.test');
   });
 
+  test('rejects discovery documents missing required endpoints', async () => {
+    const storage = createMemoryStorage();
+    const calls = installFetch(() => jsonResponse({
+      authorization_endpoint: manualEndpoints.authorization_endpoint,
+    }));
+    const provider = createSSOAuthProvider({
+      issuer: 'https://issuer.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+    });
+
+    const loginResult = await provider.login({});
+
+    expect(loginResult.success).toBe(false);
+    expect(loginResult.error?.message).toBe(
+      'OIDC discovery returned incomplete endpoints: missing token_endpoint, userinfo_endpoint',
+    );
+    expect(calls).toHaveLength(1);
+    expect(window.location.href).toBe('http://app.test/');
+  });
+
   test('exchanges callback code, stores tokens, and preserves unrelated URL parts', async () => {
     const storage = createMemoryStorage();
     storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'verifier-123');
@@ -499,6 +522,77 @@ describe('createSSOAuthProvider', () => {
     expect(result).toEqual({ authenticated: true });
     expect(calls).toHaveLength(1);
     expect(await provider.getAccessToken()).toBe('fresh-access');
+  });
+
+  test('rejects and removes malformed persisted token sets', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}tokens`, JSON.stringify({
+      access_token: 42,
+      token_type: 'Bearer',
+    }));
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    const authCheck = await provider.check();
+
+    expect(authCheck).toEqual({ authenticated: false, logout: true });
+    expect(storage.getItem(`${STORAGE_PREFIX}tokens`)).toBeNull();
+    expect(await provider.getAccessToken()).toBeNull();
+  });
+
+  test('treats empty storage as logged out when browser Web Locks are unavailable', async () => {
+    Object.assign(window, { document: {}, navigator: {} });
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage: createMemoryStorage(),
+      autoRefresh: false,
+      manualEndpoints,
+    });
+
+    expect(await provider.check()).toEqual({ authenticated: false, logout: true });
+    provider.destroy();
+  });
+
+  test('does not clear a newer session while removing malformed persisted tokens', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}tokens`, JSON.stringify({
+      access_token: 42,
+      token_type: 'Bearer',
+    }));
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+    });
+    const originalGetItem = storage.getItem;
+    let replaced = false;
+    storage.getItem = (key) => {
+      const value = originalGetItem(key);
+      if (!replaced && key === `${STORAGE_PREFIX}tokens`) {
+        replaced = true;
+        storage.setItem(key, JSON.stringify({
+          access_token: 'new-access',
+          token_type: 'Bearer',
+        }));
+      }
+      return value;
+    };
+
+    expect(await provider.getAccessToken()).toBeNull();
+    expect(JSON.parse(originalGetItem(`${STORAGE_PREFIX}tokens`) ?? '{}')).toMatchObject({
+      access_token: 'new-access',
+    });
   });
 
   test('maps identity from userinfo endpoint', async () => {

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -100,6 +100,42 @@ interface TokenResponseDefaults {
 
 type TokenStringField = 'access_token' | 'refresh_token' | 'token_type';
 
+const REQUIRED_OIDC_ENDPOINTS = [
+  'authorization_endpoint',
+  'token_endpoint',
+  'userinfo_endpoint',
+] as const;
+
+function readOIDCConfig(body: unknown): OIDCConfig {
+  const discovery = typeof body === 'object' && body !== null && !Array.isArray(body)
+    ? body as Record<string, unknown>
+    : {};
+  const missingEndpoints = REQUIRED_OIDC_ENDPOINTS.filter((endpoint) => {
+    const value = discovery[endpoint];
+    return typeof value !== 'string' || value.length === 0;
+  });
+  if (missingEndpoints.length > 0) {
+    throw new SSOAuthError(
+      `OIDC discovery returned incomplete endpoints: missing ${missingEndpoints.join(', ')}`,
+      502,
+      {
+        code: 'invalid_discovery_document',
+        body,
+      },
+    );
+  }
+
+  return {
+    authorization_endpoint: discovery.authorization_endpoint as string,
+    token_endpoint: discovery.token_endpoint as string,
+    userinfo_endpoint: discovery.userinfo_endpoint as string,
+    ...(typeof discovery.end_session_endpoint === 'string'
+      && discovery.end_session_endpoint.length > 0
+      ? { end_session_endpoint: discovery.end_session_endpoint }
+      : {}),
+  };
+}
+
 function decodeJwtPayload(token: string): Record<string, unknown> | null {
   if (!token) return null;
   const parts = token.split('.');
@@ -318,9 +354,9 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     }
     if (!response.ok) throw await createSSOAuthResponseError(response, 'OIDC discovery failed');
 
-    let discovered: Partial<OIDCConfig>;
+    let discovered: unknown;
     try {
-      discovered = await response.json() as Partial<OIDCConfig>;
+      discovered = await response.json() as unknown;
     } catch (error) {
       throw new SSOAuthError('OIDC discovery returned invalid JSON', 502, {
         code: 'invalid_discovery_document',
@@ -328,17 +364,7 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
         cause: error,
       });
     }
-    if (
-      typeof discovered.authorization_endpoint !== 'string'
-      || typeof discovered.token_endpoint !== 'string'
-      || typeof discovered.userinfo_endpoint !== 'string'
-    ) {
-      throw new SSOAuthError('OIDC discovery returned incomplete endpoints', 502, {
-        code: 'invalid_discovery_document',
-        body: discovered,
-      });
-    }
-    oidcConfig = discovered as OIDCConfig;
+    oidcConfig = readOIDCConfig(discovered);
     return oidcConfig;
   }
 
@@ -553,7 +579,15 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     },
 
     async check() {
-      const existingSession = sessions.getSession();
+      let existingSession = sessions.getSession();
+      if (!existingSession) {
+        try {
+          await sessions.clearInvalidSession();
+          existingSession = sessions.getSession();
+        } catch (error) {
+          return { authenticated: false, error: getErrorResult(error) };
+        }
+      }
       if (typeof window === 'undefined') {
         const now = Math.floor(Date.now() / 1000);
         return existingSession && (

--- a/packages/sso/src/session-manager.ts
+++ b/packages/sso/src/session-manager.ts
@@ -65,6 +65,7 @@ type RefreshRaceResolution =
 
 export interface SessionManager {
   getSession: () => SSOSession | null;
+  clearInvalidSession: () => Promise<void>;
   getAuthGeneration: () => number;
   saveSession: (session: SSOSession, event?: AuthStateChangeEvent) => void;
   clearSession: () => void;
@@ -408,6 +409,17 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     }
   }
 
+  function clearInvalidSession(): Promise<void> {
+    const initialSnapshot = getSessionSnapshot();
+    if (initialSnapshot.raw === null || initialSnapshot.session) return Promise.resolve();
+
+    return runAuthMutation(async () => {
+      const currentRaw = locallySignedOut ? null : options.storage.getItem(keys.tokens);
+      if (currentRaw === null || parseSession(currentRaw)) return;
+      clearTokenSession();
+    });
+  }
+
   function resolveRefreshRace(expectedRaw: string): RefreshRaceResolution {
     const currentRaw = locallySignedOut ? null : options.storage.getItem(keys.tokens);
     if (currentRaw === expectedRaw) return { changed: false };
@@ -559,7 +571,10 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
     accessOptions: GetAccessTokenOptions = {},
   ): Promise<string | null> {
     const snapshot = getSessionSnapshot();
-    if (!snapshot.raw || !snapshot.session) return null;
+    if (!snapshot.raw || !snapshot.session) {
+      if (snapshot.raw) await clearInvalidSession();
+      return null;
+    }
     const { raw: initialRaw, session } = snapshot;
 
     const minValiditySeconds = Math.max(0, accessOptions.minValiditySeconds ?? 0);
@@ -671,6 +686,7 @@ export function createSessionManager(options: SessionManagerOptions): SessionMan
 
   return {
     getSession,
+    clearInvalidSession,
     getAuthGeneration: () => authGeneration,
     saveSession,
     clearSession,


### PR DESCRIPTION
## Summary

- Rebase the local dirty checkout onto the current `main` (`02316cd`) and preserve the existing SSO lifecycle hardening.
- Harden Core export/data-transfer behavior and add runtime coverage for provider error handling, CSV parsing, and formula escaping.
- Validate required OIDC discovery endpoints and fail closed on malformed persisted token sets without erasing newer sessions; avoid acquiring the browser auth lock for an already-empty session.
- Refresh agent-team workflow guidance so coordination DB v2 uses `agmesh context` / `agmesh automation status`, while `progress.md` remains legacy-only.

## Verification

- Focused Bun tests: 97 passed, 0 failed.
- Full test suite: 551 Bun tests + 141 Vitest tests passed.
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run pack:check`
- `git diff --check`
- Svelte autofixer: no issues or suggestions.

No npm publish or deployment was performed. This PR is intentionally opened as a draft for CI and maintainer review.
