### PR TITLE
fix(auth): stop treating client claims as permissions

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -10,6 +10,7 @@ interface AuthProvider {
   logout: (params?: Record<string, unknown>) => Promise<AuthActionResult>;
   check: (params?: Record<string, unknown>) => Promise<CheckResult>;
   getIdentity: () => Promise<Identity | null>;
+  // UI-only hints; API, RLS, and action handlers must authorize independently.
   getPermissions?: (params?: Record<string, unknown>) => Promise<unknown>;
   register?: (params: Record<string, unknown>) => Promise<AuthActionResult>;
   forgotPassword?: (params: Record<string, unknown>) => Promise<AuthActionResult>;
@@ -84,9 +85,13 @@ mutate(error); // Calls authProvider.onError → may redirect or logout
 ### `usePermissions()`
 
 ```typescript
-const { data, isLoading, error } = usePermissions<string[]>();
-// data: whatever authProvider.getPermissions() returns
+const permissionHints = usePermissions<string[]>();
+// UI only: whatever a custom authProvider.getPermissions() returns
 ```
+
+The built-in Supabase and SSO providers deliberately do not implement `getPermissions()`.
+If an application supplies it, its value may change labels, navigation, or disabled controls
+only. API, RLS, and action handlers must independently authenticate and authorize every request.
 
 ## Auth Pages
 

--- a/docs/src/content/docs/hooks/auth.md
+++ b/docs/src/content/docs/hooks/auth.md
@@ -37,17 +37,20 @@ const { isAuthenticated, isLoading } = useIsAuthenticated();
 ### `usePermissions<T>()`
 
 ```typescript
-const { raw, has, can, isLoading, refetch } = usePermissions<string[]>();
+const permissionHints = usePermissions<string[]>();
 
-// Check specific permission
-if (has('admin')) { /* ... */ }
+// Change navigation or a disabled control from a UI hint.
+if (permissionHints.has('admin')) { /* ... */ }
 
-// Check resource:action permission
-if (can('posts', 'edit')) { /* ... */ }
+// Read a UI hint using the resource:action naming convention.
+if (permissionHints.can('posts', 'edit')) { /* ... */ }
 
-// Session-level refresh (e.g. after role upgrade)
-await refetch();
+await permissionHints.refetch();
 ```
+
+The built-in Supabase and SSO providers leave `getPermissions()` undefined. A custom
+implementation can supply UI hints only; do not use these browser-visible values as an API,
+RLS, or action authorization decision. The backend must authenticate and authorize every request.
 
 ### `useOnError()`
 

--- a/docs/src/content/docs/providers/auth.md
+++ b/docs/src/content/docs/providers/auth.md
@@ -13,6 +13,7 @@ interface AuthProvider {
   logout: (params?: Record<string, unknown>) => Promise<AuthActionResult>;
   check: (params?: Record<string, unknown>) => Promise<CheckResult>;
   getIdentity: () => Promise<Identity | null>;
+  // UI-only hints; API, RLS, and action handlers must authorize independently.
   getPermissions?: (params?: Record<string, unknown>) => Promise<unknown>;
   register?: (params: Record<string, unknown>) => Promise<AuthActionResult>;
   forgotPassword?: (params: Record<string, unknown>) => Promise<AuthActionResult>;
@@ -33,7 +34,7 @@ interface AuthProvider {
 | `useGetIdentity()` | Get current user info |
 | `useIsAuthenticated()` | Check auth status |
 | `useOnError()` | Handle API errors (401→logout) |
-| `usePermissions()` | Get user permissions |
+| `usePermissions()` | Get UI-only permission hints |
 
 ### Usage
 
@@ -41,6 +42,10 @@ interface AuthProvider {
 const { mutate: login, isPending } = useLogin();
 await login({ email: 'user@example.com', password: 'secret' });
 ```
+
+The built-in Supabase and SSO providers intentionally leave `getPermissions()` undefined.
+An application may add it for labels, navigation, or disabled controls, but browser-visible
+values never authorize API, RLS, or action requests; the backend must enforce those separately.
 
 ## Auth Pages
 

--- a/docs/src/content/docs/providers/sso.md
+++ b/docs/src/content/docs/providers/sso.md
@@ -114,14 +114,13 @@ const authProvider = createSSOAuthProvider({
 });
 ```
 
-### Permissions from ID Token
+### Permission Hints
 
-The provider automatically extracts `roles`, `groups`, or `permissions` claims from the ID token via `getPermissions()`.
-
-```typescript
-const permissions = await authProvider.getPermissions();
-// → ['admin', 'editor'] (from ID token claims)
-```
+The default SSO provider intentionally does not implement `getPermissions()` or turn ID-token
+`roles`, `groups`, or `permissions` claims into browser permissions. If an application adds a
+custom `getPermissions()` implementation, its result is a UI hint for labels, navigation, or
+disabled controls only. API endpoints must independently validate the token and enforce
+authorization; this hook is not an API, RLS, or action authorization boundary.
 
 ### Calling Protected APIs
 

--- a/docs/src/content/docs/zh-cn/hooks/auth.md
+++ b/docs/src/content/docs/zh-cn/hooks/auth.md
@@ -37,17 +37,19 @@ const { isAuthenticated, isLoading } = useIsAuthenticated();
 ### `usePermissions<T>()`
 
 ```typescript
-const { raw, has, can, isLoading, refetch } = usePermissions<string[]>();
+const permissionHints = usePermissions<string[]>();
 
-// 检查特定权限
-if (has('admin')) { /* ... */ }
+// 使用 UI 提示调整导航或禁用控件。
+if (permissionHints.has('admin')) { /* ... */ }
 
-// 检查资源:操作权限
-if (can('posts', 'edit')) { /* ... */ }
+// 使用 resource:action 命名读取 UI 提示。
+if (permissionHints.can('posts', 'edit')) { /* ... */ }
 
-// 重新获取权限（比如角色升级后）
-await refetch();
+await permissionHints.refetch();
 ```
+
+内置 Supabase 与 SSO Provider 不提供 `getPermissions()`。自定义实现只能返回 UI 提示，绝不能
+将浏览器中的值作为 API、RLS 或动作授权决定；后端必须认证并授权每一个请求。
 
 ### `useOnError()`
 

--- a/docs/src/content/docs/zh-cn/providers/auth.md
+++ b/docs/src/content/docs/zh-cn/providers/auth.md
@@ -13,6 +13,7 @@ interface AuthProvider {
   logout: (params?: Record<string, unknown>) => Promise<AuthActionResult>;
   check: (params?: Record<string, unknown>) => Promise<CheckResult>;
   getIdentity: () => Promise<Identity | null>;
+  // 仅限 UI 提示；API、RLS 和动作处理器必须独立授权。
   getPermissions?: (params?: Record<string, unknown>) => Promise<unknown>;
   register?: (params: Record<string, unknown>) => Promise<AuthActionResult>;
   forgotPassword?: (params: Record<string, unknown>) => Promise<AuthActionResult>;
@@ -33,7 +34,7 @@ interface AuthProvider {
 | `useGetIdentity()` | 获取当前用户信息 |
 | `useIsAuthenticated()` | 检查认证状态 |
 | `useOnError()` | 处理 API 错误（401→登出） |
-| `usePermissions()` | 获取用户权限 |
+| `usePermissions()` | 获取仅限 UI 的权限提示 |
 
 ### 用法
 
@@ -41,6 +42,9 @@ interface AuthProvider {
 const { mutate: login, isPending } = useLogin();
 await login({ email: 'user@example.com', password: 'secret' });
 ```
+
+内置 Supabase 与 SSO Provider 有意不实现 `getPermissions()`。应用可自行提供它来调整标签、
+导航或禁用控件，但浏览器中的值绝不能授权 API、RLS 或动作请求；后端必须独立强制授权。
 
 ## 认证页面
 

--- a/docs/src/content/docs/zh-cn/providers/sso.md
+++ b/docs/src/content/docs/zh-cn/providers/sso.md
@@ -98,14 +98,12 @@ const authProvider = createSSOAuthProvider({
 });
 ```
 
-### 从 ID Token 提取权限
+### 权限提示
 
-自动从 ID Token 的 `roles`、`groups`、`permissions` claim 中提取权限信息。
-
-```typescript
-const permissions = await authProvider.getPermissions();
-// → ['admin', 'editor']（来自 ID Token claims）
-```
+默认 SSO Provider 有意不实现 `getPermissions()`，也不会把 ID Token 的 `roles`、`groups`
+或 `permissions` claim 转化为浏览器权限。应用如自行实现 `getPermissions()`，其结果也只能
+用于标签、导航或禁用控件等 UI 提示。API 端点必须独立验证令牌并强制授权；该 hook 不是 API、
+RLS 或动作授权边界。
 
 ### 调用受保护 API
 

--- a/packages/core/src/auth-hooks.svelte.ts
+++ b/packages/core/src/auth-hooks.svelte.ts
@@ -269,19 +269,10 @@ export function useOnError() {
 // ─── usePermissions ──────────────────────────────────────────
 
 /**
- * Fetches permissions from authProvider.getPermissions().
- * Returns a reactive object with convenience methods for permission checks.
- * 
- * Supports `refetch()` for session-level permission refresh (e.g., after role change).
- * 
- * @example
- * ```svelte
- * <script>
- *   import { usePermissions } from '@svadmin/core';
- *   const perms = usePermissions();
- *   const canAdmin = $derived(perms.has('admin'));
- * </script>
- * ```
+ * Fetches UI-only hints from authProvider.getPermissions().
+ * The result can change labels, navigation, and disabled controls, but it runs in
+ * the browser and never authorizes API, RLS, or action requests. Those requests
+ * must be independently authenticated and authorized by the backend.
  */
 export function usePermissions<T = unknown>() {
   const adminContext = captureAdminContext();

--- a/packages/core/src/permissions.svelte.ts
+++ b/packages/core/src/permissions.svelte.ts
@@ -20,8 +20,9 @@ export interface CanResult {
 
 
 /**
- * Formal Access Control Provider interface.
- * Implement this to define your authorization logic.
+ * UI access-control integration point.
+ * It can mirror a backend policy decision for navigation and controls, but browser
+ * checks never authorize an API request. The backend must enforce the same policy.
  *
  * @example
  * ```ts
@@ -78,8 +79,8 @@ export function getAccessControlOptions() {
 }
 
 /**
- * Async access check. 
- * Supports both single capability requests or an array of batched checks.
+ * UI access check supporting single capabilities or a batch.
+ * Its result can change browser presentation but never authorizes the backend action.
  */
 export async function canAccessAsync(params: CanParams[]): Promise<CanResult[]>;
 export async function canAccessAsync(resource: string, action: Action, params?: Record<string, unknown>, meta?: Record<string, unknown>): Promise<CanResult>;
@@ -100,7 +101,7 @@ export async function canAccessAsync(resourceOrBatch: string | CanParams[], acti
 // ─── Feature Gate ─────────────────────────────────────────────
 
 export interface FeatureGateConfig {
-  /** 允许访问的角色列表 */
+  /** 仅用于前端展示的角色列表。 */
   roles?: string[];
   /**
    * 需要的最低角色 (含以上所有角色)。
@@ -112,17 +113,19 @@ export interface FeatureGateConfig {
    * 由调用方按自身业务定义，框架不预设任何角色。
    */
   roleHierarchy?: string[];
-  /** 需要的权限列表 (全部匹配) */
+  /** 仅用于前端展示的权限列表 (全部匹配)。 */
   permissions?: string[];
 }
 
+/** 浏览器中的角色和权限提示，不是授权凭据。 */
 export interface FeatureGateUser {
   role: string;
   permissions: string[];
 }
 
 /**
- * 创建功能门控函数 — 基于角色和权限判断用户是否可访问某功能。
+ * 创建仅用于前端展示的功能门控函数。
+ * 输入可被篡改；后端必须独立完成令牌验证和操作授权。
  * 不预设任何角色层级，由调用方完全定义。
  *
  * @example

--- a/packages/core/src/permissions.test.svelte.ts
+++ b/packages/core/src/permissions.test.svelte.ts
@@ -1,5 +1,15 @@
-import { describe, test, expect } from 'bun:test';
-import type { CanParams, CanResult, AccessControlProvider } from './permissions.svelte';
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+  canAccessAsync,
+  createFeatureGate,
+  resetAccessControlProvider,
+  setAccessControlProvider,
+  type AccessControlProvider,
+  type CanParams,
+  type CanResult,
+} from './permissions.svelte';
+
+afterEach(resetAccessControlProvider);
 
 describe('permissions', () => {
   test('canAccessAsync respects deny rule', async () => {
@@ -110,6 +120,19 @@ describe('permissions', () => {
       can: async () => ({ can: true }),
     };
     expect(provider.options).toBeUndefined();
+  });
+
+  test('a forged feature-gate hint cannot override a configured access-control decision', async () => {
+    const showAdminNavigation = createFeatureGate({ roles: ['admin'] });
+    setAccessControlProvider({
+      can: async () => ({ can: false, reason: 'Configured policy denied this action' }),
+    });
+
+    expect(showAdminNavigation({ role: 'admin', permissions: ['*'] })).toBe(true);
+    expect(await canAccessAsync('users', 'delete')).toEqual({
+      can: false,
+      reason: 'Configured policy denied this action',
+    });
   });
 });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -334,6 +334,11 @@ export interface AuthProvider {
   logout: (params?: Record<string, unknown>) => Promise<AuthActionResult>;
   check: (params?: Record<string, unknown>) => Promise<CheckResult>;
   getIdentity: () => Promise<Identity | null>;
+  /**
+   * Returns UI-only permission hints for labels, navigation, or disabled controls.
+   * Browser-visible values are not authorization evidence: API, RLS, and action
+   * handlers must authenticate and authorize the request independently.
+   */
   getPermissions?: (params?: Record<string, unknown>) => Promise<unknown>;
   register?: (params: Record<string, unknown>) => Promise<AuthActionResult>;
   forgotPassword?: (params: Record<string, unknown>) => Promise<AuthActionResult>;

--- a/packages/sso/src/auth-provider.test.ts
+++ b/packages/sso/src/auth-provider.test.ts
@@ -234,7 +234,11 @@ describe('createSSOAuthProvider', () => {
 
     const calls = installFetch((_url, _init) => jsonResponse({
       access_token: 'access-123',
-      id_token: jwt({ roles: ['admin'] }),
+      id_token: jwt({
+        roles: ['admin'],
+        groups: ['administrators'],
+        permissions: ['users:delete'],
+      }),
       refresh_token: 'refresh-123',
       expires_in: 3600,
       token_type: 'bearer',
@@ -264,7 +268,7 @@ describe('createSSOAuthProvider', () => {
     expect(storage.getItem(`${STORAGE_PREFIX}state`)).toBeNull();
     expect(await provider.getAccessToken()).toBe('access-123');
     expect((await provider.getSession())?.token_type).toBe('Bearer');
-    expect(await provider.getPermissions?.()).toEqual(['admin']);
+    expect(provider.getPermissions).toBeUndefined();
   });
 
   test('does not restore a callback session after logout cancels an in-flight exchange', async () => {

--- a/packages/sso/src/auth-provider.ts
+++ b/packages/sso/src/auth-provider.ts
@@ -712,18 +712,6 @@ export function createSSOAuthProvider(config: SSOConfig): SSOAuthProvider {
       }
     },
 
-    async getPermissions() {
-      const idToken = sessions.getSession()?.id_token;
-      if (!idToken) return null;
-
-      try {
-        const payload = decodeJwtPayload(idToken);
-        return payload?.roles ?? payload?.groups ?? payload?.permissions ?? null;
-      } catch {
-        return null;
-      }
-    },
-
     getSession: async () => sessions.getSession(),
     refreshSession: () => sessions.refreshSession(),
     getAccessToken: (options) => sessions.getAccessToken(options),

--- a/packages/supabase/src/auth-provider.ts
+++ b/packages/supabase/src/auth-provider.ts
@@ -89,15 +89,6 @@ export function createSupabaseAuthProvider(client: SupabaseClient): AuthProvider
       };
     },
 
-    async getPermissions(): Promise<unknown> {
-      const { data: { user }, error } = await client.auth.getUser();
-      if (error && isInvalidRefreshTokenError(error)) {
-        await clearInvalidSession(client);
-        return null;
-      }
-      return user?.user_metadata?.role ?? 'user';
-    },
-
     async register({ email, password, ...rest }: Record<string, unknown>): Promise<AuthActionResult> {
       const { error } = await client.auth.signUp({
         email: email as string,

--- a/packages/supabase/src/supabase.test.ts
+++ b/packages/supabase/src/supabase.test.ts
@@ -165,11 +165,10 @@ describe('Supabase AuthProvider', () => {
     expect(identity!.avatar).toBe('http://avatar');
   });
 
-  test('getPermissions surfaces role from user_metadata', async () => {
+  test('user metadata cannot provide permissions', async () => {
     const { createSupabaseAuthProvider } = await import('./auth-provider');
     const auth = createSupabaseAuthProvider(createMockSupabaseClient());
-    const role = await auth.getPermissions?.();
-    expect(role).toBe('admin');
+    expect(auth.getPermissions).toBeUndefined();
   });
 
   test('getIdentity clears invalid refresh token sessions', async () => {


### PR DESCRIPTION
## Summary
- Stop the Supabase and SSO defaults from treating browser-visible claims as permissions.
- Define getPermissions, feature gates, and client access checks as UI-only presentation helpers.
- Cover forged UI hints and run the permissions suite through Svelte/Vitest.

## Validation
- bun run test
- bun run typecheck
- bun run lint
- bun run build:packages
- bun run docs:build
- git diff --check