### PR TITLE
feat(auth): require trusted permission resolvers

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -83,9 +83,12 @@ mutate(error); // Calls authProvider.onError → may redirect or logout
 
 ### `usePermissions()`
 
+`usePermissions()` is a client-side rendering helper. It can hide or disable UI, but APIs, data providers, and database policies must enforce authorization independently.
+
 ```typescript
-const { data, isLoading, error } = usePermissions<string[]>();
-// data: whatever authProvider.getPermissions() returns
+const { raw, has, can, isLoading, error } = usePermissions<string[]>();
+// raw: whatever trusted authProvider.getPermissions() resolver returns
+// has/can: exact client-side UI checks
 ```
 
 ## Auth Pages

--- a/docs/src/content/docs/hooks/auth.md
+++ b/docs/src/content/docs/hooks/auth.md
@@ -36,6 +36,8 @@ const { isAuthenticated, isLoading } = useIsAuthenticated();
 
 ### `usePermissions<T>()`
 
+`usePermissions()` is a client-side rendering helper. It can hide or disable UI, but APIs, data providers, and database policies must enforce authorization independently.
+
 ```typescript
 const { raw, has, can, isLoading, refetch } = usePermissions<string[]>();
 

--- a/docs/src/content/docs/providers/auth.md
+++ b/docs/src/content/docs/providers/auth.md
@@ -21,6 +21,8 @@ interface AuthProvider {
 }
 ```
 
+`getPermissions` is intentionally a UI hint hook. It should return permissions only when the application provides a trusted resolver; it must not replace API, backend, or database authorization.
+
 ## Auth Hooks
 
 | Hook | Purpose |
@@ -91,10 +93,19 @@ export const mockAuthProvider: AuthProvider = {
 
 ```typescript
 import { createSupabaseAuthProvider } from '@svadmin/supabase';
-const authProvider = createSupabaseAuthProvider(supabaseClient);
+const authProvider = createSupabaseAuthProvider(supabaseClient, {
+  getPermissions: async ({ client }) => {
+    const { data, error } = await client
+      .from('effective_permission_grants')
+      .select('permission');
+    if (error) throw error;
+    return data.map((grant) => grant.permission);
+  },
+});
 ```
 
 `@supacloud/js` does not change the auth flow. Keep using the official Supabase client with `createSupabaseAuthProvider()`, and layer any task APIs separately through [`@svadmin/supabase/supacloud`](/providers/supacloud).
+Do not use user-editable metadata as an authorization fact.
 
 ### Appwrite
 

--- a/docs/src/content/docs/providers/sso.md
+++ b/docs/src/content/docs/providers/sso.md
@@ -73,6 +73,8 @@ interface SSOConfig {
   refreshLock?: RefreshLock;
   /** Injectable fetch implementation for tests and SSR runtimes. */
   fetcher?: typeof fetch;
+  /** Trusted permission resolver for UI hints. */
+  getPermissions?: (context: SSOPermissionResolverContext) => Promise<unknown> | unknown;
 }
 ```
 
@@ -114,13 +116,21 @@ const authProvider = createSSOAuthProvider({
 });
 ```
 
-### Permissions from ID Token
+### Trusted Permissions Resolver
 
-The provider automatically extracts `roles`, `groups`, or `permissions` claims from the ID token via `getPermissions()`.
+`getPermissions()` returns `null` unless you configure a trusted resolver. Use the resolver to call your application authorization endpoint or another backend-controlled source. ID Token claims can be useful display hints, but they are not a replacement for API or database authorization.
 
 ```typescript
-const permissions = await authProvider.getPermissions();
-// → ['admin', 'editor'] (from ID token claims)
+const authProvider = createSSOAuthProvider({
+  issuer: 'https://your-tenant.okta.com',
+  clientId: 'abc',
+  redirectUri: '/callback',
+  getPermissions: async ({ createAuthenticatedFetch }) => {
+    const response = await createAuthenticatedFetch()(new URL('/api/me/permissions', window.location.origin));
+    if (!response.ok) throw new Error('Failed to load permissions');
+    return response.json();
+  },
+});
 ```
 
 ### Calling Protected APIs

--- a/docs/src/content/docs/zh-cn/hooks/auth.md
+++ b/docs/src/content/docs/zh-cn/hooks/auth.md
@@ -36,6 +36,8 @@ const { isAuthenticated, isLoading } = useIsAuthenticated();
 
 ### `usePermissions<T>()`
 
+`usePermissions()` 只是客户端渲染辅助。它可以隐藏或禁用 UI，但 API、DataProvider 和数据库策略必须独立执行授权。
+
 ```typescript
 const { raw, has, can, isLoading, refetch } = usePermissions<string[]>();
 

--- a/docs/src/content/docs/zh-cn/providers/auth.md
+++ b/docs/src/content/docs/zh-cn/providers/auth.md
@@ -21,6 +21,8 @@ interface AuthProvider {
 }
 ```
 
+`getPermissions` 只作为 UI hint。只有应用提供可信 resolver 时才应返回权限；它不能替代 API、后端或数据库授权。
+
 ## 认证 Hook
 
 | Hook | 用途 |
@@ -91,10 +93,19 @@ export const mockAuthProvider: AuthProvider = {
 
 ```typescript
 import { createSupabaseAuthProvider } from '@svadmin/supabase';
-const authProvider = createSupabaseAuthProvider(supabaseClient);
+const authProvider = createSupabaseAuthProvider(supabaseClient, {
+  getPermissions: async ({ client }) => {
+    const { data, error } = await client
+      .from('effective_permission_grants')
+      .select('permission');
+    if (error) throw error;
+    return data.map((grant) => grant.permission);
+  },
+});
 ```
 
 `@supacloud/js` 不会改变认证流程。认证部分仍然建议继续使用官方 Supabase 客户端配合 `createSupabaseAuthProvider()`，任务相关 API 再通过 [`@svadmin/supabase/supacloud`](/zh-cn/providers/supacloud) 单独组合接入。
+不要把用户可修改的 metadata 当成授权事实。
 
 ### Appwrite
 

--- a/docs/src/content/docs/zh-cn/providers/sso.md
+++ b/docs/src/content/docs/zh-cn/providers/sso.md
@@ -65,6 +65,8 @@ interface SSOConfig {
   refreshBuffer?: number;
   /** 额外授权请求参数，例如 audience 或 prompt */
   authorizationParams?: Record<string, string>;
+  /** 可信权限 resolver，仅用于 UI hint */
+  getPermissions?: (context: SSOPermissionResolverContext) => Promise<unknown> | unknown;
 }
 ```
 
@@ -98,13 +100,21 @@ const authProvider = createSSOAuthProvider({
 });
 ```
 
-### 从 ID Token 提取权限
+### 可信权限 Resolver
 
-自动从 ID Token 的 `roles`、`groups`、`permissions` claim 中提取权限信息。
+未配置可信 resolver 时，`getPermissions()` 返回 `null`。请在 resolver 中调用应用自己的授权接口或后端控制的数据源。ID Token claims 可以作为展示提示，但不能替代 API 或数据库授权。
 
 ```typescript
-const permissions = await authProvider.getPermissions();
-// → ['admin', 'editor']（来自 ID Token claims）
+const authProvider = createSSOAuthProvider({
+  issuer: 'https://your-tenant.okta.com',
+  clientId: 'abc',
+  redirectUri: '/callback',
+  getPermissions: async ({ createAuthenticatedFetch }) => {
+    const response = await createAuthenticatedFetch()(new URL('/api/me/permissions', window.location.origin));
+    if (!response.ok) throw new Error('Failed to load permissions');
+    return response.json();
+  },
+});
 ```
 
 ### 调用受保护 API

--- a/packages/core/src/auth-hooks.svelte.ts
+++ b/packages/core/src/auth-hooks.svelte.ts
@@ -270,7 +270,9 @@ export function useOnError() {
 
 /**
  * Fetches permissions from authProvider.getPermissions().
- * Returns a reactive object with convenience methods for permission checks.
+ * Returns a reactive UI helper with convenience methods for permission checks.
+ * API routes, data providers, and database policies must enforce authorization
+ * independently; this hook only gates client-side rendering.
  * 
  * Supports `refetch()` for session-level permission refresh (e.g., after role change).
  * 

--- a/packages/core/src/permissions.feature-gate.test.svelte.ts
+++ b/packages/core/src/permissions.feature-gate.test.svelte.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { createFeatureGate } from './permissions.svelte';
+
+describe('createFeatureGate', () => {
+  it('requires exact permissions', () => {
+    const canEditPosts = createFeatureGate({
+      permissions: ['posts:edit'],
+    });
+
+    expect(canEditPosts({ role: 'admin', permissions: ['posts:edit'] })).toBe(true);
+    expect(canEditPosts({ role: 'admin', permissions: ['posts:*'] })).toBe(false);
+    expect(canEditPosts({ role: 'admin', permissions: ['*'] })).toBe(false);
+  });
+
+  it('enforces role hierarchy when provided', () => {
+    const canModerate = createFeatureGate({
+      minRole: 'editor',
+      roleHierarchy: ['admin', 'editor', 'viewer'],
+    });
+
+    expect(canModerate({ role: 'admin', permissions: [] })).toBe(true);
+    expect(canModerate({ role: 'editor', permissions: [] })).toBe(true);
+    expect(canModerate({ role: 'viewer', permissions: [] })).toBe(false);
+  });
+});

--- a/packages/core/src/permissions.svelte.ts
+++ b/packages/core/src/permissions.svelte.ts
@@ -123,7 +123,8 @@ export interface FeatureGateUser {
 
 /**
  * 创建功能门控函数 — 基于角色和权限判断用户是否可访问某功能。
- * 不预设任何角色层级，由调用方完全定义。
+ * 只做客户端 UI 门控；真实 API、数据库或 RLS 必须独立授权。
+ * 不预设任何角色层级，也不解释通配符权限。
  *
  * @example
  * ```ts
@@ -157,14 +158,7 @@ export function createFeatureGate(config: FeatureGateConfig): (user: FeatureGate
     }
 
     if (config.permissions && config.permissions.length > 0) {
-      const hasAll = config.permissions.every((permission) => {
-        if (user.permissions.includes("*")) return true;
-        if (user.permissions.includes(permission)) return true;
-        const [resource] = permission.split(":");
-        if (resource && user.permissions.includes(`${resource}:*`)) return true;
-        return false;
-      });
-      if (!hasAll) return false;
+      if (!config.permissions.every((permission) => user.permissions.includes(permission))) return false;
     }
 
     return true;

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -264,7 +264,39 @@ describe('createSSOAuthProvider', () => {
     expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBeNull();
     expect(await provider.getAccessToken()).toBe('access-123');
     expect((await provider.getSession())?.token_type).toBe('Bearer');
-    expect(await provider.getPermissions?.()).toEqual(['admin']);
+    expect(await provider.getPermissions?.()).toBeNull();
+  });
+
+  test('resolves permissions only through the configured resolver', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem(`${STORAGE_PREFIX}pkce_verifier`, 'verifier-123');
+    storage.setItem(`${STORAGE_PREFIX}state`, 'state-123');
+    installWindow('http://app.test/callback?code=code-123&state=state-123');
+
+    installFetch(() => jsonResponse({
+      access_token: 'access-123',
+      id_token: jwt({ roles: ['admin'] }),
+      refresh_token: 'refresh-123',
+      expires_in: 3600,
+      token_type: 'bearer',
+    }));
+    const provider = createSSOAuthProvider({
+      issuer: 'https://idp.test',
+      clientId: 'admin-console',
+      redirectUri: 'http://app.test/callback',
+      storage,
+      autoRefresh: false,
+      manualEndpoints,
+      getPermissions: async ({ session, getAccessToken }) => {
+        expect(session.id_token).toBeDefined();
+        expect(await getAccessToken()).toBe('access-123');
+        return ['admin', 'posts:edit'];
+      },
+    });
+
+    await provider.check();
+
+    expect(await provider.getPermissions?.()).toEqual(['admin', 'posts:edit']);
   });
 
   test('does not restore a callback session after logout cancels an in-flight exchange', async () => {

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -58,6 +58,8 @@ export interface SSOConfig {
   refreshLock?: RefreshLock;
   /** Injectable fetch implementation for testing and SSR runtimes. */
   fetcher?: typeof fetch;
+  /** Trusted permission resolver. Without one, getPermissions() returns null. */
+  getPermissions?: SSOPermissionResolver;
   /**
    * Manual OAuth2 endpoints for providers that don't support OIDC discovery
    * (e.g., GitHub). When provided, OIDC auto-discovery is skipped.
@@ -75,6 +77,16 @@ export interface TokenStorage {
   setItem: (key: string, value: string) => void;
   removeItem: (key: string) => void;
 }
+
+export interface SSOPermissionResolverContext {
+  session: SSOSession;
+  getAccessToken: (options?: GetAccessTokenOptions) => Promise<string | null>;
+  createAuthenticatedFetch: (fetcher?: typeof fetch) => typeof fetch;
+}
+
+export type SSOPermissionResolver = (
+  context: SSOPermissionResolverContext,
+) => Promise<unknown> | unknown;
 
 export interface SSOAuthProvider extends AuthProvider {
   getSession: () => Promise<SSOSession | null>;
@@ -511,6 +523,13 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     },
   };
 
+  function createProviderAuthenticatedFetch(fetcher?: typeof fetch): typeof fetch {
+    return buildAuthenticatedFetch(
+      authorizationSource,
+      fetcher ?? getFetcher(),
+    );
+  }
+
   const provider: SSOAuthProvider = {
     async login() {
       if (typeof window === 'undefined') {
@@ -713,25 +732,20 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
     },
 
     async getPermissions() {
-      const idToken = sessions.getSession()?.id_token;
-      if (!idToken) return null;
-
-      try {
-        const payload = decodeJwtPayload(idToken);
-        return payload?.roles ?? payload?.groups ?? payload?.permissions ?? null;
-      } catch {
-        return null;
-      }
+      const session = sessions.getSession();
+      if (!session || !config.getPermissions) return null;
+      return config.getPermissions({
+        session,
+        getAccessToken: (options) => sessions.getAccessToken(options),
+        createAuthenticatedFetch: createProviderAuthenticatedFetch,
+      });
     },
 
     getSession: async () => sessions.getSession(),
     refreshSession: () => sessions.refreshSession(),
     getAccessToken: (options) => sessions.getAccessToken(options),
     onAuthStateChange: (callback) => sessions.onAuthStateChange(callback),
-    createAuthenticatedFetch: (fetcher) => buildAuthenticatedFetch(
-      authorizationSource,
-      fetcher ?? getFetcher(),
-    ),
+    createAuthenticatedFetch: createProviderAuthenticatedFetch,
     destroy: () => sessions.destroy(),
 
     async onError(error) {

--- a/packages/sso/src/index.ts
+++ b/packages/sso/src/index.ts
@@ -13,6 +13,8 @@ export type {
   AuthStateChangeEvent,
   GetAccessTokenOptions,
   RefreshLock,
+  SSOPermissionResolver,
+  SSOPermissionResolverContext,
   SSOAuthProvider,
   SSOConfig,
   SSOSession,

--- a/packages/supabase/src/auth-provider.ts
+++ b/packages/supabase/src/auth-provider.ts
@@ -1,7 +1,20 @@
 // Supabase AuthProvider
-import type { SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient, User } from '@supabase/supabase-js';
 import type { AuthProvider, Identity, AuthActionResult, CheckResult } from '@svadmin/core';
 import { audit } from '@svadmin/core';
+
+export interface SupabasePermissionResolverContext {
+  client: SupabaseClient;
+  user: User;
+}
+
+export type SupabasePermissionResolver = (
+  context: SupabasePermissionResolverContext,
+) => Promise<unknown> | unknown;
+
+export interface SupabaseAuthProviderOptions {
+  getPermissions?: SupabasePermissionResolver;
+}
 
 const INVALID_REFRESH_TOKEN_MESSAGES = [
   'refresh token is not valid',
@@ -23,7 +36,20 @@ async function clearInvalidSession(client: SupabaseClient): Promise<void> {
   await client.auth.signOut({ scope: 'local' });
 }
 
-export function createSupabaseAuthProvider(client: SupabaseClient): AuthProvider {
+async function currentPermissionUser(client: SupabaseClient): Promise<User | null> {
+  const { data: { user }, error } = await client.auth.getUser();
+  if (error && isInvalidRefreshTokenError(error)) {
+    await clearInvalidSession(client);
+    return null;
+  }
+  if (error) return null;
+  return user ?? null;
+}
+
+export function createSupabaseAuthProvider(
+  client: SupabaseClient,
+  options: SupabaseAuthProviderOptions = {},
+): AuthProvider {
   return {
     async login({ email, password }: Record<string, unknown>): Promise<AuthActionResult> {
       const { data, error } = await client.auth.signInWithPassword({
@@ -90,12 +116,10 @@ export function createSupabaseAuthProvider(client: SupabaseClient): AuthProvider
     },
 
     async getPermissions(): Promise<unknown> {
-      const { data: { user }, error } = await client.auth.getUser();
-      if (error && isInvalidRefreshTokenError(error)) {
-        await clearInvalidSession(client);
-        return null;
-      }
-      return user?.user_metadata?.role ?? 'user';
+      if (!options.getPermissions) return null;
+      const user = await currentPermissionUser(client);
+      if (!user) return null;
+      return options.getPermissions({ client, user });
     },
 
     async register({ email, password, ...rest }: Record<string, unknown>): Promise<AuthActionResult> {

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -2,6 +2,11 @@
 
 export { createSupabaseDataProvider } from './data-provider';
 export { createSupabaseAuthProvider } from './auth-provider';
+export type {
+  SupabaseAuthProviderOptions,
+  SupabasePermissionResolver,
+  SupabasePermissionResolverContext,
+} from './auth-provider';
 export { createSupabaseLiveProvider } from './live-provider';
 export { createSupabaseAuditHandler } from './audit-handler';
 export {

--- a/packages/supabase/src/supabase.test.ts
+++ b/packages/supabase/src/supabase.test.ts
@@ -165,11 +165,23 @@ describe('Supabase AuthProvider', () => {
     expect(identity!.avatar).toBe('http://avatar');
   });
 
-  test('getPermissions surfaces role from user_metadata', async () => {
+  test('getPermissions fails closed without a trusted resolver', async () => {
     const { createSupabaseAuthProvider } = await import('./auth-provider');
     const auth = createSupabaseAuthProvider(createMockSupabaseClient());
-    const role = await auth.getPermissions?.();
-    expect(role).toBe('admin');
+    const permissions = await auth.getPermissions?.();
+    expect(permissions).toBeNull();
+  });
+
+  test('getPermissions uses the configured permission resolver', async () => {
+    const { createSupabaseAuthProvider } = await import('./auth-provider');
+    const client = createMockSupabaseClient();
+    const auth = createSupabaseAuthProvider(client, {
+      getPermissions: ({ user }) => user.email === 'admin@test.com'
+        ? ['admin', 'posts:edit']
+        : [],
+    });
+    const permissions = await auth.getPermissions?.();
+    expect(permissions).toEqual(['admin', 'posts:edit']);
   });
 
   test('getIdentity clears invalid refresh token sessions', async () => {


### PR DESCRIPTION
## Summary

- make Supabase and SSO `getPermissions()` fail closed unless the app provides a trusted resolver
- remove implicit permissions from user-editable Supabase metadata and SSO ID Token claims
- document `usePermissions()` / `createFeatureGate()` as UI rendering helpers, not authorization boundaries
- make `createFeatureGate()` require exact permission strings and add Svelte/Vitest coverage

## Validation

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run lint`
- `git diff --check`
- `NPM_CONFIG_CACHE=/tmp/svadmin-pr-bqxCkt/npm-cache bun run pack:check`

## Notes

- This is a breaking authorization hardening change.
- API routes, data providers, and database/RLS policies must still enforce authorization independently.
- Custom menu and direct resource-route access-control guards remain a separate UI hardening follow-up.
