### PR TITLE
fix(admin): unblock scoped consumers

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "@sveltejs/kit": "^2.70.2",
-    "@svadmin/core": "workspace:*",
+    "@svadmin/core": ">=0.32.2 <0.36.0",
     "svelte": "^5.56.8"
   },
   "license": "MIT",

--- a/packages/sveltekit/tests/peer-compat.test.ts
+++ b/packages/sveltekit/tests/peer-compat.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'bun:test';
+import manifest from '../package.json';
+
+describe('@svadmin/sveltekit peer compatibility', () => {
+  test('supports the current core release without dropping existing consumers', () => {
+    expect(manifest.peerDependencies['@svadmin/core']).toBe('>=0.32.2 <0.36.0');
+  });
+});

--- a/packages/ui/src/components/AutoTable.svelte
+++ b/packages/ui/src/components/AutoTable.svelte
@@ -262,10 +262,12 @@
   const acEnabled = $derived(!!adminContext.accessControlProvider);
   const canCreatePerm = useCan(() => ({ resource: resourceName, action: 'create', queryOptions: { enabled: acEnabled } }));
   const canEditPerm = useCan(() => ({ resource: resourceName, action: 'edit', queryOptions: { enabled: acEnabled } }));
+  const canShowPerm = useCan(() => ({ resource: resourceName, action: 'show', queryOptions: { enabled: acEnabled } }));
   const canDeletePerm = useCan(() => ({ resource: resourceName, action: 'delete', queryOptions: { enabled: acEnabled } }));
   const canExportPerm = useCan(() => ({ resource: resourceName, action: 'export', queryOptions: { enabled: acEnabled } }));
   const canCreate = $derived(canCreatePerm.allowed && resource.canCreate !== false);
   const canEdit = $derived(canEditPerm.allowed && resource.canEdit !== false);
+  const canShow = $derived(canShowPerm.allowed && resource.canShow !== false);
   const canDelete = $derived(canDeletePerm.allowed && resource.canDelete !== false);
   const canExport = $derived(canExportPerm.allowed);
 
@@ -837,9 +839,11 @@
                       <Pencil class="h-4 w-4" /> {i18n.t('common.edit')}
                     </ContextMenu.Item>
                   {/if}
-                  <ContextMenu.Item onclick={() => adminContext.navigate(`/${resourceName}/show/${id}`)} class="gap-2">
-                    <Eye class="h-4 w-4" /> {i18n.t('common.detail')}
-                  </ContextMenu.Item>
+                  {#if canShow}
+                    <ContextMenu.Item onclick={() => adminContext.navigate(`/${resourceName}/show/${id}`)} class="gap-2">
+                      <Eye class="h-4 w-4" /> {i18n.t('common.detail')}
+                    </ContextMenu.Item>
+                  {/if}
                   <ContextMenu.Item onclick={() => navigator.clipboard?.writeText(String(id))} class="gap-2">
                     <Copy class="h-4 w-4" /> {i18n.t('common.copyId')}
                   </ContextMenu.Item>
@@ -913,9 +917,11 @@
                         <Pencil class="h-4 w-4" />
                       </TooltipButton>
                     {/if}
-                    <TooltipButton tooltip={i18n.t('common.detail')} variant="ghost" size="icon-sm" onclick={() => adminContext.navigate(`/${resourceName}/show/${id}`)}>
-                      <Eye class="h-4 w-4" />
-                    </TooltipButton>
+                    {#if canShow}
+                      <TooltipButton tooltip={i18n.t('common.detail')} variant="ghost" size="icon-sm" onclick={() => adminContext.navigate(`/${resourceName}/show/${id}`)}>
+                        <Eye class="h-4 w-4" />
+                      </TooltipButton>
+                    {/if}
                     {#if canDelete}
                       <TooltipButton tooltip={i18n.t('common.delete')} variant="ghost" size="icon-sm" onclick={() => confirmDelete(id)} class="hover:text-destructive">
                         <Trash2 class="h-4 w-4" />

--- a/packages/ui/src/components/DevTools.svelte
+++ b/packages/ui/src/components/DevTools.svelte
@@ -5,7 +5,6 @@
   import {
     captureAdminContext,
     getColorTheme,
-    getResources,
     getTheme,
   } from '@svadmin/core';
   import { useTranslation } from '@svadmin/core/i18n';
@@ -85,13 +84,7 @@
     };
   });
 
-  const resources = $derived.by(() => {
-    try {
-      return getResources();
-    } catch {
-      return [];
-    }
-  });
+  const resources = $derived(adminContext.resources);
   const path = $derived(adminContext.currentPath());
   const theme = $derived(getTheme());
   const colorTheme = $derived(getColorTheme());

--- a/packages/ui/src/components/auto-table-interactions.test.svelte.ts
+++ b/packages/ui/src/components/auto-table-interactions.test.svelte.ts
@@ -95,4 +95,55 @@ describe('AutoTable interactions', () => {
       expect(view.queryByText('已展开：user@example.com')).toBeNull();
     });
   });
+
+  it('does not expose detail navigation for a resource that disables show actions', async () => {
+    const onNavigate = vi.fn();
+    const view = render(AutoTableInteractionsHarness, { onNavigate, canShow: false });
+
+    const [email] = await view.findAllByText('user@example.com');
+    if (!email) throw new Error('Expected the desktop row email cell');
+    await fireEvent.contextMenu(email);
+
+    expect(await view.findByText('复制 ID')).not.toBeNull();
+    await waitFor(() => {
+      expect(view.queryByText('详情')).toBeNull();
+      expect(view.queryByRole('button', { name: '详情' })).toBeNull();
+    });
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when access control rejects the show action', async () => {
+    const view = render(AutoTableInteractionsHarness, {
+      onNavigate: vi.fn(),
+      canShow: true,
+      showAllowed: false,
+    });
+
+    const [email] = await view.findAllByText('user@example.com');
+    if (!email) throw new Error('Expected the desktop row email cell');
+    await fireEvent.contextMenu(email);
+
+    expect(await view.findByText('复制 ID')).not.toBeNull();
+    expect(view.queryByText('详情')).toBeNull();
+    expect(view.queryByRole('button', { name: '详情' })).toBeNull();
+  });
+
+  it('navigates to detail when both resource and access control allow show', async () => {
+    const onNavigate = vi.fn();
+    const view = render(AutoTableInteractionsHarness, {
+      onNavigate,
+      canShow: true,
+      showAllowed: true,
+    });
+
+    const [email] = await view.findAllByText('user@example.com');
+    if (!email) throw new Error('Expected the desktop row email cell');
+    await fireEvent.contextMenu(email);
+    await fireEvent.click(await view.findByText('详情'));
+
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith({
+      to: '/users/show/user-1',
+      type: 'push',
+    }));
+  });
 });

--- a/packages/ui/src/components/devtools-diagnostics.test.svelte.ts
+++ b/packages/ui/src/components/devtools-diagnostics.test.svelte.ts
@@ -84,4 +84,34 @@ describe('DevTools diagnostics', () => {
     queryClient.setQueryData(['default', 'second-resource', 'list'], { data: [] });
     await waitFor(() => expect(view.getByTestId('devtools-query-total').textContent).toBe('2'));
   });
+
+  it('tracks resources from the scoped AdminContext after rerender', async () => {
+    const queryClient = new QueryClient();
+    const routerProvider = createRouterProvider();
+    const dataProvider = { default: createDataProvider('scoped') };
+    const view = render(ContextHost, {
+      instance: 'resource-rerender',
+      dataProvider,
+      routerProvider,
+      resources,
+      queryClient,
+    });
+
+    await fireEvent.click(await view.findByRole('button', { name: /DevTools|开发者工具/ }));
+    expect(view.getByText('Resources (1)')).not.toBeNull();
+
+    await view.rerender({
+      instance: 'resource-rerender',
+      dataProvider,
+      routerProvider,
+      resources: [
+        ...resources,
+        { name: 'second-resource', label: 'Second resource', fields: [] },
+      ],
+      queryClient,
+    });
+
+    await waitFor(() => expect(view.getByText('Resources (2)')).not.toBeNull());
+    expect(view.getByText('second-resource')).not.toBeNull();
+  });
 });

--- a/packages/ui/test/fixtures/AutoTableInteractionsHarness.svelte
+++ b/packages/ui/test/fixtures/AutoTableInteractionsHarness.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-  import type { DataProvider, ResourceDefinition, RouterProvider } from '@svadmin/core';
+  import type { AccessControlProvider, DataProvider, ResourceDefinition, RouterProvider } from '@svadmin/core';
   import AdminApp from '../../src/components/AdminApp.svelte';
   import AutoTable from '../../src/components/AutoTable.svelte';
 
   interface Props {
     onNavigate: RouterProvider['go'];
     locale?: string;
+    canShow?: boolean;
+    showAllowed?: boolean;
   }
 
-  let { onNavigate, locale = 'zh-CN' }: Props = $props();
+  let { onNavigate, locale = 'zh-CN', canShow = true, showAllowed }: Props = $props();
 
   const dataProvider = {
     getList: async () => ({ data: [{ id: 'user-1', email: 'user@example.com' }], total: 1 }),
@@ -25,6 +27,7 @@
     canCreate: false,
     canEdit: false,
     canDelete: false,
+    get canShow() { return canShow; },
     fields: [
       { key: 'id', label: 'ID', type: 'text' },
       { key: 'email', label: 'Email', type: 'text', searchable: true },
@@ -36,6 +39,21 @@
     back: () => {},
     parse: () => ({ pathname: '/', params: {} }),
   };
+
+  const testAccessControlProvider: AccessControlProvider = {
+    can: async (params) => {
+      if (Array.isArray(params)) {
+        return params.map((entry) => ({
+          can: entry.action === 'show' ? showAllowed === true : true,
+        }));
+      }
+      return { can: params.action === 'show' ? showAllowed === true : true };
+    },
+  };
+
+  const accessControlProvider = $derived(
+    showAllowed === undefined ? undefined : testAccessControlProvider,
+  );
 </script>
 
 {#snippet dashboard()}
@@ -46,4 +64,4 @@
   <AutoTable resourceName="users" selectable={false} expandedRowRender={expandedRowRender as never} />
 {/snippet}
 
-<AdminApp {dataProvider} {resources} {routerProvider} {locale} dashboard={dashboard as never} />
+<AdminApp {dataProvider} {resources} {routerProvider} {accessControlProvider} {locale} dashboard={dashboard as never} />


### PR DESCRIPTION
## Summary

- widen `@svadmin/sveltekit` core peer compatibility through 0.35.x
- honor `canShow` and access-control show permissions in AutoTable detail actions
- keep DevTools resource diagnostics scoped to the active AdminContext
- add peer, permission, navigation, and reactive-resource regressions

## Verification

- `bun test packages/sveltekit/tests/peer-compat.test.ts packages/sveltekit/tests/router-provider.test.ts`
- focused AutoTable permission/navigation tests: 3 passed
- focused AutoTable + DevTools suites: 8 passed after oracle correction
- `bun run typecheck`
- targeted ESLint and Svelte autofixer
- `bun install --frozen-lockfile`
- `bun run pack:check`
- `git diff --check`

This is a prerequisite for upgrading SupaCloud's admin console to core 0.35 and the next UI/SvelteKit patch releases.
