### PR TITLE
fix(refine-adapter): map current pagination to currentPage

### DIFF
--- a/packages/refine-adapter/src/index.test.ts
+++ b/packages/refine-adapter/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
+import type { GetListParams } from '@svadmin/core';
 import { createRefineAdapter } from './index';
+
+type RefineGetListParams = Omit<GetListParams, 'pagination'> & {
+  pagination?: NonNullable<GetListParams['pagination']> & { currentPage?: number };
+};
 
 function createMockRefineProvider() {
   const provider = {
@@ -34,6 +39,28 @@ function createMockRefineProvider() {
 }
 
 describe('createRefineAdapter', () => {
+  test('maps svadmin current pagination to Refine currentPage', async () => {
+    let receivedParams: RefineGetListParams | undefined;
+    const refineProvider = {
+      ...createMockRefineProvider(),
+      async getList(params: RefineGetListParams) {
+        receivedParams = params;
+        return { data: [], total: 0 };
+      },
+    };
+    const adapter = createRefineAdapter(refineProvider);
+
+    await adapter.getList({
+      resource: 'posts',
+      pagination: { current: 2, pageSize: 25, mode: 'server' },
+    });
+
+    expect(receivedParams).toEqual({
+      resource: 'posts',
+      pagination: { current: 2, currentPage: 2, pageSize: 25, mode: 'server' },
+    });
+  });
+
   test('binds required and optional Refine data provider methods', async () => {
     const adapter = createRefineAdapter(createMockRefineProvider());
 

--- a/packages/refine-adapter/src/index.ts
+++ b/packages/refine-adapter/src/index.ts
@@ -45,15 +45,20 @@ function assertRefineDataProvider(value: unknown): asserts value is RefineDataPr
 
 /**
  * Adapter to consume an official @refinedev/* data provider in SvelteAdmin.
- * Refine's DataProvider interface directly matches the core interface 
- * definition of @svadmin/core.
+ * Refine's DataProvider interface mostly matches the core interface
+ * definition of @svadmin/core, except for the current page property.
  */
 export function createRefineAdapter(refineProvider: unknown): SvadminDataProvider {
   assertRefineDataProvider(refineProvider);
 
   const adapter: SvadminDataProvider = {
     getApiUrl: () => refineProvider.getApiUrl?.() ?? '',
-    getList: refineProvider.getList.bind(refineProvider),
+    getList(params) {
+      const pagination = params.pagination?.current === undefined
+        ? params.pagination
+        : { ...params.pagination, currentPage: params.pagination.current };
+      return refineProvider.getList({ ...params, pagination });
+    },
     getOne: refineProvider.getOne.bind(refineProvider),
     create: refineProvider.create.bind(refineProvider),
     update: refineProvider.update.bind(refineProvider),


### PR DESCRIPTION
## Summary

- map svadmin core pagination.current to the Refine currentPage field at the shared refine-adapter seam
- preserve pagination.current and all other request fields for backward compatibility
- add a regression test that proves requesting page 2 reaches the underlying Refine provider as currentPage: 2

## Problem

@svadmin/core sends pagination.current. Official Refine data providers consume pagination.currentPage, so page 2 was silently interpreted as page 1. HiCigar currently carries a local workaround in apps/admin/src/lib/data-provider-compat.ts; a published upstream fix will allow that workaround to be removed.

## TDD evidence

Before the implementation, the new regression test failed because the underlying provider received current: 2 without currentPage: 2. After the minimal adapter mapping:

- refine-adapter test: 6 passed, 0 failed
- package build: passed
- full repository tests: 548 Bun tests passed plus all Vitest suites passed
- bun run check: 0 errors, 0 warnings
- bun run lint: passed
- independent real-provider probe: page 2 generated _start=25&_end=50

## Scope

This PR intentionally excludes release dependency closure and release workflow changes. Those will be proposed separately.