### PR TITLE
fix(release): verify workspace dependency closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,18 @@ jobs:
       - name: Build publishable packages
         run: bun run build:packages
 
+      - name: Verify dependency closure and plan publication
+        id: release_plan
+        env:
+          RELEASE_MANIFEST: ${{ inputs.release_manifest }}
+        run: |
+          set -euo pipefail
+          {
+            echo 'paths<<SVADMIN_RELEASE_PATHS'
+            bun scripts/plan-release-publication.ts
+            echo 'SVADMIN_RELEASE_PATHS'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Prepare publish manifests
         run: |
           set -e
@@ -188,7 +200,7 @@ jobs:
             const raw = fs.readFileSync(pjson, 'utf8');
             const pkg = JSON.parse(raw);
             let changed = false;
-            for (const t of ['dependencies', 'devDependencies', 'peerDependencies']) {
+            for (const t of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
               if (pkg[t]) {
                 for (const k in pkg[t]) {
                   if (pkg[t][k] === 'workspace:*' && versions[k]) {
@@ -210,48 +222,39 @@ jobs:
 
       - name: Publish released packages
         env:
-          RELEASE_MANIFEST: ${{ inputs.release_manifest }}
+          RELEASE_DIRS: ${{ steps.release_plan.outputs.paths }}
         run: |
           set -e
-          PUBLISH_FAILED=0
-          RELEASE_DIRS=$(node <<'NODE'
-          const releases = JSON.parse(process.env.RELEASE_MANIFEST || '[]');
-          if (!Array.isArray(releases) || releases.length === 0) {
-            throw new Error('release-please returned no release manifest');
-          }
-          for (const release of releases) {
-            const packagePath = release?.path;
-            if (typeof packagePath !== 'string' || !/^packages\/[^/]+$/.test(packagePath)) {
-              throw new Error(`Invalid release package path: ${String(packagePath)}`);
-            }
-            console.log(`${packagePath}/`);
-          }
-          NODE
-          )
+          if [ -z "$RELEASE_DIRS" ]; then
+            echo "::error::Release publication plan is empty"
+            exit 1
+          fi
 
           while IFS= read -r pkg_dir; do
             PKG_JSON="$pkg_dir/package.json"
             if [ -f "$PKG_JSON" ]; then
-              NAME=$(node -p "require('./$PKG_JSON').name")
-              LOCAL_VER=$(node -p "require('./$PKG_JSON').version")
-              NPM_EXISTS=$(npm view "$NAME@$LOCAL_VER" version 2>/dev/null || echo "")
+              NAME=$(node -p "require(process.argv[1]).name" "./$PKG_JSON")
+              LOCAL_VER=$(node -p "require(process.argv[1]).version" "./$PKG_JSON")
 
-              if [ -z "$NPM_EXISTS" ]; then
+              if ! NPM_STATUS=$(bun scripts/npm-package-version.ts "$NAME" "$LOCAL_VER"); then
+                echo "::error::npm registry lookup failed for $NAME@$LOCAL_VER"
+                exit 1
+              fi
+
+              if [ "$NPM_STATUS" = "missing" ]; then
                 echo "🚀 Publishing $NAME@$LOCAL_VER..."
                 if ! (cd "$pkg_dir" && npm publish --provenance --access public); then
                   echo "❌ Publish FAILED for $NAME"
-                  PUBLISH_FAILED=1
+                  exit 1
                 fi
-              else
+              elif [ "$NPM_STATUS" = "published" ]; then
                 echo "⏭️ $NAME@$LOCAL_VER already on npm, skipping"
+              else
+                echo "::error::Invalid npm registry status for $NAME@$LOCAL_VER: $NPM_STATUS"
+                exit 1
               fi
             else
               echo "::error::Release package manifest not found: $PKG_JSON"
-              PUBLISH_FAILED=1
+              exit 1
             fi
           done <<< "$RELEASE_DIRS"
-
-          if [ "$PUBLISH_FAILED" -eq 1 ]; then
-            echo "::error::One or more packages failed to publish"
-            exit 1
-          fi

--- a/scripts/npm-package-version.test.ts
+++ b/scripts/npm-package-version.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { npmPackageVersionStatus } from './npm-package-version';
+
+const packageVersion = {
+  name: '@svadmin/refine-adapter',
+  version: '0.10.0',
+};
+
+describe('npm package version status', () => {
+  test('accepts only the exact published version', () => {
+    expect(
+      npmPackageVersionStatus({
+        ...packageVersion,
+        runNpmView: () => ({ status: 0, stdout: '0.10.0\n', stderr: '' }),
+      }),
+    ).toBe('published');
+
+    expect(() =>
+      npmPackageVersionStatus({
+        ...packageVersion,
+        runNpmView: () => ({ status: 0, stdout: '0.9.4\n', stderr: '' }),
+      }),
+    ).toThrow('npm returned 0.9.4 for @svadmin/refine-adapter, expected 0.10.0');
+  });
+
+  test('treats only an explicit E404 as missing', () => {
+    expect(
+      npmPackageVersionStatus({
+        ...packageVersion,
+        runNpmView: () => ({ status: 1, stdout: '', stderr: 'npm error code E404' }),
+      }),
+    ).toBe('missing');
+
+    expect(() =>
+      npmPackageVersionStatus({
+        ...packageVersion,
+        runNpmView: () => ({ status: 1, stdout: '', stderr: 'npm error code ECONNRESET' }),
+      }),
+    ).toThrow('npm registry lookup failed for @svadmin/refine-adapter@0.10.0 (exit 1)');
+  });
+
+  test('fails closed when the registry command times out', () => {
+    expect(() =>
+      npmPackageVersionStatus({
+        ...packageVersion,
+        runNpmView: () => ({
+          status: null,
+          stdout: '',
+          stderr: '',
+          error: new Error('ETIMEDOUT'),
+        }),
+      }),
+    ).toThrow('npm registry lookup could not start for @svadmin/refine-adapter@0.10.0');
+  });
+});

--- a/scripts/npm-package-version.ts
+++ b/scripts/npm-package-version.ts
@@ -1,0 +1,66 @@
+import { spawnSync } from 'node:child_process';
+
+export type NpmPackageVersionStatus = 'published' | 'missing';
+
+interface NpmViewCommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+interface NpmPackageVersionStatusOptions {
+  name: string;
+  version: string;
+  runNpmView?: (name: string, version: string) => NpmViewCommandResult;
+}
+
+function runNpmView(name: string, version: string): NpmViewCommandResult {
+  const commandResult = spawnSync('npm', ['view', `${name}@${version}`, 'version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 30_000,
+  });
+  return {
+    status: commandResult.status,
+    stdout: commandResult.stdout,
+    stderr: commandResult.stderr,
+    error: commandResult.error,
+  };
+}
+
+export function npmPackageVersionStatus({
+  name,
+  version,
+  runNpmView: executeNpmView = runNpmView,
+}: NpmPackageVersionStatusOptions): NpmPackageVersionStatus {
+  const commandResult = executeNpmView(name, version);
+  if (commandResult.error) {
+    throw new Error(`npm registry lookup could not start for ${name}@${version}`, {
+      cause: commandResult.error,
+    });
+  }
+  if (commandResult.status === 0) {
+    const publishedVersion = commandResult.stdout.trim();
+    if (publishedVersion !== version) {
+      throw new Error(`npm returned ${publishedVersion || 'no version'} for ${name}, expected ${version}`);
+    }
+    return 'published';
+  }
+  if (/\bE404\b/.test(commandResult.stderr)) return 'missing';
+  throw new Error(`npm registry lookup failed for ${name}@${version} (exit ${String(commandResult.status)})`);
+}
+
+if (import.meta.main) {
+  try {
+    const name = process.argv[2];
+    const version = process.argv[3];
+    if (!name || !version) {
+      throw new Error('Usage: bun scripts/npm-package-version.ts <package-name> <version>');
+    }
+    console.info(npmPackageVersionStatus({ name, version }));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/plan-release-publication.ts
+++ b/scripts/plan-release-publication.ts
@@ -1,0 +1,283 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { isReleasePackagePath } from './verify-release-manifest';
+import { npmPackageVersionStatus } from './npm-package-version';
+
+interface PackageManifest {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+interface WorkspacePackage {
+  path: string;
+  manifest: PackageManifest;
+}
+
+interface WorkspaceIndex {
+  packagesByPath: Map<string, WorkspacePackage>;
+  packagesByName: Map<string, WorkspacePackage>;
+}
+
+interface PlanReleasePublicationOptions {
+  repositoryRoot: string;
+  releaseManifest: string;
+  isPackageVersionPublished?: (name: string, version: string) => boolean;
+}
+
+interface DependencyClosureContext {
+  releasePathSet: Set<string>;
+  packagesByName: Map<string, WorkspacePackage>;
+  isPackageVersionPublished: (name: string, version: string) => boolean;
+  publicationLookups: Map<string, boolean>;
+}
+
+const dependencySections = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+
+function readPackageManifest(path: string): PackageManifest {
+  const parsedManifest: unknown = JSON.parse(readFileSync(path, 'utf8'));
+  if (!parsedManifest || typeof parsedManifest !== 'object' || Array.isArray(parsedManifest)) {
+    throw new Error(`Expected a package manifest object in ${path}`);
+  }
+
+  const manifest = parsedManifest as Partial<PackageManifest>;
+  if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+    throw new Error(`Package manifest has no valid name: ${path}`);
+  }
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    throw new Error(`Package manifest has no valid version: ${path}`);
+  }
+  return manifest as PackageManifest;
+}
+
+function discoverWorkspacePackages(repositoryRoot: string): WorkspacePackage[] {
+  const packagesDirectory = resolve(repositoryRoot, 'packages');
+  if (!existsSync(packagesDirectory)) {
+    throw new Error(`Workspace packages directory does not exist: ${packagesDirectory}`);
+  }
+
+  return readdirSync(packagesDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => {
+      const packagePath = `packages/${entry.name}`;
+      const manifestPath = join(packagesDirectory, entry.name, 'package.json');
+      return existsSync(manifestPath)
+        ? [{ path: packagePath, manifest: readPackageManifest(manifestPath) }]
+        : [];
+    });
+}
+
+function releasePathFromManifestEntry(manifestEntry: unknown): string {
+  const packagePath =
+    manifestEntry && typeof manifestEntry === 'object' && !Array.isArray(manifestEntry)
+      ? (manifestEntry as Record<string, unknown>).path
+      : undefined;
+  if (!isReleasePackagePath(packagePath)) {
+    throw new Error(`Invalid release package path: ${String(packagePath)}`);
+  }
+  return packagePath;
+}
+
+function parseReleasePaths(releaseManifest: string): string[] {
+  const parsedManifest: unknown = JSON.parse(releaseManifest || '[]');
+  if (!Array.isArray(parsedManifest) || parsedManifest.length === 0) {
+    throw new Error('release-please returned no release manifest');
+  }
+
+  const releasePaths: string[] = [];
+  const seenPaths = new Set<string>();
+  for (const manifestEntry of parsedManifest) {
+    const packagePath = releasePathFromManifestEntry(manifestEntry);
+    if (seenPaths.has(packagePath)) {
+      throw new Error(`Duplicate release package path: ${packagePath}`);
+    }
+    seenPaths.add(packagePath);
+    releasePaths.push(packagePath);
+  }
+  return releasePaths;
+}
+
+function defaultIsPackageVersionPublished(name: string, version: string): boolean {
+  return npmPackageVersionStatus({ name, version }) === 'published';
+}
+
+function dependencyEntries(
+  manifest: PackageManifest,
+  section: (typeof dependencySections)[number],
+): Array<[string, string]> {
+  const dependencies: unknown = manifest[section];
+  if (dependencies === undefined) return [];
+  if (!dependencies || typeof dependencies !== 'object' || Array.isArray(dependencies)) {
+    throw new Error(`${manifest.name} has an invalid ${section} section`);
+  }
+  return Object.entries(dependencies).map(([name, version]) => {
+    if (typeof version !== 'string') {
+      throw new Error(`${manifest.name} has an invalid ${section} version for ${name}`);
+    }
+    return [name, version];
+  });
+}
+
+function workspaceDependencyNames(manifest: PackageManifest): string[] {
+  const names = new Set<string>();
+  for (const section of dependencySections) {
+    for (const [name, version] of dependencyEntries(manifest, section)) {
+      if (version.startsWith('workspace:')) {
+        names.add(name);
+      }
+    }
+  }
+  return [...names];
+}
+
+function indexWorkspacePackages(workspacePackages: WorkspacePackage[]): WorkspaceIndex {
+  const packagesByPath = new Map<string, WorkspacePackage>();
+  const packagesByName = new Map<string, WorkspacePackage>();
+  for (const workspacePackage of workspacePackages) {
+    const existingPackage = packagesByName.get(workspacePackage.manifest.name);
+    if (existingPackage) {
+      throw new Error(
+        `Duplicate workspace package name ${workspacePackage.manifest.name}: ${existingPackage.path}, ${workspacePackage.path}`,
+      );
+    }
+    packagesByPath.set(workspacePackage.path, workspacePackage);
+    packagesByName.set(workspacePackage.manifest.name, workspacePackage);
+  }
+  return { packagesByPath, packagesByName };
+}
+
+function assertDependencyPublished(
+  releasePackage: WorkspacePackage,
+  dependencyPackage: WorkspacePackage,
+  context: DependencyClosureContext,
+): void {
+  const lookupKey = `${dependencyPackage.manifest.name}@${dependencyPackage.manifest.version}`;
+  let isPublished = context.publicationLookups.get(lookupKey);
+  if (isPublished === undefined) {
+    isPublished = context.isPackageVersionPublished(
+      dependencyPackage.manifest.name,
+      dependencyPackage.manifest.version,
+    );
+    context.publicationLookups.set(lookupKey, isPublished);
+  }
+  if (!isPublished) {
+    throw new Error(
+      `${releasePackage.manifest.name}@${releasePackage.manifest.version} depends on unpublished workspace package ${lookupKey}; include ${dependencyPackage.path} in the release manifest or publish that version first`,
+    );
+  }
+}
+
+function releasedDependencyPath(
+  releasePackage: WorkspacePackage,
+  dependencyName: string,
+  context: DependencyClosureContext,
+): string | undefined {
+  const dependencyPackage = context.packagesByName.get(dependencyName);
+  if (!dependencyPackage) {
+    throw new Error(
+      `${releasePackage.manifest.name}@${releasePackage.manifest.version} references missing workspace package ${dependencyName}`,
+    );
+  }
+  if (context.releasePathSet.has(dependencyPackage.path)) return dependencyPackage.path;
+  assertDependencyPublished(releasePackage, dependencyPackage, context);
+  return undefined;
+}
+
+function releaseDependencies(
+  releasePackage: WorkspacePackage,
+  context: DependencyClosureContext,
+): Set<string> {
+  const dependencyPaths = workspaceDependencyNames(releasePackage.manifest).flatMap((dependencyName) => {
+    const dependencyPath = releasedDependencyPath(releasePackage, dependencyName, context);
+    return dependencyPath ? [dependencyPath] : [];
+  });
+  return new Set(dependencyPaths);
+}
+
+function releaseDependencyGraph(
+  releasePaths: string[],
+  packagesByPath: Map<string, WorkspacePackage>,
+  context: DependencyClosureContext,
+): Map<string, Set<string>> {
+  return new Map(releasePaths.map((releasePath) => {
+    const releasePackage = packagesByPath.get(releasePath);
+    if (!releasePackage) {
+      throw new Error(`Release package manifest not found: ${releasePath}/package.json`);
+    }
+    return [releasePath, releaseDependencies(releasePackage, context)];
+  }));
+}
+
+function nextPublishablePath(
+  releasePaths: string[],
+  publishedPaths: Set<string>,
+  dependenciesByReleasePath: Map<string, Set<string>>,
+): string | undefined {
+  return releasePaths.find(
+    (releasePath) =>
+      !publishedPaths.has(releasePath) &&
+      [...(dependenciesByReleasePath.get(releasePath) ?? [])].every((dependencyPath) =>
+        publishedPaths.has(dependencyPath),
+      ),
+  );
+}
+
+function orderReleasePaths(
+  releasePaths: string[],
+  dependenciesByReleasePath: Map<string, Set<string>>,
+): string[] {
+  const orderedPaths: string[] = [];
+  const publishedPaths = new Set<string>();
+  while (orderedPaths.length < releasePaths.length) {
+    const nextPath = nextPublishablePath(releasePaths, publishedPaths, dependenciesByReleasePath);
+    if (!nextPath) {
+      const remainingPaths = releasePaths.filter((releasePath) => !publishedPaths.has(releasePath));
+      throw new Error(`Circular workspace dependencies in release manifest: ${remainingPaths.join(', ')}`);
+    }
+    orderedPaths.push(nextPath);
+    publishedPaths.add(nextPath);
+  }
+  return orderedPaths;
+}
+
+export function planReleasePublication({
+  repositoryRoot,
+  releaseManifest,
+  isPackageVersionPublished = defaultIsPackageVersionPublished,
+}: PlanReleasePublicationOptions): string[] {
+  const releasePaths = parseReleasePaths(releaseManifest);
+  const { packagesByPath, packagesByName } = indexWorkspacePackages(
+    discoverWorkspacePackages(repositoryRoot),
+  );
+  const closureContext: DependencyClosureContext = {
+    releasePathSet: new Set(releasePaths),
+    packagesByName,
+    isPackageVersionPublished,
+    publicationLookups: new Map(),
+  };
+  const dependencyGraph = releaseDependencyGraph(releasePaths, packagesByPath, closureContext);
+  return orderReleasePaths(releasePaths, dependencyGraph);
+}
+
+if (import.meta.main) {
+  try {
+    const releasePaths = planReleasePublication({
+      repositoryRoot: resolve(import.meta.dir, '..'),
+      releaseManifest: process.env.RELEASE_MANIFEST ?? '[]',
+    });
+    for (const releasePath of releasePaths) {
+      console.info(releasePath);
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-publication-plan.test.ts
+++ b/scripts/release-publication-plan.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { planReleasePublication } from './plan-release-publication';
+
+interface FixturePackage {
+  path: string;
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+function createRepositoryFixture(packages: FixturePackage[]): string {
+  const root = mkdtempSync(join(tmpdir(), 'svadmin-release-publication-'));
+  for (const packageDefinition of packages) {
+    const packageDirectory = join(root, packageDefinition.path);
+    mkdirSync(packageDirectory, { recursive: true });
+    writeFileSync(
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({
+        name: packageDefinition.name,
+        version: packageDefinition.version,
+        dependencies: packageDefinition.dependencies,
+        devDependencies: packageDefinition.devDependencies,
+      }),
+    );
+  }
+  return root;
+}
+
+const refineAdapter: FixturePackage = {
+  path: 'packages/refine-adapter',
+  name: '@svadmin/refine-adapter',
+  version: '0.10.0',
+};
+
+const supabase: FixturePackage = {
+  path: 'packages/supabase',
+  name: '@svadmin/supabase',
+  version: '0.11.8',
+  dependencies: { '@svadmin/refine-adapter': 'workspace:*' },
+};
+
+describe('release publication planning', () => {
+  test('rejects release paths that could inject output or JavaScript', () => {
+    const root = createRepositoryFixture([supabase]);
+    try {
+      for (const maliciousPath of [
+        'packages/supabase\nSVADMIN_RELEASE_PATHS',
+        "packages/supabase');process.exit(0)",
+      ]) {
+        expect(() =>
+          planReleasePublication({
+            repositoryRoot: root,
+            releaseManifest: JSON.stringify([{ path: maliciousPath }]),
+            isPackageVersionPublished: () => true,
+          }),
+        ).toThrow(`Invalid release package path: ${maliciousPath}`);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects a workspace dependency that is neither released nor published', () => {
+    const root = createRepositoryFixture([refineAdapter, supabase]);
+    try {
+      expect(() =>
+        planReleasePublication({
+          repositoryRoot: root,
+          releaseManifest: JSON.stringify([{ path: supabase.path, tag: 'supabase-v0.11.8' }]),
+          isPackageVersionPublished: () => false,
+        }),
+      ).toThrow(
+        '@svadmin/supabase@0.11.8 depends on unpublished workspace package @svadmin/refine-adapter@0.10.0',
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('includes workspace dev dependencies in the release closure', () => {
+    const releaseTool: FixturePackage = {
+      path: 'packages/release-tool',
+      name: '@svadmin/release-tool',
+      version: '0.1.0',
+      devDependencies: { '@svadmin/refine-adapter': 'workspace:*' },
+    };
+    const root = createRepositoryFixture([refineAdapter, releaseTool]);
+    try {
+      expect(() =>
+        planReleasePublication({
+          repositoryRoot: root,
+          releaseManifest: JSON.stringify([{ path: releaseTool.path }]),
+          isPackageVersionPublished: () => false,
+        }),
+      ).toThrow(
+        '@svadmin/release-tool@0.1.0 depends on unpublished workspace package @svadmin/refine-adapter@0.10.0',
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('accepts a workspace dependency whose exact version is already published', () => {
+    const root = createRepositoryFixture([refineAdapter, supabase]);
+    const lookups: string[] = [];
+    try {
+      expect(
+        planReleasePublication({
+          repositoryRoot: root,
+          releaseManifest: JSON.stringify([{ path: supabase.path, tag: 'supabase-v0.11.8' }]),
+          isPackageVersionPublished: (name, version) => {
+            lookups.push(`${name}@${version}`);
+            return true;
+          },
+        }),
+      ).toEqual([supabase.path]);
+      expect(lookups).toEqual(['@svadmin/refine-adapter@0.10.0']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('orders a same-batch workspace dependency before its dependent', () => {
+    const root = createRepositoryFixture([refineAdapter, supabase]);
+    try {
+      expect(
+        planReleasePublication({
+          repositoryRoot: root,
+          releaseManifest: JSON.stringify([
+            { path: supabase.path, tag: 'supabase-v0.11.8' },
+            { path: refineAdapter.path, tag: 'refine-adapter-v0.10.0' },
+          ]),
+          isPackageVersionPublished: () => {
+            throw new Error('same-batch dependencies must not query npm');
+          },
+        }),
+      ).toEqual([refineAdapter.path, supabase.path]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects circular workspace dependencies in the release batch', () => {
+    const cyclicAdapter: FixturePackage = {
+      ...refineAdapter,
+      dependencies: { '@svadmin/supabase': 'workspace:*' },
+    };
+    const root = createRepositoryFixture([cyclicAdapter, supabase]);
+    try {
+      expect(() =>
+        planReleasePublication({
+          repositoryRoot: root,
+          releaseManifest: JSON.stringify([
+            { path: supabase.path, tag: 'supabase-v0.11.8' },
+            { path: refineAdapter.path, tag: 'refine-adapter-v0.10.0' },
+          ]),
+          isPackageVersionPublished: () => true,
+        }),
+      ).toThrow('Circular workspace dependencies in release manifest');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/release-workflow-contract.test.ts
+++ b/scripts/release-workflow-contract.test.ts
@@ -44,6 +44,21 @@ describe('npm trusted-publishing workflow contract', () => {
     expect(ciWorkflow).toContain('group: npm-publish-${{ inputs.release_sha }}');
     expect(ciWorkflow).toContain('id-token: write');
     expect(ciWorkflow).not.toContain('secrets.NPM_TOKEN');
+    expect(ciWorkflow).toContain('bun scripts/plan-release-publication.ts');
+    expect(ciWorkflow).toContain('id: release_plan');
+    expect(ciWorkflow).toContain('RELEASE_DIRS: ${{ steps.release_plan.outputs.paths }}');
+    expect(ciWorkflow).toContain(
+      "['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']",
+    );
+    expect(ciWorkflow).not.toContain('PUBLISH_FAILED=0');
+    expect(ciWorkflow).not.toContain('|| echo ""');
+    expect(ciWorkflow).toContain(
+      'if ! NPM_STATUS=$(bun scripts/npm-package-version.ts "$NAME" "$LOCAL_VER"); then',
+    );
+    expect(ciWorkflow).toContain('if [ "$NPM_STATUS" = "missing" ]; then');
+    expect(ciWorkflow).toContain('elif [ "$NPM_STATUS" = "published" ]; then');
+    expect(ciWorkflow).toContain('require(process.argv[1])');
+    expect(ciWorkflow).not.toContain("require('./$PKG_JSON')");
 
     const verifier = readFileSync(resolve(repositoryRoot, 'scripts', 'verify-release-manifest.ts'), 'utf8');
     expect(verifier).toContain('refs/tags/${tag}^{commit}');

--- a/scripts/verify-release-manifest.ts
+++ b/scripts/verify-release-manifest.ts
@@ -16,6 +16,10 @@ interface VerifyReleaseManifestOptions {
 
 type JsonRecord = Record<string, unknown>;
 
+export function isReleasePackagePath(packagePath: unknown): packagePath is string {
+  return typeof packagePath === 'string' && /^packages\/[a-z0-9][a-z0-9._-]*$/.test(packagePath);
+}
+
 function readJsonRecord(path: string): JsonRecord {
   const value: unknown = JSON.parse(readFileSync(path, 'utf8'));
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -65,7 +69,7 @@ export function verifyReleaseManifest({
     const release = rawRelease as JsonRecord;
     const packagePath = release.path;
     const tag = release.tag;
-    if (typeof packagePath !== 'string' || !/^packages\/[^/]+$/.test(packagePath)) {
+    if (!isReleasePackagePath(packagePath)) {
       throw new Error(`Invalid release package path: ${String(packagePath)}`);
     }
     if (typeof tag !== 'string' || !/^[A-Za-z0-9._-]+$/.test(tag)) {


### PR DESCRIPTION
## Summary

- verify every released package workspace dependency across dependencies, devDependencies, optionalDependencies, and peerDependencies before any npm publish
- require an exact npm version or the dependency package in the same release batch, then topologically order same-batch dependencies first
- distinguish exact published versions, explicit E404 misses, and registry failures; outages and timeouts fail closed
- stop immediately after a publish failure so dependents cannot be published against a missing package
- restrict release paths to an ASCII allowlist and pass manifest paths to Node through argv

## Problem and #218

Release PR #218 currently includes `@svadmin/supabase@0.11.8` but not `packages/refine-adapter`. The published Supabase manifest rewrites its workspace dependency to `@svadmin/refine-adapter@^0.10.0`, while npm currently has only 0.9.3 and 0.9.4. The existing tarball check installs local workspace tarballs, so it cannot detect this registry closure failure.

The live #218-equivalent manifest now exits before publish with:

`@svadmin/supabase@0.11.7 depends on unpublished workspace package @svadmin/refine-adapter@0.10.0`

When refine-adapter is present in the same release manifest, the plan places it before Supabase. #218 therefore needs to refresh after the adapter release change is included; merging #218 in its current package set will be intentionally blocked instead of publishing a broken consumer dependency. HiCigar can remove its temporary dependency override after a compatible adapter release reaches npm.

This PR is independent from pagination PR #219 and does not change package versions, package manifests, or release-please configuration.

## TDD and verification

- RED: the workflow contract proved there was no dependency closure preflight and registry errors were collapsed into a publish attempt
- targeted release tests: 13 passed, 0 failed
- live npm probe: refine-adapter 0.10.0 is `missing`; core 0.34.1 is `published`
- malicious newline and quote release paths: rejected
- simulated registry outage and ETIMEDOUT: fail-fast, no dependent publish reached
- `bun run build:packages`: passed
- `bun run check`: 0 errors, 0 warnings
- `bun run lint`: passed
- `bun run pack:check`: passed, including npm and pnpm consumer imports
- independent read-only review: PASS, 0 blockers

Local full orchestration reached 556/556 Bun tests and all example, core, Lite, and Lite-security suites. The unchanged UI suite was 42/43 because the existing markdown dynamic-peer test crossed its 15-second timeout during APFS I/O contention; an isolated retry of that exact file passed 4/4. This PR does not modify UI code or relax that test. Remote CI remains the final independent gate.