### PR TITLE
fix(sso): complete RP-initiated logout

### DIFF
--- a/docs/src/content/docs/providers/sso.md
+++ b/docs/src/content/docs/providers/sso.md
@@ -53,6 +53,8 @@ interface SSOConfig {
   scopes?: string[];
   /** Redirect after logout */
   postLogoutRedirectUri?: string;
+  /** Public RP-Initiated Logout endpoint override */
+  endSessionEndpoint?: string;
   /** Token storage. Default: 'local' (localStorage) */
   storage?: 'local' | 'session' | TokenStorage;
   /** Storage namespace. Defaults to an issuer/client-specific key. */

--- a/docs/src/content/docs/zh-cn/providers/sso.md
+++ b/docs/src/content/docs/zh-cn/providers/sso.md
@@ -53,6 +53,8 @@ interface SSOConfig {
   scopes?: string[];
   /** 登出后重定向地址 */
   postLogoutRedirectUri?: string;
+  /** 覆盖 discovery 的公开 RP-Initiated Logout 端点 */
+  endSessionEndpoint?: string;
   /** Token 存储方式，默认: 'local' (localStorage) */
   storage?: 'local' | 'session' | TokenStorage;
   /** 自定义身份映射函数 */

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -34,6 +34,8 @@ export interface SSOConfig {
   scopes?: string[];
   /** Where to redirect after logout */
   postLogoutRedirectUri?: string;
+  /** Optional public RP-initiated logout endpoint override. */
+  endSessionEndpoint?: string;
   /** Token storage backend. Default: 'local' (localStorage) */
   storage?: 'local' | 'session' | TokenStorage;
   /** Storage namespace. Defaults to an issuer/client-specific key. */
@@ -341,7 +343,10 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
   async function discover(): Promise<OIDCConfig> {
     if (oidcConfig) return oidcConfig;
     if (config.manualEndpoints) {
-      oidcConfig = config.manualEndpoints;
+      oidcConfig = {
+        ...config.manualEndpoints,
+        ...(config.endSessionEndpoint ? { end_session_endpoint: config.endSessionEndpoint } : {}),
+      };
       return oidcConfig;
     }
 
@@ -364,7 +369,10 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
         cause: error,
       });
     }
-    oidcConfig = readOIDCConfig(discovered);
+    const discoveredConfig = readOIDCConfig(discovered);
+    oidcConfig = config.endSessionEndpoint
+      ? { ...discoveredConfig, end_session_endpoint: config.endSessionEndpoint }
+      : discoveredConfig;
     return oidcConfig;
   }
 
@@ -558,14 +566,15 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
 
       try {
         const endpoints = await discover();
-        if (typeof window !== 'undefined' && endpoints.end_session_endpoint && session?.id_token) {
-          const params = new URLSearchParams({
-            id_token_hint: session.id_token,
-            ...(config.postLogoutRedirectUri
-              ? { post_logout_redirect_uri: config.postLogoutRedirectUri }
-              : {}),
-          });
-          window.location.href = `${endpoints.end_session_endpoint}?${params}`;
+        if (typeof window !== 'undefined' && endpoints.end_session_endpoint) {
+          const logoutUrl = new URL(endpoints.end_session_endpoint, window.location.href);
+          logoutUrl.searchParams.set('client_id', config.clientId);
+          logoutUrl.searchParams.delete('id_token_hint');
+          if (session?.id_token) logoutUrl.searchParams.set('id_token_hint', session.id_token);
+          if (config.postLogoutRedirectUri) {
+            logoutUrl.searchParams.set('post_logout_redirect_uri', config.postLogoutRedirectUri);
+          }
+          window.location.href = logoutUrl.href;
           return { success: true };
         }
       } catch {

--- a/packages/sso/src/session-lifecycle.test.ts
+++ b/packages/sso/src/session-lifecycle.test.ts
@@ -1468,6 +1468,125 @@ describe('authenticated fetch recovery', () => {
 });
 
 describe('logout and SSR behavior', () => {
+  test('navigates the discovered end-session endpoint without an ID token hint', async () => {
+    const location = { href: 'https://app.test/' };
+    Object.defineProperty(globalThis, 'window', {
+      value: { location } as unknown as Window,
+      configurable: true,
+    });
+    const storage = createMemoryStorage();
+    const storageKey = 'logout-without-id-token';
+    saveSession(storage, storageKey, {
+      access_token: 'access',
+      refresh_token: 'refresh',
+      token_type: 'Bearer',
+    });
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'https://app.test/callback',
+      postLogoutRedirectUri: 'https://app.test/signed-out',
+      storage,
+      storageKey,
+      autoRefresh: false,
+      manualEndpoints: endpoints,
+    });
+
+    expect(await provider.logout()).toEqual({ success: true });
+    const logoutUrl = new URL(location.href);
+    expect(`${logoutUrl.origin}${logoutUrl.pathname}`).toBe(endpoints.end_session_endpoint);
+    expect(logoutUrl.searchParams.get('client_id')).toBe('admin-console');
+    expect(logoutUrl.searchParams.get('id_token_hint')).toBeNull();
+    expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe(
+      'https://app.test/signed-out',
+    );
+    expect(storage.getItem(sessionKey(storageKey))).toBeNull();
+    provider.destroy();
+  });
+
+  test('uses an explicit end-session endpoint when discovery omits it', async () => {
+    const location = { href: 'https://app.test/' };
+    Object.defineProperty(globalThis, 'window', {
+      value: { location } as unknown as Window,
+      configurable: true,
+    });
+    const storage = createMemoryStorage();
+    const storageKey = 'explicit-end-session-endpoint';
+    saveSession(storage, storageKey, {
+      access_token: 'access',
+      id_token: 'id-token',
+      token_type: 'Bearer',
+    });
+    let discoveryCalls = 0;
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'https://app.test/callback',
+      postLogoutRedirectUri: 'https://app.test/signed-out',
+      endSessionEndpoint: 'https://public-idp.test/logout?tenant=default#signed-out',
+      storage,
+      storageKey,
+      autoRefresh: false,
+      fetcher: asFetcher(() => {
+        discoveryCalls += 1;
+        return jsonResponse({
+          authorization_endpoint: endpoints.authorization_endpoint,
+          token_endpoint: endpoints.token_endpoint,
+          userinfo_endpoint: endpoints.userinfo_endpoint,
+        });
+      }),
+    });
+
+    expect(await provider.logout()).toEqual({ success: true });
+    const logoutUrl = new URL(location.href);
+    expect(`${logoutUrl.origin}${logoutUrl.pathname}`).toBe('https://public-idp.test/logout');
+    expect(logoutUrl.searchParams.get('tenant')).toBe('default');
+    expect(logoutUrl.searchParams.get('client_id')).toBe('admin-console');
+    expect(logoutUrl.searchParams.get('id_token_hint')).toBe('id-token');
+    expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe(
+      'https://app.test/signed-out',
+    );
+    expect(logoutUrl.hash).toBe('#signed-out');
+    expect(discoveryCalls).toBe(1);
+    expect(storage.getItem(sessionKey(storageKey))).toBeNull();
+    provider.destroy();
+  });
+
+  test('explicit end-session endpoint overrides the discovered endpoint', async () => {
+    const location = { href: 'https://app.test/' };
+    Object.defineProperty(globalThis, 'window', {
+      value: { location } as unknown as Window,
+      configurable: true,
+    });
+    const storage = createMemoryStorage();
+    const storageKey = 'override-discovered-end-session-endpoint';
+    saveSession(storage, storageKey, {
+      access_token: 'access',
+      id_token: 'id-token',
+      token_type: 'Bearer',
+    });
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'https://app.test/callback',
+      endSessionEndpoint: 'https://public-idp.test/configured-logout',
+      storage,
+      storageKey,
+      autoRefresh: false,
+      fetcher: asFetcher(() => jsonResponse({
+        authorization_endpoint: endpoints.authorization_endpoint,
+        token_endpoint: endpoints.token_endpoint,
+        userinfo_endpoint: endpoints.userinfo_endpoint,
+        end_session_endpoint: 'https://discovered-idp.test/logout',
+      })),
+    });
+
+    expect(await provider.logout()).toEqual({ success: true });
+    expect(new URL(location.href).origin).toBe('https://public-idp.test');
+    expect(new URL(location.href).pathname).toBe('/configured-logout');
+    provider.destroy();
+  });
+
   test('overwrites persisted tokens when storage removal fails', async () => {
     const storage = createMemoryStorage();
     const storageKey = 'logout-remove-failure';


### PR DESCRIPTION
## Summary

修复 `@svadmin/sso` 的 RP-Initiated Logout 流程。旧实现只有在同时存在 `end_session_endpoint` 和 `id_token` 时才导航到 OP；当本地 session 没有 `id_token` 时只清理 RP 本地 session，中央认证会话可能继续存在并导致重新登录原账号。

## Changes

- 新增 `SSOConfig.endSessionEndpoint`，允许显式覆盖 discovery/manual endpoint。
- 浏览器登出始终携带 `client_id`；有 `id_token` 时继续携带 `id_token_hint`。
- 配置了 `postLogoutRedirectUri` 时携带已登记的 `post_logout_redirect_uri`。
- 使用 `URL.searchParams` 合并 endpoint 参数，保留已有 query/fragment。
- 保持 SSR 不导航、本地会话先清理、现有 refresh/callback 竞态防护不变。
- 更新中英文文档与生命周期测试。

## Security / compatibility

RP-Initiated Logout 允许使用 `client_id` 标识客户端；OP 仍必须校验已登记的 post-logout redirect URI。endpoint 和 redirect URI 只来自开发者配置或可信 discovery，不接受运行时用户输入。

此 PR 修复客户端是否正确发起 RP 登出请求；中心 Hosted Auth/GoTrue 会话最终是否清除仍取决于对应 OP logout endpoint 的运行时行为，本 PR 不宣称替代 SupAuth 端点修复。

## Verification

- `bun install --frozen-lockfile`
- `bun test packages/sso/src`（73 pass, 0 fail）
- `bun run --cwd packages/sso build`
- `bunx tsc --noEmit -p packages/sso/tsconfig.json`
- `bun run --cwd packages/ui build`
- `bun run --cwd packages/editor build`
- `bun run typecheck`（0 errors, 0 warnings）
- `bunx eslint packages/sso/src/auth-provider.ts packages/sso/src/session-lifecycle.test.ts`
- `git diff --check`