### PR TITLE
fix(ui): enforce access control for custom menus

### DIFF
--- a/packages/ui/src/components/Sidebar.svelte
+++ b/packages/ui/src/components/Sidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { captureAdminContext, getResources, canAccessAsync } from '@svadmin/core';
+  import { captureAdminContext, getResources, canAccessAsync, getAccessControlProvider } from '@svadmin/core';
   import type { Identity, MenuItem } from '@svadmin/core';
   import { getPath } from '../router-state.svelte.js';
   import { useTranslation } from '@svadmin/core/i18n';
@@ -120,6 +120,14 @@
     return candidate !== null;
   }
 
+  function snapshotCustomMenuItems(menuItems: MenuItem[]): MenuItem[] {
+    return menuItems.map((menuItem) => ({
+      ...menuItem,
+      meta: menuItem.meta ? { ...menuItem.meta } : undefined,
+      children: menuItem.children ? snapshotCustomMenuItems(menuItem.children) : undefined,
+    }));
+  }
+
   async function visibleCustomMenuItem(menuItem: MenuItem): Promise<MenuItem | null> {
     if (menuItem.meta?.hidden || !await hasCustomMenuAccess(menuItem)) return null;
     if (!menuItem.children) return menuItem;
@@ -137,9 +145,11 @@
   let customMenuItems = $state.raw<MenuItem[]>([]);
 
   $effect(() => {
-    const configuredMenu = menu;
+    const configuredMenu = menu?.length ? snapshotCustomMenuItems(menu) : [];
+    // Provider swaps must invalidate checks nested below public menu groups.
+    getAccessControlProvider();
     customMenuItems = [];
-    if (!configuredMenu?.length) return;
+    if (configuredMenu.length === 0) return;
 
     let cancelled = false;
     void visibleCustomMenuItems(configuredMenu).then((visibleItems) => {

--- a/packages/ui/src/components/Sidebar.svelte
+++ b/packages/ui/src/components/Sidebar.svelte
@@ -103,6 +103,52 @@
     items: NavItem[];
   }
 
+  async function hasCustomMenuAccess(menuItem: MenuItem): Promise<boolean> {
+    const resource = menuItem.meta?.resource;
+    if (!resource) return true;
+
+    try {
+      const { can } = await canAccessAsync(resource, menuItem.meta?.action ?? 'list');
+      return can;
+    } catch {
+      // Permission-provider failures must not expose protected navigation.
+      return false;
+    }
+  }
+
+  function isVisibleCustomMenuItem(candidate: MenuItem | null): candidate is MenuItem {
+    return candidate !== null;
+  }
+
+  async function visibleCustomMenuItem(menuItem: MenuItem): Promise<MenuItem | null> {
+    if (menuItem.meta?.hidden || !await hasCustomMenuAccess(menuItem)) return null;
+    if (!menuItem.children) return menuItem;
+
+    const children = await visibleCustomMenuItems(menuItem.children);
+    if (children.length === 0 && !menuItem.href) return null;
+    return { ...menuItem, children };
+  }
+
+  async function visibleCustomMenuItems(menuItems: MenuItem[]): Promise<MenuItem[]> {
+    const filteredItems = await Promise.all(menuItems.map(visibleCustomMenuItem));
+    return filteredItems.filter(isVisibleCustomMenuItem);
+  }
+
+  let customMenuItems = $state.raw<MenuItem[]>([]);
+
+  $effect(() => {
+    const configuredMenu = menu;
+    customMenuItems = [];
+    if (!configuredMenu?.length) return;
+
+    let cancelled = false;
+    void visibleCustomMenuItems(configuredMenu).then((visibleItems) => {
+      if (!cancelled) customMenuItems = visibleItems;
+    });
+
+    return () => { cancelled = true; };
+  });
+
   let navItems = $state.raw<NavItem[]>([]);
 
   $effect(() => {
@@ -239,7 +285,7 @@
   <nav aria-label="Main menu" class="pb-4" class:px-[10px]={!collapsed} class:px-2={collapsed}>
     {#if menu && menu.length > 0}
       <div class="space-y-[2px]">
-        {#each menu as item, _i (_i)}
+        {#each customMenuItems as item (item.name)}
           <SidebarItem {item} currentPath={path} {collapsed} depth={0} />
         {/each}
       </div>

--- a/packages/ui/src/components/sidebar-access-control.test.svelte.ts
+++ b/packages/ui/src/components/sidebar-access-control.test.svelte.ts
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/svelte';
+import {
+  resetContext,
+  setAccessControlProvider,
+  setResources,
+  type AccessControlProvider,
+  type CanParams,
+  type MenuItem,
+  type ResourceDefinition,
+} from '@svadmin/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Sidebar from './Sidebar.svelte';
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', {
+    length: 0,
+    clear: vi.fn(),
+    getItem: vi.fn(() => null),
+    key: vi.fn(() => null),
+    removeItem: vi.fn(),
+    setItem: vi.fn(),
+  } satisfies Storage);
+});
+
+afterEach(() => {
+  resetContext();
+  vi.unstubAllGlobals();
+});
+
+function renderSidebar(menu?: MenuItem[]) {
+  return render(Sidebar, {
+    collapsed: false,
+    identity: null,
+    title: 'Test Admin',
+    onToggle: vi.fn(),
+    onLogout: vi.fn(),
+    menu,
+  });
+}
+
+describe('Sidebar access control', () => {
+  it('filters denied custom menu items before rendering and prunes empty groups', async () => {
+    const permissionChecks: CanParams[] = [];
+    const accessControlProvider: AccessControlProvider = {
+      can: async (request) => {
+        if (Array.isArray(request)) {
+          return request.map(({ resource }) => ({ can: resource !== 'denied' }));
+        }
+        permissionChecks.push(request);
+        return { can: request.resource !== 'denied' };
+      },
+    };
+    setAccessControlProvider(accessControlProvider);
+
+    renderSidebar([
+      {
+        name: 'catalog',
+        label: 'Catalog',
+        children: [
+          {
+            name: 'allowed',
+            label: 'Allowed',
+            href: '/allowed',
+            meta: { resource: 'products', action: 'list' },
+          },
+          {
+            name: 'denied',
+            label: 'Denied',
+            href: '/denied',
+            meta: { resource: 'denied', action: 'list' },
+          },
+        ],
+      },
+      {
+        name: 'empty-group',
+        label: 'Empty Group',
+        children: [
+          {
+            name: 'empty-denied',
+            label: 'Empty Denied',
+            href: '/empty-denied',
+            meta: { resource: 'denied', action: 'show' },
+          },
+        ],
+      },
+      { name: 'public', label: 'Public', href: '/public' },
+      {
+        name: 'default-list-denied',
+        label: 'Default List Denied',
+        href: '/default-list-denied',
+        meta: { resource: 'denied' },
+      },
+      { name: 'hidden', label: 'Hidden', href: '/hidden', meta: { hidden: true } },
+    ]);
+
+    expect(screen.queryByText('Denied')).toBeNull();
+    expect(screen.queryByText('Default List Denied')).toBeNull();
+    expect(screen.queryByText('Empty Group')).toBeNull();
+    expect(screen.queryByText('Hidden')).toBeNull();
+    expect(await screen.findByText('Allowed')).toBeTruthy();
+    expect(screen.getByText('Catalog')).toBeTruthy();
+    expect(screen.getByText('Public')).toBeTruthy();
+    expect(permissionChecks
+      .map(({ resource, action }) => `${resource}:${action}`)
+      .sort()).toEqual([
+      'denied:list',
+      'denied:list',
+      'denied:show',
+      'products:list',
+    ]);
+  });
+
+  it('keeps automatic resources filtered by their list permission', async () => {
+    const resources = [
+      { name: 'visible', label: 'Visible Resource', fields: [] },
+      { name: 'denied', label: 'Denied Resource', fields: [] },
+    ] satisfies ResourceDefinition[];
+    setResources(resources);
+    setAccessControlProvider({
+      can: async (request) => {
+        if (Array.isArray(request)) {
+          return request.map(({ resource }) => ({ can: resource !== 'denied' }));
+        }
+        return { can: request.resource !== 'denied' };
+      },
+    });
+
+    renderSidebar();
+
+    expect(await screen.findByText('Visible Resource')).toBeTruthy();
+    expect(screen.queryByText('Denied Resource')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/sidebar-access-control.test.svelte.ts
+++ b/packages/ui/src/components/sidebar-access-control.test.svelte.ts
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import {
   resetContext,
   setAccessControlProvider,
@@ -182,9 +183,13 @@ describe('Sidebar access control', () => {
     const denyCan = vi.fn(async () => ({ can: false }));
     setAccessControlProvider({ can: denyCan });
     await waitFor(() => expect(denyCan).toHaveBeenCalledTimes(1));
-    resolveInitialAccess({ can: true });
-
     expect(await screen.findByText('Public')).toBeTruthy();
+
+    resolveInitialAccess({ can: true });
+    // Let the superseded permission chain finish before checking that it cannot publish.
+    await new Promise<void>((resolve) => { setTimeout(resolve, 0); });
+    await tick();
+
     expect(screen.queryByText('Race Child')).toBeNull();
   });
 

--- a/packages/ui/src/components/sidebar-access-control.test.svelte.ts
+++ b/packages/ui/src/components/sidebar-access-control.test.svelte.ts
@@ -1,10 +1,11 @@
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import {
   resetContext,
   setAccessControlProvider,
   setResources,
   type AccessControlProvider,
   type CanParams,
+  type CanResult,
   type MenuItem,
   type ResourceDefinition,
 } from '@svadmin/core';
@@ -93,11 +94,11 @@ describe('Sidebar access control', () => {
       { name: 'hidden', label: 'Hidden', href: '/hidden', meta: { hidden: true } },
     ]);
 
+    expect(await screen.findByText('Allowed')).toBeTruthy();
     expect(screen.queryByText('Denied')).toBeNull();
     expect(screen.queryByText('Default List Denied')).toBeNull();
     expect(screen.queryByText('Empty Group')).toBeNull();
     expect(screen.queryByText('Hidden')).toBeNull();
-    expect(await screen.findByText('Allowed')).toBeTruthy();
     expect(screen.getByText('Catalog')).toBeTruthy();
     expect(screen.getByText('Public')).toBeTruthy();
     expect(permissionChecks
@@ -129,5 +130,85 @@ describe('Sidebar access control', () => {
 
     expect(await screen.findByText('Visible Resource')).toBeTruthy();
     expect(screen.queryByText('Denied Resource')).toBeNull();
+  });
+
+  it('removes protected nested items when the access-control provider changes', async () => {
+    setAccessControlProvider({ can: async () => ({ can: true }) });
+    renderSidebar([
+      {
+        name: 'group',
+        label: 'Group',
+        children: [
+          {
+            name: 'protected-child',
+            label: 'Protected Child',
+            href: '/protected',
+            meta: { resource: 'protected' },
+          },
+        ],
+      },
+    ]);
+
+    expect(await screen.findByText('Protected Child')).toBeTruthy();
+
+    setAccessControlProvider({ can: async () => ({ can: false }) });
+
+    await waitFor(() => expect(screen.queryByText('Protected Child')).toBeNull());
+  });
+
+  it('ignores stale nested permission results after the provider changes', async () => {
+    let resolveInitialAccess!: (result: CanResult) => void;
+    const initialCan = vi.fn(
+      () => new Promise<CanResult>((resolve) => { resolveInitialAccess = resolve; }),
+    );
+    setAccessControlProvider({ can: initialCan });
+    renderSidebar([
+      {
+        name: 'group',
+        label: 'Group',
+        children: [
+          {
+            name: 'race-child',
+            label: 'Race Child',
+            href: '/race',
+            meta: { resource: 'protected' },
+          },
+        ],
+      },
+      { name: 'public', label: 'Public', href: '/public' },
+    ]);
+    await waitFor(() => expect(initialCan).toHaveBeenCalledTimes(1));
+
+    const denyCan = vi.fn(async () => ({ can: false }));
+    setAccessControlProvider({ can: denyCan });
+    await waitFor(() => expect(denyCan).toHaveBeenCalledTimes(1));
+    resolveInitialAccess({ can: true });
+
+    expect(await screen.findByText('Public')).toBeTruthy();
+    expect(screen.queryByText('Race Child')).toBeNull();
+  });
+
+  it('fails closed when a nested permission check rejects', async () => {
+    setAccessControlProvider({
+      can: async () => { throw new Error('permission service unavailable'); },
+    });
+    renderSidebar([
+      {
+        name: 'group',
+        label: 'Group',
+        children: [
+          {
+            name: 'protected-child',
+            label: 'Protected Child',
+            href: '/protected',
+            meta: { resource: 'protected' },
+          },
+        ],
+      },
+      { name: 'public', label: 'Public', href: '/public' },
+    ]);
+
+    expect(await screen.findByText('Public')).toBeTruthy();
+    expect(screen.queryByText('Protected Child')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- filter custom `adminMenu` trees through the configured access-control provider before rendering
- default resource-only menu permissions to `list` and fail closed when permission checks reject
- prune nested groups with no visible children while preserving `meta.hidden` and automatic resource-menu behavior

## Regression coverage

- RED on `origin/main`: a denied custom menu item rendered in the sidebar
- GREEN: component tests cover allowed/denied items, default `list`, hidden items, nested-group pruning, and automatic resource filtering

## Verification

- `bun run --cwd packages/ui test -- src/components/sidebar-access-control.test.svelte.ts` (2 passed)
- `bun run check` (0 errors, 0 warnings)
- `bun run lint`
- `bun run test`
- `bun run build`
- `git diff --check`
- Svelte 5 autofixer review
- independent verifier: PASS, no blocking findings
