### PR TITLE
chore(repo): transfer to vibeunion org

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > 面向 Svelte 5 的 Headless 管理后台框架 — 自带后端适配
 
 [![npm](https://img.shields.io/npm/v/@svadmin/core?color=ff3e00&label=npm)](https://www.npmjs.com/package/@svadmin/core)
-[![license](https://img.shields.io/github/license/zuohuadong/svadmin)](LICENSE)
+[![license](https://img.shields.io/github/license/vibeunion/svadmin)](LICENSE)
 
 [English](#-features) | [中文](#-特性) | [📖 Documentation / 文档](https://svadmin.nestjs.cn)
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -45,10 +45,10 @@ export default defineConfig({
         'zh-cn': { label: '简体中文', lang: 'zh-CN' },
       },
       social: [
-        { icon: 'github', label: 'GitHub', href: 'https://github.com/zuohuadong/svadmin' },
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/vibeunion/svadmin' },
       ],
       editLink: {
-        baseUrl: 'https://github.com/zuohuadong/svadmin/edit/main/docs/',
+        baseUrl: 'https://github.com/vibeunion/svadmin/edit/main/docs/',
       },
       sidebar: [
         {

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -13,7 +13,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: View on GitHub
-      link: https://github.com/zuohuadong/svadmin
+      link: https://github.com/vibeunion/svadmin
       icon: external
       variant: minimal
 ---

--- a/docs/src/content/docs/zh-cn/index.mdx
+++ b/docs/src/content/docs/zh-cn/index.mdx
@@ -13,7 +13,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: GitHub 仓库
-      link: https://github.com/zuohuadong/svadmin
+      link: https://github.com/vibeunion/svadmin
       icon: external
       variant: minimal
 ---

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zuohuadong/svadmin.git"
+    "url": "git+https://github.com/vibeunion/svadmin.git"
   },
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.2.1",

--- a/packages/airtable/package.json
+++ b/packages/airtable/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/airtable"
   },
   "peerDependenciesMeta": {

--- a/packages/appwrite/package.json
+++ b/packages/appwrite/package.json
@@ -35,12 +35,12 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/appwrite"
   },
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   },
   "peerDependenciesMeta": {
     "@svadmin/core": {

--- a/packages/auth-utils/package.json
+++ b/packages/auth-utils/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin",
+    "url": "https://github.com/vibeunion/svadmin",
     "directory": "packages/auth-utils"
   },
   "sideEffects": false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/core"
   },
   "main": "src/index.ts",
@@ -59,7 +59,7 @@
     }
   },
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   },
   "description": "Core SDK — hooks, types, context, i18n, permissions, router",
   "files": [
@@ -69,7 +69,7 @@
     "!src/**/vitest.config.*",
     "!src/**/setupTest.*"
   ],
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "license": "MIT",
   "sideEffects": false,
   "type": "module",

--- a/packages/create-svadmin/package.json
+++ b/packages/create-svadmin/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/create-svadmin"
   }
 }

--- a/packages/create-svadmin/src/index.ts
+++ b/packages/create-svadmin/src/index.ts
@@ -286,7 +286,7 @@ dist
 
   fs.writeFileSync(path.join(projectDir, 'README.md'), `# ${response.projectName}
 
-Built with [svadmin](https://github.com/zuohuadong/svadmin) — Headless Admin Framework for Svelte 5.
+Built with [svadmin](https://github.com/vibeunion/svadmin) — Headless Admin Framework for Svelte 5.
 
 ## Getting Started
 
@@ -327,7 +327,7 @@ bun run dev
   }
   console.log(`    ${pc.cyan('bun run dev')}`);
   console.log();
-  console.log(`  Docs: ${pc.blue('https://github.com/zuohuadong/svadmin')}`);
+  console.log(`  Docs: ${pc.blue('https://github.com/vibeunion/svadmin')}`);
   console.log();
 }
 

--- a/packages/directus/package.json
+++ b/packages/directus/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/directus"
   },
   "peerDependenciesMeta": {

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -27,12 +27,12 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/drizzle"
   },
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   },
   "devDependencies": {
     "drizzle-orm": "^1.0.0-rc.1",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -79,7 +79,7 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/editor"
   },
   "peerDependenciesMeta": {

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -28,7 +28,7 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/elysia"
   },
   "peerDependenciesMeta": {

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/firebase"
   },
   "peerDependenciesMeta": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/graphql"
   },
   "peerDependenciesMeta": {

--- a/packages/hasura/package.json
+++ b/packages/hasura/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/hasura"
   },
   "peerDependenciesMeta": {

--- a/packages/lite/README.md
+++ b/packages/lite/README.md
@@ -1,6 +1,6 @@
 # @svadmin/lite
 
-**Lightweight, SSR-compatible admin UI for [@svadmin](https://github.com/zuohuadong/svadmin).**
+**Lightweight, SSR-compatible admin UI for [@svadmin](https://github.com/vibeunion/svadmin).**
 
 Core server-driven CRUD flows can run without hydration. An optional `enhance.js` asset adds progressive client-side conveniences.
 
@@ -61,7 +61,7 @@ export const csr = false;
 
 Put these options on the `/lite` layout so every child route returns server-rendered
 HTML without shipping or executing the Svelte runtime in IE11. See the runnable
-[SSR example](https://github.com/zuohuadong/svadmin/tree/main/packages/lite/example)
+[SSR example](https://github.com/vibeunion/svadmin/tree/main/packages/lite/example)
 for the complete contract and its real-response check.
 
 ```svelte

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -80,7 +80,7 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/lite"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -30,12 +30,12 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/mcp"
   },
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   },
   "peerDependenciesMeta": {
     "@svadmin/core": {

--- a/packages/medusa/package.json
+++ b/packages/medusa/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/medusa"
   },
   "peerDependenciesMeta": {

--- a/packages/nestjs-query/package.json
+++ b/packages/nestjs-query/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/nestjs-query"
   },
   "peerDependenciesMeta": {

--- a/packages/nestjsx-crud/package.json
+++ b/packages/nestjsx-crud/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/nestjsx-crud"
   },
   "peerDependenciesMeta": {

--- a/packages/pocketbase/package.json
+++ b/packages/pocketbase/package.json
@@ -34,12 +34,12 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/pocketbase"
   },
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   },
   "peerDependenciesMeta": {
     "@svadmin/core": {

--- a/packages/refine-adapter/package.json
+++ b/packages/refine-adapter/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/refine-adapter"
   },
   "peerDependenciesMeta": {

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/sanity"
   },
   "peerDependenciesMeta": {

--- a/packages/simple-rest/package.json
+++ b/packages/simple-rest/package.json
@@ -27,12 +27,12 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/simple-rest"
   },
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   },
   "peerDependenciesMeta": {
     "@svadmin/core": {

--- a/packages/sso/package.json
+++ b/packages/sso/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin",
+    "url": "https://github.com/vibeunion/svadmin",
     "directory": "packages/sso"
   },
   "sideEffects": false,

--- a/packages/strapi/package.json
+++ b/packages/strapi/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/strapi"
   },
   "peerDependenciesMeta": {

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -33,12 +33,12 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/supabase"
   },
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   },
   "peerDependenciesMeta": {
     "@svadmin/core": {

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -53,11 +53,11 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/surface"
   },
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   }
 }

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/sveltekit"
   },
   "peerDependenciesMeta": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -89,12 +89,12 @@
   "author": "zuohuadong",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuohuadong/svadmin.git",
+    "url": "https://github.com/vibeunion/svadmin.git",
     "directory": "packages/ui"
   },
-  "homepage": "https://github.com/zuohuadong/svadmin#readme",
+  "homepage": "https://github.com/vibeunion/svadmin#readme",
   "bugs": {
-    "url": "https://github.com/zuohuadong/svadmin/issues"
+    "url": "https://github.com/vibeunion/svadmin/issues"
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.11.2",


### PR DESCRIPTION
## 仓库迁移到 vibeunion 组织

GitHub 原生 Transfer 已完成：`zuohuadong/svadmin` → `vibeunion/svadmin`

保留了全部 Issues、PRs、Releases、Stars、Forks，旧 URL 自动重定向到新地址。

### 本 PR 内容

将 34 个文件中的 `zuohuadong/svadmin` 替换为 `vibeunion/svadmin`：

- 根 `package.json` — repository.url / homepage / bugs.url
- 26 个子包 `packages/*/package.json` — repository.url / homepage / bugs.url
- `README.md` — license badge
- `docs/astro.config.mjs` — GitHub 链接和编辑 base URL
- `docs/src/content/docs/index.mdx` + `zh-cn/index.mdx` — 链接
- `packages/create-svadmin/src/index.ts` — CLI 输出和 footer
- `packages/lite/README.md` — 链接

### 未修改

- **CHANGELOG.md**（共 27 个）— Release Please 自动生成的历史记录，保留原始引用
- **.github/workflows/** — 使用 `${{ github.repository }}`，转移后自动生效
- **.github/dependabot.yml** — 无仓库地址引用
- **release-please-config.json** — 无仓库地址引用
- **author 字段** — 个人作者名，不属于组织迁移范围
- **RELEASE_PAT secret** — 仓库转移后 secret 自动保留，无需更新

### 已完成

- [x] GitHub 仓库转移（即时生效）
- [x] 本地 remote 更新为 `git@github.com:vibeunion/svadmin.git`
- [x] 分支推送验证 SSH 连接正常