### PR TITLE
fix(ui): harden file input handling

### DIFF
--- a/packages/ui/src/components/ui/command/command.test.svelte.ts
+++ b/packages/ui/src/components/ui/command/command.test.svelte.ts
@@ -38,7 +38,7 @@ describe('Command', () => {
 	});
 
 	it('keeps the dialog, loading, separator, and selected-value API compatible', async () => {
-		render(CommandHarness, { props: { dialog: true } });
+		const { unmount } = render(CommandHarness, { props: { dialog: true } });
 
 		const input = screen.getByRole('combobox', { name: 'Dialog actions' });
 		expect(screen.getByRole('progressbar', { name: 'Loading...' }).getAttribute('aria-valuenow')).toBe('50');
@@ -52,5 +52,12 @@ describe('Command', () => {
 
 		expect(screen.getByTestId('selected-command').textContent).toBe('dialog-settings');
 		expect(screen.getByTestId('dialog-value').textContent).toBe('dialog-settings');
+
+		unmount();
+		// bits-ui restores body scroll styles on a short timer after the dialog is destroyed.
+		// Let that cleanup finish before Vitest tears down the browser environment.
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, 30);
+		});
 	});
 });

--- a/packages/ui/src/components/ui/input/input.svelte
+++ b/packages/ui/src/components/ui/input/input.svelte
@@ -23,9 +23,11 @@
 		"data-slot": dataSlot = "input",
 		...restProps
 	}: Props = $props();
+
+	const isFileInput = $derived(type?.toLowerCase() === "file");
 </script>
 
-{#if type === "file"}
+{#if isFileInput}
 	<input
 		bind:this={ref}
 		data-slot={dataSlot}

--- a/packages/ui/src/components/ui/input/input.test.svelte.ts
+++ b/packages/ui/src/components/ui/input/input.test.svelte.ts
@@ -1,19 +1,49 @@
 import { fireEvent, render, screen } from "@testing-library/svelte";
 import type { ComponentProps } from "svelte";
 import { describe, expect, expectTypeOf, it } from "vitest";
+import InputHarness from "../../../../test/fixtures/InputHarness.svelte";
 import Input from "./input.svelte";
 
 describe("Input", () => {
-	it("renders a file input without binding its protected value property", async () => {
-		expect(() => {
-			render(Input, { type: "file", "aria-label": "Attachment" });
-		}).not.toThrow();
+	it("binds uploaded and cleared files without writing the protected value property", async () => {
+		render(InputHarness, { props: { multiple: true } });
 
 		const input = screen.getByLabelText<HTMLInputElement>("Attachment");
+		const firstFile = new File(["first"], "first.txt", { type: "text/plain" });
+		const secondFile = new File(["second"], "second.txt", { type: "text/plain" });
+		const uploadedFiles = new DataTransfer();
+		uploadedFiles.items.add(firstFile);
+		uploadedFiles.items.add(secondFile);
+
+		await fireEvent.change(input, { target: { files: uploadedFiles.files } });
+		expect(screen.getByTestId("bound-files").textContent).toBe("first.txt,second.txt");
+
+		await fireEvent.change(input, { target: { files: new DataTransfer().files } });
+		expect(screen.getByTestId("bound-files").textContent).toBe("");
+	});
+
+	it("treats dynamically supplied input types case-insensitively", () => {
+		expect(() => {
+			render(Input, {
+				type: "FILE",
+				value: "must-not-be-written",
+				files: new DataTransfer().files,
+				"aria-label": "Dynamic attachment",
+			} as never);
+		}).not.toThrow();
+
+		const input = screen.getByLabelText<HTMLInputElement>("Dynamic attachment");
 		expect(input.type).toBe("file");
-		const file = new File(["evidence"], "evidence.txt", { type: "text/plain" });
-		await fireEvent.change(input, { target: { files: [file] } });
-		expect(input.files?.[0]).toBe(file);
+		expect(input.value).toBe("");
+	});
+
+	it("keeps value binding for non-file inputs", async () => {
+		render(InputHarness, { props: { mode: "text" } });
+
+		const input = screen.getByLabelText<HTMLInputElement>("Text value");
+		expect(input.value).toBe("initial");
+		await fireEvent.input(input, { target: { value: "updated" } });
+		expect(screen.getByTestId("bound-value").textContent).toBe("updated");
 	});
 
 	it("keeps file values out of the public prop contract", () => {

--- a/packages/ui/test/fixtures/InputHarness.svelte
+++ b/packages/ui/test/fixtures/InputHarness.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import Input from "../../src/components/ui/input/input.svelte";
+
+	let {
+		mode = "file",
+		multiple = false,
+	}: {
+		mode?: "file" | "text";
+		multiple?: boolean;
+	} = $props();
+
+	let files = $state<FileList>(new DataTransfer().files);
+	let value = $state("initial");
+</script>
+
+{#if mode === "file"}
+	<Input type="file" {multiple} bind:files aria-label="Attachment" />
+	<output data-testid="bound-files">
+		{Array.from(files ?? [], (file) => file.name).join(",")}
+	</output>
+{:else}
+	<Input type="text" bind:value aria-label="Text value" />
+	<output data-testid="bound-value">{value}</output>
+{/if}


### PR DESCRIPTION
Summary

- normalize dynamic input types before selecting the file-only branch
- verify bound file state for multi-file uploads and clearing
- preserve non-file value binding and forbid protected file value writes
- await bits-ui dialog cleanup before the browser test environment is destroyed

Verification

- mutation checks fail for strict FILE matching, restored file value binding, removed files binding, and removed text value binding
- Svelte autofixer: no issues in changed Svelte files
- targeted Input and Command tests: 6 passed
- complete UI suite: 16 files, 52 tests passed
- full repository tests after package build: 557 Bun tests and 171 Vitest tests passed
- package build, full lint, and typecheck: passed