### PR TITLE
fix(ui): preserve expanded rows with TanStack 9

### DIFF
--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -410,8 +410,6 @@
       get enableExpanding() { return !!expandedRowRender; },
       getRowCanExpand: () => !!expandedRowRender,
     },
-    // AutoTable reads focused atoms directly; selecting the full state triggers Svelte proxy equality warnings.
-    () => undefined,
   );
 
   $effect.pre(() => {

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -25,7 +25,6 @@
     row_getIsSelected,
     row_toggleSelected,
     row_getVisibleCells,
-    row_toggleExpanded,
     cell_getValue,
   } from '@tanstack/table-core/static-functions';
 
@@ -434,6 +433,26 @@
       rows: table_getRowModel(tbl).rows,
     };
   });
+
+  function toggleRowExpanded(rowId: string): void {
+    const current = tableExpanded.current;
+    if (current === true) {
+      expandedAtom.set(Object.fromEntries(
+        table_getRowModel(tbl).flatRows
+          .filter((row) => row.id !== rowId)
+          .map((row) => [row.id, true])
+      ));
+      return;
+    }
+    if (current[rowId]) {
+      expandedAtom.set(Object.fromEntries(
+        Object.entries(current).filter(([id, isExpanded]) => id !== rowId && isExpanded)
+      ));
+      return;
+    }
+    expandedAtom.set({ ...current, [rowId]: true });
+  }
+
   const totalPages = $derived(Math.ceil((query.data?.total ?? 0) / (pagination.pageSize ?? 10)));
 
   // ─── Pagination helpers ───────────────────────────────────────
@@ -730,7 +749,7 @@
                               onCheckedChange={() => row_toggleSelected(row)}
                             />
                           {:else if cell.column.id === '_expand'}
-                            <TooltipButton tooltip={rowIsExpanded(row.id) ? i18n.t('common.collapse') : i18n.t('common.expand')} variant="ghost" size="icon" class="h-7 w-7" onclick={() => row_toggleExpanded(row)}>
+                            <TooltipButton tooltip={rowIsExpanded(row.id) ? i18n.t('common.collapse') : i18n.t('common.expand')} variant="ghost" size="icon" class="h-7 w-7" onclick={() => toggleRowExpanded(row.id)}>
                               {#if rowIsExpanded(row.id)}
                                 <ChevronUp class="h-4 w-4" />
                               {:else}

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -406,6 +406,7 @@
       onColumnVisibilityChange: columnVisibilityAtom.set,
       onRowSelectionChange: rowSelectionAtom.set,
       onExpandedChange: expandedAtom.set,
+      autoResetExpanded: false,
       get enableRowSelection() { return selectable && (canDelete || batchActions); },
       get enableExpanding() { return !!expandedRowRender; },
       getRowCanExpand: () => !!expandedRowRender,

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -3,7 +3,13 @@
   import { cn } from '../utils.js';
   import {
     createTable,
-    createCoreRowModel,
+    tableFeatures,
+    columnOrderingFeature,
+    columnSizingFeature,
+    columnVisibilityFeature,
+    rowExpandingFeature,
+    rowSelectionFeature,
+    rowSortingFeature,
     type ColumnDef,
     type SortingState,
     type RowSelectionState,
@@ -288,6 +294,14 @@
   const rowSelectionAtom = createAtom({} as RowSelectionState);
   const expandedAtom = createAtom({} as ExpandedState);
   const columnOrderAtom = createAtom([] as string[]);
+  const features = tableFeatures({
+    columnOrderingFeature,
+    columnSizingFeature,
+    columnVisibilityFeature,
+    rowExpandingFeature,
+    rowSelectionFeature,
+    rowSortingFeature,
+  });
 
   const tableSorting = useSelector(sortingAtom);
   const tableColumnVisibility = useSelector(columnVisibilityAtom);
@@ -387,12 +401,11 @@
   });
 
   // ─── Create TanStack Table ────────────────────────────────────
-  const tbl = createTable(
+  const tbl = createTable<TableFeatures, BaseRecord>(
     {
+      features,
       get data() { return query.data?.data ?? []; },
       get columns() { return orderedColumns; },
-      getCoreRowModel: createCoreRowModel(),
-      manualPagination: true,
       manualSorting: true,
       getRowId: (row: BaseRecord) => String(row[primaryKey]),
       atoms: {
@@ -401,12 +414,8 @@
         rowSelection: rowSelectionAtom,
         expanded: expandedAtom,
       },
-      onSortingChange: sortingAtom.set,
-      onColumnVisibilityChange: columnVisibilityAtom.set,
-      onRowSelectionChange: rowSelectionAtom.set,
-      onExpandedChange: expandedAtom.set,
       autoResetExpanded: false,
-      get enableRowSelection() { return selectable && (canDelete || batchActions); },
+      get enableRowSelection() { return selectable && (canDelete || !!batchActions); },
       get enableExpanding() { return !!expandedRowRender; },
       getRowCanExpand: () => !!expandedRowRender,
     },


### PR DESCRIPTION
## Summary
- preserve row expansion state across TanStack Table recalculation
- drive expand/collapse actions from the rendered expanded-state selector
- complete the stable TanStack Table 9 migration with explicit feature registration, stable createTable generics, and single-owner external atoms

## Validation
- stable 9.0.0 `bun run typecheck`: 0 errors, 0 warnings
- stable 9.0.0 AutoTable interaction tests: 5/5 passed
- ESLint on AutoTable: passed
- full GitHub CI: pending