### PR TITLE
fix(ui): unblock AutoTable release verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: "[]"
+      e2e_sha:
+        description: Optional commit SHA used only for E2E verification of an immutable release
+        required: false
+        type: string
+        default: ""
       publish:
         description: Publish the release-please packages after all gates pass
         required: false
@@ -78,9 +83,19 @@ jobs:
     if: github.event_name == 'pull_request' || inputs.publish
 
     steps:
+      - name: Validate E2E recovery SHA
+        if: inputs.e2e_sha != ''
+        env:
+          E2E_SHA: ${{ inputs.e2e_sha }}
+        run: |
+          if [[ ! "$E2E_SHA" =~ ^[0-9a-f]{40,64}$ ]]; then
+            echo "::error::Invalid E2E SHA"
+            exit 1
+          fi
+
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.release_sha || github.sha }}
+          ref: ${{ inputs.e2e_sha || inputs.release_sha || github.sha }}
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -56,13 +56,19 @@ test.describe('CRUD Operations', () => {
     const firstRow = table.locator('tbody tr').first();
     await expect(firstRow).toBeVisible();
 
-    const firstSortableHeader = table.locator('thead button:not([role="checkbox"])').first();
-    await firstSortableHeader.click();
     await expect.poll(() => {
       const [, query = ''] = new URL(page.url()).hash.split('?');
       const params = new URLSearchParams(query);
       return { sort: params.get('sort'), order: params.get('order') };
     }).toEqual({ sort: 'name', order: 'asc' });
+
+    const idSortableHeader = table.getByRole('button', { name: /^ID/ });
+    await idSortableHeader.click();
+    await expect.poll(() => {
+      const [, query = ''] = new URL(page.url()).hash.split('?');
+      const params = new URLSearchParams(query);
+      return { sort: params.get('sort'), order: params.get('order') };
+    }).toEqual({ sort: 'id', order: 'desc' });
 
     const firstRowCheckbox = firstRow.getByRole('checkbox');
     await firstRowCheckbox.click();

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -410,6 +410,8 @@
       get enableExpanding() { return !!expandedRowRender; },
       getRowCanExpand: () => !!expandedRowRender,
     },
+    // AutoTable reads focused atoms directly; selecting the full state triggers Svelte proxy equality warnings.
+    () => undefined,
   );
 
   $effect.pre(() => {

--- a/scripts/release-workflow-contract.test.ts
+++ b/scripts/release-workflow-contract.test.ts
@@ -31,6 +31,9 @@ describe('npm trusted-publishing workflow contract', () => {
 
     expect(ciWorkflow).toContain('workflow_dispatch:');
     expect(ciWorkflow).not.toContain('workflow_call:');
+    expect(ciWorkflow).toContain('e2e_sha:');
+    expect(ciWorkflow).toContain('Invalid E2E SHA');
+    expect(ciWorkflow).toContain('ref: ${{ inputs.e2e_sha || inputs.release_sha || github.sha }}');
     expect(ciWorkflow).toContain(
       "if: github.event_name == 'workflow_dispatch' && inputs.publish && inputs.release_sha != ''",
     );


### PR DESCRIPTION
## Summary

- stop `AutoTable` from selecting the unused full TanStack table state, eliminating Svelte proxy-equality warnings while keeping focused atom subscriptions
- make the sorting E2E target the ID column explicitly and assert both the initial `name/asc` state and the clicked `id/desc` state
- add a validated optional `e2e_sha` for manually re-verifying an immutable release after a test or adjacent-package gate fix
- extend the release workflow contract test for the recovery path

## Root cause

The failed release run clicked the first sortable header, which is numeric `ID`, but asserted `name/asc`. After correcting that assertion, the existing console-warning guard exposed `createTable` selecting its unused full state through TanStack Svelte Store, whose strict proxy/raw comparison emits `state_proxy_equality_mismatch`.

## Verification

- `bun run playwright test` — 10 passed
- `bun run test` — passed
- `bun run lint` — passed
- `bun run typecheck` — 0 errors, 0 warnings
- `bun run build:packages` — passed
- `bun run --cwd example build` and `bun run bundle:check` — passed
- `bun run docs:build` — passed
- `bun run pack:check` — passed
- `bun test scripts/release-workflow-contract.test.ts` — 4 passed
- `git diff --check` — passed