### PR TITLE
fix: resolve GitHub Code Quality findings

### DIFF
--- a/packages/lite/src/components/LiteForm.test.svelte.ts
+++ b/packages/lite/src/components/LiteForm.test.svelte.ts
@@ -121,7 +121,8 @@ describe('LiteForm array fields', () => {
     expect(removeSubmitter?.type).toBe('submit');
     expect(removeSubmitter?.formNoValidate).toBe(true);
     expect(removeSubmitter?.textContent?.trim()).toBe('Remove item');
-    expect(removeSubmitter && form ? new FormData(form, removeSubmitter).get('contacts[0][_delete]') : null).toBe('1');
+    expect(removeSubmitter?.name).toBe('contacts[0][_delete]');
+    expect(removeSubmitter?.value).toBe('1');
   });
 
   it('keeps file uploads native while image fields retain shared URL semantics', () => {


### PR DESCRIPTION
## Finding

- `#1 js/superfluous-trailing-arguments` (`warning`, reliability)
- `packages/lite/src/components/LiteForm.test.svelte.ts:124`
- CodeQL reported the second argument passed to `FormData` as superfluous.

## Fix

- replace `new FormData(form, removeSubmitter)` with direct assertions for the submit button's `name` and `value`
- preserve the no-JavaScript removal contract (`type="submit"`, `formnovalidate`, payload name/value)
- keep the final diff limited to one test file and one commit

## Validation

- [x] repository CI run 1082: lint, builds, Lite SSR, tests, example bundle, docs, typecheck, pack checks, audit
- [x] Playwright E2E tests
- [x] final PR head has no Code Quality bot comments or review threads

The temporary read-only diagnostics workflow used to retrieve the exact finding was removed before the branch was squashed. The default-branch dashboard finding is expected to close after this PR is merged and `main` is rescanned.