### PR TITLE
fix(ui): avoid value binding for file inputs

### DIFF
--- a/packages/ui/src/components/ui/input/input.svelte
+++ b/packages/ui/src/components/ui/input/input.svelte
@@ -1,12 +1,17 @@
-<script lang="ts">
+<script
+	lang="ts"
+	generics="Type extends HTMLInputTypeAttribute | undefined = undefined"
+>
 	import type { HTMLInputAttributes, HTMLInputTypeAttribute } from "svelte/elements";
 	import { cn, type WithElementRef } from "../../../utils.js";
 
-	type InputType = Exclude<HTMLInputTypeAttribute, "file">;
+	type InputValue = HTMLInputAttributes["value"];
 
 	type Props = WithElementRef<
-		Omit<HTMLInputAttributes, "type"> &
-			({ type: "file"; files?: FileList } | { type?: InputType; files?: undefined })
+		Omit<HTMLInputAttributes, "type" | "value"> &
+			(Type extends "file"
+				? { type: "file"; files?: FileList; value?: never }
+				: { type?: Type; files?: undefined; value?: InputValue })
 	>;
 
 	let {
@@ -30,7 +35,6 @@
 		)}
 		type="file"
 		bind:files
-		bind:value
 		{...restProps}
 	/>
 {:else}

--- a/packages/ui/src/components/ui/input/input.test.svelte.ts
+++ b/packages/ui/src/components/ui/input/input.test.svelte.ts
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import type { ComponentProps } from "svelte";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import Input from "./input.svelte";
+
+describe("Input", () => {
+	it("renders a file input without binding its protected value property", async () => {
+		expect(() => {
+			render(Input, { type: "file", "aria-label": "Attachment" });
+		}).not.toThrow();
+
+		const input = screen.getByLabelText<HTMLInputElement>("Attachment");
+		expect(input.type).toBe("file");
+		const file = new File(["evidence"], "evidence.txt", { type: "text/plain" });
+		await fireEvent.change(input, { target: { files: [file] } });
+		expect(input.files?.[0]).toBe(file);
+	});
+
+	it("keeps file values out of the public prop contract", () => {
+		type FileInputProps = ComponentProps<typeof Input<"file">>;
+		type TextInputProps = ComponentProps<typeof Input<"text">>;
+		expectTypeOf<{ type: "file"; value: string }>().not.toExtend<FileInputProps>();
+		expectTypeOf<{ type: "text"; value: string }>().toExtend<TextInputProps>();
+	});
+});


### PR DESCRIPTION
## Summary

- stop binding the protected `value` property on file inputs
- reject file input values in the public prop contract while preserving dynamically typed non-file inputs
- add runtime and type-contract regression coverage

## Verification

- `bun run --cwd packages/ui test` (16 files, 50 tests passed)
- `bun run build:packages`
- `bun run typecheck` (0 errors, 0 warnings)
- `bunx eslint packages/ui/src/components/ui/input/input.svelte packages/ui/src/components/ui/input/input.test.svelte.ts`
- `git diff --check origin/main...HEAD`