### PR TITLE
fix(ui): give the default button variant a hover state on <button> elements

### DIFF
--- a/packages/ui/src/components/ui/button/button.svelte
+++ b/packages/ui/src/components/ui/button/button.svelte
@@ -7,7 +7,7 @@
 		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
-				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+				default: "bg-primary text-primary-foreground hover:bg-primary/80",
 				outline: "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
 				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
 				ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",

--- a/packages/ui/src/components/ui/button/button.test.ts
+++ b/packages/ui/src/components/ui/button/button.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { buttonVariants } from './button.svelte';
+
+describe('buttonVariants', () => {
+	it('applies the default-variant hover state to real <button> elements, not only anchors', () => {
+		const classes = buttonVariants({ variant: 'default' });
+
+		// 组件默认渲染 <button>，hover 反馈不能只对 <a> 生效（badge 的 [a]: 模式不适用于 button）。
+		expect(classes).toContain('hover:bg-primary/80');
+		expect(classes).not.toContain('[a]:hover:bg-primary/80');
+	});
+
+	it('keeps anchor-only hover scoping out of every button variant', () => {
+		for (const variant of ['default', 'outline', 'secondary', 'ghost', 'destructive', 'link'] as const) {
+			expect(buttonVariants({ variant })).not.toMatch(/\[a\]:/);
+		}
+	});
+});


### PR DESCRIPTION
## 问题

`buttonVariants` 的 default 变体使用了 badge 的锚点作用域写法 `[a]:hover:bg-primary/80`。Button 组件默认渲染为原生 `<button>`，该选择器编译后为 `.[a]:hover:bg-primary/80:is(a):hover`，只对 `<a>` 生效——**普通按钮的 primary 变体没有任何 hover 反馈**，只有 `<Button href>` 渲染的锚点按钮才有。

同文件内 outline / secondary / ghost / destructive / link 变体的 hover 均不带 `[a]:` 作用域，badge.svelte 的 `[a]:` 模式（非锚点渲染为静态 span，只需给链接态 hover）不适用于 button，应为移植时的笔误。

## 修复

`[a]:hover:bg-primary/80` → `hover:bg-primary/80`，与其余变体保持一致。

## 验证

- 新增 `button.test.ts`：断言 default 变体含 `hover:bg-primary/80` 且所有变体不含 `[a]:` 作用域；`packages/ui` vitest 43/43 通过。
- 端到端：在下游消费方（xigu-fa）构建产物中，修复后生成 `.hover\:bg-primary\/80:hover`（对 `<button>` 生效），修复前仅有 `:is(a):hover` 规则；badge 的 `[a]:` 规则保持不变。