### PR TITLE
fix(ui): stabilize AutoTable state and search navigation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -486,6 +486,7 @@
       "dependencies": {
         "@floating-ui/dom": "^1.8.0",
         "@lucide/svelte": "^1.25.0",
+        "@tanstack/svelte-store": "^0.12.0",
         "@tanstack/svelte-table": "9.0.0-alpha.53",
         "@tanstack/table-core": "9.0.0-alpha.53",
         "bits-ui": "^2.18.1",

--- a/packages/sveltekit/src/router-provider.ts
+++ b/packages/sveltekit/src/router-provider.ts
@@ -38,7 +38,12 @@ export function createSvelteKitRouterProvider(): RouterProvider {
       const url = resolve(...runtimeResolveArgs(path));
 
       const gotoPromise = type === 'replace'
-        ? goto(url, { replaceState: true })
+        ? goto(url, {
+          replaceState: true,
+          noScroll: true,
+          keepFocus: true,
+          invalidateAll: false,
+        })
         : goto(url);
 
       gotoPromise.then(() => {

--- a/packages/sveltekit/tests/router-provider.test.ts
+++ b/packages/sveltekit/tests/router-provider.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
-const gotoMock = mock((_url: string, _options?: { replaceState?: boolean }) => Promise.resolve());
+const gotoMock = mock((_url: string, _options?: {
+  replaceState?: boolean;
+  noScroll?: boolean;
+  keepFocus?: boolean;
+  invalidateAll?: boolean;
+}) => Promise.resolve());
 const pathsState = {
   base: '/admin',
   resolvedRoot: '../../',
@@ -46,7 +51,12 @@ describe('createSvelteKitRouterProvider', () => {
 
     expect(gotoMock).toHaveBeenCalledWith(
       '/admin/posts?search=hello+world#details',
-      { replaceState: true },
+      {
+        replaceState: true,
+        noScroll: true,
+        keepFocus: true,
+        invalidateAll: false,
+      },
     );
     expect(provider.formatLink?.('posts')).toBe('/admin/posts');
   });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,6 +76,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.8.0",
     "@lucide/svelte": "^1.25.0",
+    "@tanstack/svelte-store": "^0.12.0",
     "@tanstack/svelte-table": "9.0.0-alpha.53",
     "@tanstack/table-core": "9.0.0-alpha.53",
     "bits-ui": "^2.18.1",

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
   import { cn } from '../utils.js';
   import {
     createTable,
@@ -10,23 +10,21 @@
     type ColumnVisibilityState,
     type ExpandedState,
   } from '@tanstack/svelte-table';
-  import type { Column, Header, TableFeatures, Updater } from '@tanstack/table-core';
+  import type { Column, Header, TableFeatures } from '@tanstack/table-core';
+  import { createAtom, useSelector } from '@tanstack/svelte-store';
   import {
     column_getCanSort,
     column_getIsSorted,
     column_toggleSorting,
-    column_getIsVisible,
     column_toggleVisibility,
     header_getSize,
     table_getRowModel,
-    table_getHeaderGroups,
     table_getAllLeafColumns,
     table_getIsAllRowsSelected,
     table_toggleAllRowsSelected,
     row_getIsSelected,
     row_toggleSelected,
     row_getVisibleCells,
-    row_getIsExpanded,
     row_toggleExpanded,
     cell_getValue,
   } from '@tanstack/table-core/static-functions';
@@ -130,6 +128,22 @@
   );
   let filters = $state<Filter[]>([]);
   let searchText = $state(urlState.search ?? '');
+  let appliedSearchText = $state(untrack(() => searchText));
+  let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function scheduleSearch(event: Event) {
+    searchText = (event.currentTarget as HTMLInputElement).value;
+    if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = setTimeout(() => {
+      appliedSearchText = searchText;
+      pagination = { ...pagination, current: 1 };
+      searchDebounceTimer = undefined;
+    }, 300);
+  }
+
+  onDestroy(() => {
+    if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+  });
 
   // Sync external controlled state
   $effect(() => {
@@ -151,7 +165,7 @@
       pageSize: pagination.pageSize,
       sortField: sorters[0]?.field,
       sortOrder: sorters[0]?.order,
-      search: searchText || undefined,
+      search: appliedSearchText || undefined,
     }, adminContext);
   });
 
@@ -162,16 +176,16 @@
   const activeFilterCount = $derived(Object.values(filterValues).filter(v => v.trim()).length);
   const activeFilters = $derived.by(() => {
     const result: Filter[] = [...filters];
-    if (searchText.trim() && searchableFields.length > 0) {
+    if (appliedSearchText.trim() && searchableFields.length > 0) {
       if (searchableFields.length === 1) {
-        result.push({ field: searchableFields[0].key, operator: 'contains', value: searchText });
+        result.push({ field: searchableFields[0].key, operator: 'contains', value: appliedSearchText });
       } else {
         const searchFilter: LogicalFilter = {
           operator: 'or',
           value: searchableFields.map(f => ({
             field: f.key,
             operator: 'contains',
-            value: searchText
+            value: appliedSearchText
           }))
         };
         result.push(searchFilter);
@@ -251,10 +265,10 @@
   const canExport = $derived(canExportPerm.allowed);
 
   // ─── TanStack Table state ────────────────────────────────────
-  let sorting = $state<SortingState>(untrack(() =>
+  const initialSorting = untrack<SortingState>(() =>
     sorters.map(s => ({ id: s.field, desc: s.order === 'desc' }))
-  ));
-  let columnVisibility = $state<ColumnVisibilityState>((() => {
+  );
+  const initialColumnVisibility = (() => {
     // Try to restore from localStorage first
     const storageKey = `svadmin-columns-${resourceName}`;
     if (typeof window !== 'undefined') {
@@ -269,79 +283,41 @@
       if (f.showInList === false) vis[f.key] = false;
     }
     return vis;
-  })());
-  let rowSelection = $state<RowSelectionState>({});
-  let expanded = $state.raw<ExpandedState>({});
-  let columnOrder = $state<string[]>([]);
+  })();
+  const sortingAtom = createAtom(initialSorting);
+  const columnVisibilityAtom = createAtom(initialColumnVisibility);
+  const rowSelectionAtom = createAtom({} as RowSelectionState);
+  const expandedAtom = createAtom({} as ExpandedState);
+  const columnOrderAtom = createAtom([] as string[]);
 
-  function applyTableUpdater<T>(current: T, updater: Updater<T>): T {
-    return typeof updater === 'function' ? (updater as (old: T) => T)(current) : updater;
+  const tableSorting = useSelector(sortingAtom);
+  const tableColumnVisibility = useSelector(columnVisibilityAtom);
+  const tableRowSelection = useSelector(rowSelectionAtom);
+  const tableExpanded = useSelector(expandedAtom);
+  const tableColumnOrder = useSelector(columnOrderAtom);
+
+  function rowIsExpanded(rowId: string): boolean {
+    const expanded = tableExpanded.current;
+    return expanded === true || expanded[rowId] === true;
   }
 
-  const tableSorting = $derived<SortingState>(sorting.map(sorter => ({
-    id: sorter.id,
-    desc: sorter.desc,
-  })));
-  const tableColumnVisibility = $derived<ColumnVisibilityState>({ ...columnVisibility });
-  const tableRowSelection = $derived<RowSelectionState>({ ...rowSelection });
-  const tableExpanded = $derived<ExpandedState>(expanded === true ? true : { ...expanded });
-  const tableColumnOrder = $derived<string[]>([...columnOrder]);
+  $effect(() => {
+    const nextSorters: Sort[] = tableSorting.current.map((sorter) => ({
+      field: sorter.id,
+      order: sorter.desc ? 'desc' as const : 'asc' as const,
+    }));
 
-  const sortingAtom = {
-    get: () => tableSorting,
-    set: (updater: Updater<SortingState>) => {
-      const nextSorting = applyTableUpdater(tableSorting, updater);
-      sorting = nextSorting;
-
-      const nextSorters: Sort[] = nextSorting.map((s) => ({
-        field: s.id,
-        order: s.desc ? 'desc' as const : 'asc' as const,
-      }));
-
-      if (JSON.stringify(nextSorters) !== JSON.stringify(sorters)) {
-        sorters = nextSorters;
-      }
-
-      if ((pagination.current ?? 1) !== 1) {
-        pagination = { ...pagination, current: 1 };
-      }
-    },
-  };
-
-  const columnVisibilityAtom = {
-    get: () => tableColumnVisibility,
-    set: (updater: Updater<ColumnVisibilityState>) => {
-      columnVisibility = applyTableUpdater(tableColumnVisibility, updater);
-    },
-  };
-
-  const rowSelectionAtom = {
-    get: () => tableRowSelection,
-    set: (updater: Updater<RowSelectionState>) => {
-      rowSelection = applyTableUpdater(tableRowSelection, updater);
-    },
-  };
-
-  const expandedAtom = {
-    get: () => tableExpanded,
-    set: (updater: Updater<ExpandedState>) => {
-      expanded = applyTableUpdater(tableExpanded, updater);
-    },
-  };
-
-  const columnOrderAtom = {
-    get: () => tableColumnOrder,
-    set: (updater: Updater<string[]>) => {
-      columnOrder = applyTableUpdater(tableColumnOrder, updater);
-    },
-  };
+    if (JSON.stringify(nextSorters) !== JSON.stringify(sorters)) {
+      sorters = nextSorters;
+    }
+  });
 
   // Persist column visibility to localStorage
   $effect(() => {
     const storageKey = `svadmin-columns-${resourceName}`;
     if (typeof window !== 'undefined') {
       try {
-        localStorage.setItem(storageKey, JSON.stringify(columnVisibility));
+        localStorage.setItem(storageKey, JSON.stringify(tableColumnVisibility.current));
       } catch { /* ignore quota errors */ }
     }
   });
@@ -353,8 +329,8 @@
       sorters = externalSorters;
     }
     const nextSorting = externalSorters.map(s => ({ id: s.field, desc: s.order === 'desc' }));
-    if (JSON.stringify(nextSorting) !== JSON.stringify(sorting)) {
-      sorting = nextSorting;
+    if (JSON.stringify(nextSorting) !== JSON.stringify(tableSorting.current)) {
+      sortingAtom.set(nextSorting);
     }
   });
 
@@ -397,12 +373,25 @@
       enableSorting: false,
     },
   ]);
+  const orderedColumns = $derived.by(() => {
+    const columnOrder = tableColumnOrder.current;
+    if (!columnOrder.length) return columns;
+
+    const columnsById = new Map(columns.map((column) => [column.id, column]));
+    return [
+      ...columnOrder.flatMap((id) => {
+        const column = columnsById.get(id);
+        return column ? [column] : [];
+      }),
+      ...columns.filter((column) => !columnOrder.includes(column.id ?? '')),
+    ];
+  });
 
   // ─── Create TanStack Table ────────────────────────────────────
   const tbl = createTable(
     {
       get data() { return query.data?.data ?? []; },
-      get columns() { return columns; },
+      get columns() { return orderedColumns; },
       getCoreRowModel: createCoreRowModel(),
       manualPagination: true,
       manualSorting: true,
@@ -412,15 +401,36 @@
         columnVisibility: columnVisibilityAtom,
         rowSelection: rowSelectionAtom,
         expanded: expandedAtom,
-        columnOrder: columnOrderAtom,
       },
+      onSortingChange: sortingAtom.set,
+      onColumnVisibilityChange: columnVisibilityAtom.set,
+      onRowSelectionChange: rowSelectionAtom.set,
+      onExpandedChange: expandedAtom.set,
       get enableRowSelection() { return selectable && (canDelete || batchActions); },
       get enableExpanding() { return !!expandedRowRender; },
+      getRowCanExpand: () => !!expandedRowRender,
     },
-    () => undefined,
   );
 
-  const selectedCount = $derived(Object.keys(rowSelection).length);
+  $effect.pre(() => {
+    const nextColumns = orderedColumns;
+    untrack(() => {
+      tbl.setOptions({ ...tbl.options, columns: nextColumns });
+    });
+  });
+
+  const selectedCount = $derived(Object.keys(tableRowSelection.current).length);
+  const tableView = $derived.by(() => {
+    void tableSorting.current;
+    void tableColumnVisibility.current;
+    void tableRowSelection.current;
+    void tableExpanded.current;
+    void tableColumnOrder.current;
+    return {
+      headerGroups: tbl.getHeaderGroups(),
+      rows: table_getRowModel(tbl).rows,
+    };
+  });
   const totalPages = $derived(Math.ceil((query.data?.total ?? 0) / (pagination.pageSize ?? 10)));
 
   // ─── Pagination helpers ───────────────────────────────────────
@@ -456,7 +466,7 @@
   }
 
   function confirmBatchDelete() {
-    const ids = Object.keys(rowSelection);
+    const ids = Object.keys(tableRowSelection.current);
     confirmMessage = i18n.t('common.batchDeleteConfirm', { count: ids.length });
     confirmAction = async () => {
       try {
@@ -465,7 +475,7 @@
       } catch {
         notify({ type: 'error', message: i18n.t('common.batchDeletePartialFail', { failed: 1, total: ids.length }) });
       }
-      rowSelection = {};
+      rowSelectionAtom.set({});
       confirmOpen = false;
     };
     confirmOpen = true;
@@ -520,7 +530,7 @@
       {/if}
       
       {#if selectedCount > 0 && batchActions}
-        {@render batchActions({ selectedIds: Object.keys(rowSelection) })}
+        {@render batchActions({ selectedIds: Object.keys(tableRowSelection.current) })}
       {/if}
 
       <!-- Column Visibility Picker (DropdownMenu) -->
@@ -528,14 +538,14 @@
         <DropdownMenu.Trigger>
           {#snippet child({ props })}
             <Button variant="outline" size="sm" {...props}>
-              <SlidersHorizontal class="h-4 w-4" data-icon="inline-start" /> {i18n.t('common.columns') || 'Columns'}
+              <SlidersHorizontal class="h-4 w-4" data-icon="inline-start" /> {i18n.t('common.columns')}
             </Button>
           {/snippet}
         </DropdownMenu.Trigger>
         <DropdownMenu.Content align="end" class="w-48">
           {#each table_getAllLeafColumns(tbl).filter((column: Column<TableFeatures, BaseRecord, unknown>) => !column.id.startsWith('_')) as column, _i (_i)}
             <DropdownMenu.CheckboxItem
-              checked={column_getIsVisible(column)}
+              checked={tableColumnVisibility.current[column.id] ?? true}
               onCheckedChange={(v) => column_toggleVisibility(column, !!v)}
             >
               {visibleFields.find(f => f.key === column.id)?.label ?? column.id}
@@ -561,8 +571,8 @@
         <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           type="text"
-          bind:value={searchText}
-          oninput={() => { pagination = { ...pagination, current: 1 }; }}
+          value={searchText}
+          oninput={scheduleSearch}
           placeholder={i18n.t('common.search')}
           class="pl-10 h-9"
         />
@@ -656,11 +666,11 @@
         <div class="hidden md:block">
         <Table.Root>
           <Table.Header>
-            {#each table_getHeaderGroups(tbl) as headerGroup, _i (_i)}
+            {#each tableView.headerGroups as headerGroup, _i (_i)}
               <DraggableHeader
                 columns={headerGroup.headers.map((header: Header<TableFeatures, BaseRecord, unknown>) => ({ id: header.column.id, header }))}
                 resourceName={resourceName}
-                onReorder={(newOrder) => { columnOrder = newOrder.map((column) => column.id); }}
+                onReorder={(newOrder) => columnOrderAtom.set(newOrder.map((column) => column.id))}
               >
                 {#snippet header(col, _index, dragProps)}
                   {@const header = col.header as typeof headerGroup.headers[0]}
@@ -702,7 +712,7 @@
             {/each}
           </Table.Header>
           <Table.Body>
-            {#each table_getRowModel(tbl).rows as row, _i (_i)}
+            {#each tableView.rows as row, _i (_i)}
               {@const record = row.original}
               {@const id = record[primaryKey] as string | number}
               <ContextMenu.Root>
@@ -717,8 +727,8 @@
                               onCheckedChange={() => row_toggleSelected(row)}
                             />
                           {:else if cell.column.id === '_expand'}
-                            <TooltipButton tooltip={row_getIsExpanded(row) ? i18n.t('common.collapse') : i18n.t('common.expand')} variant="ghost" size="icon" class="h-7 w-7" onclick={() => row_toggleExpanded(row)}>
-                              {#if row_getIsExpanded(row)}
+                            <TooltipButton tooltip={rowIsExpanded(row.id) ? i18n.t('common.collapse') : i18n.t('common.expand')} variant="ghost" size="icon" class="h-7 w-7" onclick={() => row_toggleExpanded(row)}>
+                              {#if rowIsExpanded(row.id)}
                                 <ChevronUp class="h-4 w-4" />
                               {:else}
                                 <ChevronDown class="h-4 w-4" />
@@ -799,7 +809,7 @@
                   {/if}
                 </ContextMenu.Content>
               </ContextMenu.Root>
-              {#if expandedRowRender && row_getIsExpanded(row)}
+              {#if expandedRowRender && rowIsExpanded(row.id)}
                 <Table.Row class="bg-muted/10 border-b border-border/10 transition-all">
                   <Table.Cell colspan={row_getVisibleCells(row).length}>
                     {@render expandedRowRender({ record })}
@@ -817,7 +827,7 @@
                         <path stroke-linecap="round" stroke-linejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
                       </svg>
                       <p class="text-sm font-medium text-muted-foreground mb-1">{i18n.t('common.noData')}</p>
-                      <p class="text-xs text-muted-foreground/60 mb-4">{i18n.t('common.noDataHint') || 'Get started by creating your first record.'}</p>
+                      <p class="text-xs text-muted-foreground/60 mb-4">{i18n.t('common.noDataHint')}</p>
                       {#if canCreate}
                         <Button variant="outline" size="sm" class="gap-2" onclick={() => adminContext.navigate(`/${resourceName}/create`)}>
                           <Plus class="h-3.5 w-3.5" />
@@ -835,7 +845,7 @@
 
         <!-- Mobile Card View (visible only on small screens) -->
         <div class="md:hidden space-y-3 p-2">
-          {#each table_getRowModel(tbl).rows as row, _i (_i)}
+          {#each tableView.rows as row, _i (_i)}
             {@const record = row.original}
             {@const id = record[primaryKey] as string | number}
             <div

--- a/packages/ui/src/components/auto-table-interactions.test.svelte.ts
+++ b/packages/ui/src/components/auto-table-interactions.test.svelte.ts
@@ -1,0 +1,96 @@
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AutoTableInteractionsHarness from '../../test/fixtures/AutoTableInteractionsHarness.svelte';
+
+beforeEach(() => {
+  const storage = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+    } satisfies Partial<Storage>,
+  });
+  Object.defineProperty(Element.prototype, 'animate', {
+    configurable: true,
+    value: () => ({ cancel: () => {}, finished: Promise.resolve() }),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AutoTable interactions', () => {
+  it('uses the active locale for built-in table labels', async () => {
+    const view = render(AutoTableInteractionsHarness, {
+      locale: 'en',
+      onNavigate: vi.fn(),
+    });
+
+    expect(await view.findByRole('button', { name: 'Columns' })).toBeTruthy();
+    expect(await view.findByPlaceholderText('Search...')).toBeTruthy();
+  });
+
+  it('updates external column visibility state after a picker click', async () => {
+    const view = render(AutoTableInteractionsHarness, { onNavigate: vi.fn() });
+
+    await fireEvent.click(await view.findByRole('button', { name: '列' }));
+    const emailColumn = await view.findByRole('menuitemcheckbox', { name: 'Email' });
+    expect(emailColumn.getAttribute('aria-checked')).toBe('true');
+
+    await fireEvent.click(emailColumn);
+
+    await waitFor(() => {
+      expect(view.getByRole('menuitemcheckbox', { name: 'Email' }).getAttribute('aria-checked')).toBe('false');
+      expect(view.queryByRole('columnheader', { name: 'Email' })).toBeNull();
+    });
+  });
+
+  it('waits for a pause before synchronizing a search with the router', async () => {
+    const onNavigate = vi.fn();
+    const view = render(AutoTableInteractionsHarness, { onNavigate });
+    const searchInput = await view.findByPlaceholderText('搜索...');
+
+    searchInput.focus();
+    await fireEvent.input(searchInput, { target: { value: 'u' } });
+    await fireEvent.input(searchInput, { target: { value: 'user' } });
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(onNavigate).toHaveBeenCalledWith({
+        to: '/',
+        query: { q: 'user' },
+        type: 'replace',
+      });
+    });
+    expect(document.activeElement).toBe(searchInput);
+  });
+
+  it('applies a persisted column order after the table mounts', async () => {
+    localStorage.setItem('svadmin-colorder-users', JSON.stringify(['email', 'id']));
+    const view = render(AutoTableInteractionsHarness, { onNavigate: vi.fn() });
+
+    await waitFor(() => {
+      const headings = view.getAllByRole('columnheader').map((heading) => heading.textContent?.trim());
+      expect(headings.findIndex((heading) => heading?.startsWith('Email')))
+        .toBeLessThan(headings.findIndex((heading) => heading?.startsWith('ID')));
+    });
+  });
+
+  it('renders expanded-row content after toggling the localized action', async () => {
+    const view = render(AutoTableInteractionsHarness, { onNavigate: vi.fn() });
+
+    const expandButton = await view.findByRole('button', { name: '展开' });
+    await fireEvent.click(expandButton);
+    expect(await view.findByRole('button', { name: '收起' })).toBeTruthy();
+    expect(await view.findByText('已展开：user@example.com')).toBeTruthy();
+
+    await fireEvent.click(await view.findByRole('button', { name: '收起' }));
+    await waitFor(() => {
+      expect(view.queryByText('已展开：user@example.com')).toBeNull();
+    });
+  });
+});

--- a/packages/ui/test/fixtures/AutoTableInteractionsHarness.svelte
+++ b/packages/ui/test/fixtures/AutoTableInteractionsHarness.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import type { DataProvider, ResourceDefinition, RouterProvider } from '@svadmin/core';
+  import AdminApp from '../../src/components/AdminApp.svelte';
+  import AutoTable from '../../src/components/AutoTable.svelte';
+
+  interface Props {
+    onNavigate: RouterProvider['go'];
+    locale?: string;
+  }
+
+  let { onNavigate, locale = 'zh-CN' }: Props = $props();
+
+  const dataProvider = {
+    getList: async () => ({ data: [{ id: 'user-1', email: 'user@example.com' }], total: 1 }),
+    getOne: async () => ({ data: { id: 'user-1' } }),
+    create: async () => ({ data: { id: 'user-1' } }),
+    update: async () => ({ data: { id: 'user-1' } }),
+    deleteOne: async () => ({ data: { id: 'user-1' } }),
+    getApiUrl: () => 'https://example.test',
+  } as DataProvider;
+
+  const resources: ResourceDefinition[] = [{
+    name: 'users',
+    label: 'Users',
+    canCreate: false,
+    canEdit: false,
+    canDelete: false,
+    fields: [
+      { key: 'id', label: 'ID', type: 'text' },
+      { key: 'email', label: 'Email', type: 'text', searchable: true },
+    ],
+  }];
+
+  const routerProvider: RouterProvider = {
+    go: (options) => onNavigate(options),
+    back: () => {},
+    parse: () => ({ pathname: '/', params: {} }),
+  };
+</script>
+
+{#snippet dashboard()}
+  {#snippet expandedRowRender({ record }: { record: Record<string, unknown> })}
+    已展开：{record.email}
+  {/snippet}
+
+  <AutoTable resourceName="users" selectable={false} {expandedRowRender} />
+{/snippet}
+
+<AdminApp {dataProvider} {resources} {routerProvider} {locale} dashboard={dashboard} />


### PR DESCRIPTION
## Summary
- use the Svelte TanStack Store atoms for sorting, visibility, selection, expansion, and column order
- debounce table search and preserve focus, scroll position, and data cache on replace navigation
- render expanded rows and persisted column order reliably
- keep built-in table labels sourced from the existing zh-CN and en dictionaries, with interaction coverage for both locales

## Validation
- bun run test (packages/ui): 13 files, 41 tests passed
- bun run build (packages/ui)
- bunx svelte-check --tsconfig ./tsconfig.json (packages/ui): 0 errors
- bun test packages/sveltekit/tests/router-provider.test.ts: 5 tests passed

Root typecheck remains blocked by the pre-existing missing @svadmin/editor/components/Editor.svelte import in example/src/components/LazyRichTextEditor.svelte.