### PR TITLE
fix(sso): harden logout and bearer interoperability

### DIFF
--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -237,7 +237,7 @@ describe('createSSOAuthProvider', () => {
       id_token: jwt({ roles: ['admin'] }),
       refresh_token: 'refresh-123',
       expires_in: 3600,
-      token_type: 'Bearer',
+      token_type: 'bearer',
     }));
     const provider = createSSOAuthProvider({
       issuer: 'https://idp.test',
@@ -263,6 +263,7 @@ describe('createSSOAuthProvider', () => {
     expect(storage.getItem(`${STORAGE_PREFIX}pkce_verifier`)).toBeNull();
     expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBeNull();
     expect(await provider.getAccessToken()).toBe('access-123');
+    expect((await provider.getSession())?.token_type).toBe('Bearer');
     expect(await provider.getPermissions?.()).toEqual(['admin']);
   });
 
@@ -599,7 +600,7 @@ describe('createSSOAuthProvider', () => {
     const storage = createMemoryStorage();
     storage.setItem(`${STORAGE_PREFIX}tokens`, JSON.stringify({
       access_token: 'access-123',
-      token_type: 'Bearer',
+      token_type: 'bearer',
     }));
     const calls = installFetch((url, init) => {
       expect(url).toBe(manualEndpoints.userinfo_endpoint);

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -202,6 +202,10 @@ function readOptionalTokenString(
     : requireTokenString(response, field, fallbackMessage);
 }
 
+function authorizationScheme(tokenType: string): string {
+  return tokenType.toLowerCase() === 'bearer' ? 'Bearer' : tokenType;
+}
+
 function normalizeTokenResponse(
   body: unknown,
   defaults: TokenResponseDefaults,
@@ -219,12 +223,14 @@ function normalizeTokenResponse(
       fallbackMessage,
     ),
     expires_at: getAccessTokenExpiry(response, accessToken),
-    token_type: readOptionalTokenString(
-      response,
-      'token_type',
-      defaults.tokenType,
-      fallbackMessage,
-    ) ?? defaults.tokenType,
+    token_type: authorizationScheme(
+      readOptionalTokenString(
+        response,
+        'token_type',
+        defaults.tokenType,
+        fallbackMessage,
+      ) ?? defaults.tokenType,
+    ),
   };
 }
 
@@ -500,7 +506,7 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
       const accessToken = await sessions.getAccessToken(options);
       const session = sessions.getSession();
       return accessToken && session?.access_token === accessToken
-        ? `${session.token_type} ${accessToken}`
+        ? `${authorizationScheme(session.token_type)} ${accessToken}`
         : null;
     },
   };

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -565,9 +565,10 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
       }
 
       try {
-        const endpoints = await discover();
-        if (typeof window !== 'undefined' && endpoints.end_session_endpoint) {
-          const logoutUrl = new URL(endpoints.end_session_endpoint, window.location.href);
+        const endSessionEndpoint = config.endSessionEndpoint
+          ?? (await discover()).end_session_endpoint;
+        if (typeof window !== 'undefined' && endSessionEndpoint) {
+          const logoutUrl = new URL(endSessionEndpoint, window.location.href);
           logoutUrl.searchParams.set('client_id', config.clientId);
           logoutUrl.searchParams.delete('id_token_hint');
           if (session?.id_token) logoutUrl.searchParams.set('id_token_hint', session.id_token);

--- a/packages/sso/src/session-lifecycle.test.ts
+++ b/packages/sso/src/session-lifecycle.test.ts
@@ -1504,7 +1504,7 @@ describe('logout and SSR behavior', () => {
     provider.destroy();
   });
 
-  test('uses an explicit end-session endpoint when discovery omits it', async () => {
+  test('uses an explicit end-session endpoint without discovery', async () => {
     const location = { href: 'https://app.test/' };
     Object.defineProperty(globalThis, 'window', {
       value: { location } as unknown as Window,
@@ -1512,6 +1512,8 @@ describe('logout and SSR behavior', () => {
     });
     const storage = createMemoryStorage();
     const storageKey = 'explicit-end-session-endpoint';
+    storage.setItem(`${storageKey}_state`, 'pending-state');
+    storage.setItem(`${storageKey}_pkce_verifier`, 'pending-verifier');
     saveSession(storage, storageKey, {
       access_token: 'access',
       id_token: 'id-token',
@@ -1529,11 +1531,7 @@ describe('logout and SSR behavior', () => {
       autoRefresh: false,
       fetcher: asFetcher(() => {
         discoveryCalls += 1;
-        return jsonResponse({
-          authorization_endpoint: endpoints.authorization_endpoint,
-          token_endpoint: endpoints.token_endpoint,
-          userinfo_endpoint: endpoints.userinfo_endpoint,
-        });
+        throw new TypeError('discovery unavailable');
       }),
     });
 
@@ -1547,8 +1545,10 @@ describe('logout and SSR behavior', () => {
       'https://app.test/signed-out',
     );
     expect(logoutUrl.hash).toBe('#signed-out');
-    expect(discoveryCalls).toBe(1);
+    expect(discoveryCalls).toBe(0);
     expect(storage.getItem(sessionKey(storageKey))).toBeNull();
+    expect(storage.getItem(`${storageKey}_state`)).toBeNull();
+    expect(storage.getItem(`${storageKey}_pkce_verifier`)).toBeNull();
     provider.destroy();
   });
 

--- a/packages/sso/src/session-lifecycle.test.ts
+++ b/packages/sso/src/session-lifecycle.test.ts
@@ -918,6 +918,7 @@ describe('rotation-safe session lifecycle', () => {
         access_token: 'new-access',
         refresh_token: 'refresh-2',
         expires_in: 3600,
+        token_type: 'bearer',
       })),
     });
 
@@ -925,6 +926,7 @@ describe('rotation-safe session lifecycle', () => {
 
     expect(session?.id_token).toBe('original-id-token');
     expect(session?.refresh_token).toBe('refresh-2');
+    expect(session?.token_type).toBe('Bearer');
     provider.destroy();
   });
 
@@ -1294,6 +1296,29 @@ describe('authenticated fetch recovery', () => {
     provider.destroy();
   });
 
+  test('normalizes a persisted lowercase bearer authorization scheme', async () => {
+    const storage = createMemoryStorage();
+    const storageKey = 'lowercase-bearer';
+    saveSession(storage, storageKey, {
+      access_token: 'access-token',
+      token_type: 'bearer',
+    });
+    let authorization = '';
+    const provider = createProvider({
+      storage,
+      storageKey,
+      fetcher: asFetcher((input) => {
+        authorization = requestHeaders(input).get('Authorization') ?? '';
+        return new Response(null, { status: 200 });
+      }),
+    });
+
+    await provider.createAuthenticatedFetch()('https://api.test/private');
+
+    expect(authorization).toBe('Bearer access-token');
+    provider.destroy();
+  });
+
   test('replays one POST after 401 with the rotated token and intact body', async () => {
     const storage = createMemoryStorage();
     const storageKey = 'fetch-recovery';
@@ -1517,7 +1542,7 @@ describe('logout and SSR behavior', () => {
     saveSession(storage, storageKey, {
       access_token: 'access',
       id_token: 'id-token',
-      token_type: 'Bearer',
+      token_type: 'bearer',
     });
     let discoveryCalls = 0;
     const provider = createSSOAuthProvider({


### PR DESCRIPTION
## Summary

- honor `SSOConfig.endSessionEndpoint` as a true RP-initiated logout override
- avoid requiring OIDC discovery before navigating to an explicitly configured logout endpoint
- canonicalize case-insensitive OAuth `token_type=bearer` to the interoperable `Authorization: Bearer <token>` form
- repair historical persisted lowercase bearer sessions at the Authorization header boundary
- keep local token, PKCE verifier, and state cleanup unchanged

## Root causes

1. `logout()` always awaited `discover()` before reading `end_session_endpoint`. After a provider was recreated from persisted session state, a transient discovery failure caused the SDK to clear only the RP-local session and fall back to `postLogoutRedirectUri`; the OP logout endpoint was never visited, so the OP SSO cookie could immediately authenticate the same account again.
2. GoTrue returns lowercase `token_type=bearer`. The SDK persisted and reused that value verbatim as the HTTP authorization scheme. Strict BFF parsers expecting canonical `Bearer ` rejected an otherwise valid JWT with 401, creating a callback/identity loop.

## Verification

- `bun test packages/sso/src` — 74 pass, 0 fail
- callback and refresh responses with lowercase `bearer` persist as `Bearer`
- historical lowercase persisted sessions send canonical Bearer through `createAuthenticatedFetch()` and `getIdentity()`
- non-Bearer schemes such as `DPoP` remain unchanged
- logout with a lowercase-token session still clears token/PKCE/state and navigates to the RP end-session endpoint
- `bun run --cwd packages/sso build`
- `bunx tsc --noEmit -p packages/sso/tsconfig.json`
- `bun run typecheck` — 0 errors, 0 warnings after building ignored workspace UI/editor package artifacts
- `bunx eslint packages/sso/src/auth-provider.ts packages/sso/src/auth-provider.test.ts packages/sso/src/session-lifecycle.test.ts`
- `git diff --check`

No deployment or npm publish was performed.
