### PR TITLE
fix(ui): keep layout mounted during auth rechecks

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -145,7 +145,7 @@ export {
 export { useParsed, resetGlobalPath, syncGlobalPath } from './useParsed.svelte';
 export * from './useStepsForm.svelte';
 export { createHashRouterProvider, createHistoryRouterProvider } from './router-provider';
-export type { RouterProvider } from './router-provider';
+export type { RouterNavigationResult, RouterProvider } from './router-provider';
 export { inferFieldType, inferResource } from './inferencer';
 export type { InferResult } from './inferencer';
 export { createWebSocketLiveProvider } from './live-websocket';

--- a/packages/core/src/router-navigation.test.svelte.ts
+++ b/packages/core/src/router-navigation.test.svelte.ts
@@ -46,6 +46,31 @@ describe('scoped router navigation', () => {
     expect(after).toHaveBeenCalledWith('/posts/edit/1', '/posts?page=2');
   });
 
+  it('waits for an asynchronous provider before syncing and running after hooks', async () => {
+    let finishNavigation!: () => void;
+    const navigation = new Promise<void>((resolve) => {
+      finishNavigation = resolve;
+    });
+    const router = createRouter();
+    router.go = vi.fn(() => navigation);
+    const after = vi.fn();
+    const sync = vi.fn();
+    registerAfterEach(after);
+    registerRouterSync(sync);
+
+    const pending = navigateWithProvider(router, '/posts/edit/1');
+    await Promise.resolve();
+
+    expect(sync).not.toHaveBeenCalled();
+    expect(after).not.toHaveBeenCalled();
+
+    finishNavigation();
+    await pending;
+
+    expect(sync).toHaveBeenCalledTimes(1);
+    expect(after).toHaveBeenCalledWith('/posts/edit/1', '/posts?page=2');
+  });
+
   it('does not navigate or sync when a guard rejects the route', async () => {
     const router = createRouter();
     const sync = vi.fn();
@@ -56,6 +81,20 @@ describe('scoped router navigation', () => {
 
     expect(router.go).not.toHaveBeenCalled();
     expect(sync).not.toHaveBeenCalled();
+  });
+
+  it('does not sync or run after hooks when the provider cancels navigation', async () => {
+    const router = createRouter();
+    router.go = vi.fn(async () => false as const);
+    const after = vi.fn();
+    const sync = vi.fn();
+    registerAfterEach(after);
+    registerRouterSync(sync);
+
+    await navigateWithProvider(router, '/cancelled');
+
+    expect(sync).not.toHaveBeenCalled();
+    expect(after).not.toHaveBeenCalled();
   });
 
   it('uses the explicit provider for current paths and formatted links', () => {

--- a/packages/core/src/router-provider.ts
+++ b/packages/core/src/router-provider.ts
@@ -1,5 +1,7 @@
 // Router Provider — abstracts routing strategy (hash, history, SvelteKit, etc.)
 
+export type RouterNavigationResult = false | ReturnType<() => void>;
+
 export interface RouterProvider {
   /** Navigate to a path */
   go: (options: {
@@ -7,7 +9,7 @@ export interface RouterProvider {
     query?: Record<string, string>;
     hash?: string;
     type?: 'push' | 'replace';
-  }) => void;
+  }) => RouterNavigationResult | Promise<RouterNavigationResult>;
   /** Navigate back */
   back: () => void;
   /** Parse current URL into structured route info */

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -82,7 +82,8 @@ export async function navigateWithProvider(
     if (!allowed) return;
   }
   if (provider) {
-    provider.go({ to: path, type: options?.replaceState ? 'replace' : 'push' });
+    const navigated = await provider.go({ to: path, type: options?.replaceState ? 'replace' : 'push' });
+    if (navigated === false) return;
   } else if (typeof window !== 'undefined') {
     window.location.hash = '#' + path.replace(/^#/, '');
   }

--- a/packages/ui/src/components/AdminApp.svelte
+++ b/packages/ui/src/components/AdminApp.svelte
@@ -200,8 +200,7 @@
   const routerState = provideRouterState(untrack(() => resolvedRouter));
   const scopedRouterProvider: RouterProvider = {
     go(options) {
-      resolvedRouter.go(options);
-      routerState.sync();
+      return navigateAfterAuthCheck(options);
     },
     back() {
       resolvedRouter.back();
@@ -303,9 +302,8 @@
   // Reactive getters for route state
   const route = $derived(routerState.route);
   const params = $derived(routerState.params);
+  const path = $derived(routerState.path);
   const resourceNames = $derived(new Set(resources.map((resource) => resource.name)));
-  const hasRouteResource = $derived(!params.resource || resourceNames.has(params.resource));
-  const currentResourcePages = $derived(params.resource ? resourcePages?.[params.resource] : undefined);
   const isStandaloneTwoFactor = $derived(route === '/2fa' || route === '/authentication/branded/2fa');
   const standaloneErrorStatus = $derived.by((): '404' | '500' | undefined => {
     if (route === '/authentication/error-404' || route === '/404' || (route === '/:resource' && params.resource === '404')) return '404';
@@ -316,9 +314,82 @@
   // Auth check
   let isAuthenticated = $state(untrack(() => !resolvedAuthProvider));
   let authChecked = $state(untrack(() => !resolvedAuthProvider));
+  let checkedAuthProvider = $state.raw<AuthProvider | null>(null);
+  let checkedAuthPath = $state<string | null>(null);
+  let navigationAuthPending = $state(false);
+  let navigationCheckId = 0;
+  const authProviderPending = $derived(!!resolvedAuthProvider && checkedAuthProvider !== resolvedAuthProvider);
+  const authRechecking = $derived(
+    navigationAuthPending
+      || (!!resolvedAuthProvider
+        && !authProviderPending
+        && authChecked
+        && isAuthenticated
+        && checkedAuthPath !== path),
+  );
+  const renderedRoute = $derived(route);
+  const renderedParams = $derived(params);
+  const renderedHasRouteResource = $derived(!renderedParams.resource || resourceNames.has(renderedParams.resource));
+  const renderedResourcePages = $derived(renderedParams.resource ? resourcePages?.[renderedParams.resource] : undefined);
 
-  async function navigateWithinApp(path: string) {
-    await adminContext.navigate(path);
+  async function navigateWithinApp(path: string, options?: { replaceState?: boolean }) {
+    await adminContext.navigate(path, options);
+  }
+
+  async function commitNavigation(options: Parameters<RouterProvider['go']>[0]): Promise<Awaited<ReturnType<RouterProvider['go']>>> {
+    const navigated = await resolvedRouter.go(options);
+    if (navigated === false) return false;
+    routerState.sync();
+    return navigated;
+  }
+
+  function recordCheckedRoute(provider: AuthProvider) {
+    checkedAuthProvider = provider;
+    checkedAuthPath = routerState.path;
+  }
+
+  async function navigateAfterAuthCheck(options: Parameters<RouterProvider['go']>[0]): Promise<Awaited<ReturnType<RouterProvider['go']>>> {
+    const provider = resolvedAuthProvider;
+    if (!provider || checkedAuthProvider !== provider || !authChecked || !isAuthenticated) {
+      return commitNavigation(options);
+    }
+
+    const checkId = ++navigationCheckId;
+    navigationAuthPending = true;
+    let result: Awaited<ReturnType<AuthProvider['check']>>;
+    try {
+      result = await provider.check();
+    } catch (err) {
+      if (checkId !== navigationCheckId || provider !== resolvedAuthProvider) return false;
+      console.warn('Auth check failed:', err);
+      isAuthenticated = false;
+      authChecked = true;
+      try {
+        await navigateWithinApp('/login', { replaceState: true });
+        recordCheckedRoute(provider);
+        return false;
+      } finally {
+        if (checkId === navigationCheckId) navigationAuthPending = false;
+      }
+    }
+
+    if (checkId !== navigationCheckId || provider !== resolvedAuthProvider) return false;
+    try {
+      if (!result.authenticated) {
+        isAuthenticated = false;
+        authChecked = true;
+        await navigateWithinApp(result.redirectTo ?? '/login', { replaceState: true });
+        recordCheckedRoute(provider);
+        return false;
+      }
+      const navigated = await commitNavigation(options);
+      if (navigated === false) return false;
+      if (checkId !== navigationCheckId || provider !== resolvedAuthProvider) return false;
+      recordCheckedRoute(provider);
+      return navigated;
+    } finally {
+      if (checkId === navigationCheckId) navigationAuthPending = false;
+    }
   }
 
   function isPublicSystemRoute(currentRoute: string): boolean {
@@ -332,19 +403,35 @@
     let cancelled = false;
     // Explicitly track route so auth is re-checked on navigation
     const _route = route;
+    const _path = path;
+    const provider = resolvedAuthProvider;
+    navigationCheckId += 1;
+    navigationAuthPending = false;
 
-    if (!resolvedAuthProvider) {
+    if (!provider) {
       if (!cancelled) {
         isAuthenticated = true;
         authChecked = true;
+        checkedAuthProvider = null;
+        checkedAuthPath = _path;
       }
       return;
     }
-    authChecked = false;
-    resolvedAuthProvider.check().then(result => {
+    if (
+      untrack(() => checkedAuthProvider) === provider
+      && untrack(() => checkedAuthPath) === _path
+    ) return;
+    const providerChanged = untrack(() => checkedAuthProvider) !== provider;
+    if (providerChanged) {
+      isAuthenticated = false;
+      authChecked = false;
+    }
+    provider.check().then(result => {
       if (cancelled) return;
       isAuthenticated = result.authenticated;
       authChecked = true;
+      checkedAuthProvider = provider;
+      checkedAuthPath = _path;
       if (!result.authenticated && _route !== '/login' && _route !== '/register' && _route !== '/forgot-password' && _route !== '/update-password' && !isPublicSystemRoute(_route)) {
         void navigateWithinApp(result.redirectTo ?? '/login');
       }
@@ -353,6 +440,8 @@
       console.warn('Auth check failed:', err);
       isAuthenticated = false;
       authChecked = true;
+      checkedAuthProvider = provider;
+      checkedAuthPath = _path;
       if (_route !== '/login' && _route !== '/register' && _route !== '/forgot-password' && _route !== '/update-password' && !isPublicSystemRoute(_route)) {
         void navigateWithinApp('/login');
       }
@@ -365,7 +454,7 @@
 <QueryClientProvider client={queryClient}>
   {#if !resolvedDataProvider}
     <ConfigErrorScreen title="{title} — DataProvider is required" />
-  {:else if !authChecked}
+  {:else if !authChecked || authProviderPending}
     <div class="flex h-screen items-center justify-center">
       <div class="space-y-4 text-center">
         <div class="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary mx-auto"></div>
@@ -390,7 +479,7 @@
     <UpdatePasswordPage {title} />
   {:else if route === '/login' || route === '/register' || route === '/forgot-password' || route === '/update-password'}
     <ConfigErrorScreen title="{title} — {translation.t('common.configRequired')}" />
-  {:else if (isAuthenticated || !resolvedAuthProvider) && isStandaloneTwoFactor}
+  {:else if (isAuthenticated || !resolvedAuthProvider) && isStandaloneTwoFactor && !authRechecking}
     <SystemPageShell {title}>
       <LazyPage loader={loadTwoFactorAuthPage} props={{}} />
     </SystemPageShell>
@@ -401,47 +490,56 @@
     </SystemPageShell>
   {:else if isAuthenticated || !resolvedAuthProvider}
     <Layout {title} {menu} {siteUrl} routeMode={resolvedRouteMode}>
-      {#key route + (params.resource ?? '') + (params.id ?? '') + (params.variant ?? '') + (params.columns ?? '')}
+      <div class="relative min-h-40" aria-busy={authRechecking}>
+        {#if authRechecking}
+          <div class="absolute inset-0 z-10 flex min-h-40 items-center justify-center bg-background/80" role="status" aria-live="polite">
+            <div class="space-y-3 text-center">
+              <div class="h-6 w-6 animate-spin rounded-full border-4 border-muted border-t-primary mx-auto"></div>
+              <p class="text-sm text-muted-foreground">Loading...</p>
+            </div>
+          </div>
+        {:else}
+      {#key renderedRoute + (renderedParams.resource ?? '') + (renderedParams.id ?? '') + (renderedParams.variant ?? '') + (renderedParams.columns ?? '')}
       <div class="svadmin-page-enter">
-      {#if route === '/public-profile'}
+      {#if renderedRoute === '/public-profile'}
         <LazyPage loader={loadPublicProfilePage} props={{ variant: 'default', initialTab: 'projects' }} />
-      {:else if route === '/public-profile/projects/:columns'}
-        <LazyPage loader={loadPublicProfilePage} props={{ variant: 'default', initialTab: 'projects', columns: params.columns?.includes('3') ? 3 : 2 }} />
-      {:else if route === '/public-profile/activity'}
+      {:else if renderedRoute === '/public-profile/projects/:columns'}
+        <LazyPage loader={loadPublicProfilePage} props={{ variant: 'default', initialTab: 'projects', columns: renderedParams.columns?.includes('3') ? 3 : 2 }} />
+      {:else if renderedRoute === '/public-profile/activity'}
         <LazyPage loader={loadPublicProfilePage} props={{ variant: 'default', initialTab: 'activity' }} />
-      {:else if route === '/public-profile/teams'}
+      {:else if renderedRoute === '/public-profile/teams'}
         <LazyPage loader={loadPublicProfilePage} props={{ variant: 'default', initialTab: 'teams' }} />
-      {:else if route === '/public-profile/profiles/:variant'}
-        <LazyPage loader={loadPublicProfilePage} props={{ variant: (params.variant === 'company' || params.variant === 'gamer' || params.variant === 'default' ? params.variant : 'default') as 'company' | 'gamer' | 'default', showSections: true }} />
-      {:else if route === '/account/get-started' || route === '/account/home/get-started'}
+      {:else if renderedRoute === '/public-profile/profiles/:variant'}
+        <LazyPage loader={loadPublicProfilePage} props={{ variant: (renderedParams.variant === 'company' || renderedParams.variant === 'gamer' || renderedParams.variant === 'default' ? renderedParams.variant : 'default') as 'company' | 'gamer' | 'default', showSections: true }} />
+      {:else if renderedRoute === '/account/get-started' || renderedRoute === '/account/home/get-started'}
         <LazyPage loader={loadGetStartedPage} props={{}} />
-      {:else if route === '/account/home/user-profile'}
+      {:else if renderedRoute === '/account/home/user-profile'}
         <LazyPage loader={loadUserProfilePage} props={{}} />
-      {:else if route === '/account/company-profile' || route === '/account/home/company-profile'}
+      {:else if renderedRoute === '/account/company-profile' || renderedRoute === '/account/home/company-profile'}
         <LazyPage loader={loadCompanyProfilePage} props={{}} />
-      {:else if route === '/account/settings-plain' || route === '/account/home/settings-plain'}
+      {:else if renderedRoute === '/account/settings-plain' || renderedRoute === '/account/home/settings-plain'}
         <LazyPage loader={loadSettingsPlainPage} props={{}} />
-      {:else if route === '/account/settings-sidebar' || route === '/account/home/settings-sidebar'}
+      {:else if renderedRoute === '/account/settings-sidebar' || renderedRoute === '/account/home/settings-sidebar'}
         <LazyPage loader={loadSettingsSidebarPage} props={{}} />
-      {:else if route === '/account/settings-enterprise' || route === '/account/home/settings-enterprise'}
+      {:else if renderedRoute === '/account/settings-enterprise' || renderedRoute === '/account/home/settings-enterprise'}
         <LazyPage loader={loadSettingsEnterprisePage} props={{}} />
-      {:else if route === '/account/:tab'}
+      {:else if renderedRoute === '/account/:tab'}
         <SettingsPage />
-      {:else if route === '/account/import-members' || route === '/account/members/import-members'}
+      {:else if renderedRoute === '/account/import-members' || renderedRoute === '/account/members/import-members'}
         <LazyPage loader={loadImportMembersPage} props={{}} />
-      {:else if route === '/account/members-starter' || route === '/account/members/members-starter'}
+      {:else if renderedRoute === '/account/members-starter' || renderedRoute === '/account/members/members-starter'}
         <LazyPage loader={loadMembersStarterPage} props={{}} />
-      {:else if route === '/account/team-members' || route === '/account/members/team-members'}
+      {:else if renderedRoute === '/account/team-members' || renderedRoute === '/account/members/team-members'}
         <LazyPage loader={loadTeamMembersPage} props={{}} />
-      {:else if route === '/account/security-log' || route === '/account/security/security-log'}
+      {:else if renderedRoute === '/account/security-log' || renderedRoute === '/account/security/security-log'}
         <LazyPage loader={loadSecurityLogPage} props={{}} />
-      {:else if route === '/network/user-cards' || route === '/network/user-cards/nft'}
+      {:else if renderedRoute === '/network/user-cards' || renderedRoute === '/network/user-cards/nft'}
         <LazyPage loader={loadUserCardsNFTPage} props={{}} />
-      {:else if route === '/network/team-crew' || route === '/network/user-table/team-crew'}
+      {:else if renderedRoute === '/network/team-crew' || renderedRoute === '/network/user-table/team-crew'}
         <LazyPage loader={loadTeamCrewTablePage} props={{}} />
-      {:else if route.startsWith('/settings')}
+      {:else if renderedRoute.startsWith('/settings')}
         <SettingsPage />
-      {:else if route === '/' || route === '' || route === '/inventory-dashboard'}
+      {:else if renderedRoute === '/' || renderedRoute === '' || renderedRoute === '/inventory-dashboard'}
         {#if dashboard}
           {@render dashboard()}
         {:else}
@@ -450,30 +548,30 @@
             <p class="text-muted-foreground">{translation.t('common.dashboardHint')}</p>
           </div>
         {/if}
-      {:else if (route === '/:resource' || route === '/:parent/:parentId/:resource') && hasRouteResource}
-        {#key params.resource}
-          {@const Comp = currentResourcePages?.list ?? mergedComponents.AutoTable}
-          <Comp resourceName={params.resource} />
+      {:else if (renderedRoute === '/:resource' || renderedRoute === '/:parent/:parentId/:resource') && renderedHasRouteResource}
+        {#key renderedParams.resource}
+          {@const Comp = renderedResourcePages?.list ?? mergedComponents.AutoTable}
+          <Comp resourceName={renderedParams.resource} />
         {/key}
-      {:else if (route === '/:resource/create' || route === '/:parent/:parentId/:resource/create') && hasRouteResource}
-        {#key params.resource}
-          {@const Comp = currentResourcePages?.create ?? mergedComponents.AutoForm}
-          <Comp resourceName={params.resource} mode="create" />
+      {:else if (renderedRoute === '/:resource/create' || renderedRoute === '/:parent/:parentId/:resource/create') && renderedHasRouteResource}
+        {#key renderedParams.resource}
+          {@const Comp = renderedResourcePages?.create ?? mergedComponents.AutoForm}
+          <Comp resourceName={renderedParams.resource} mode="create" />
         {/key}
-      {:else if (route === '/:resource/edit/:id' || route === '/:parent/:parentId/:resource/edit/:id') && hasRouteResource}
-        {#key `${params.resource}-${params.id}`}
-          {@const Comp = currentResourcePages?.edit ?? mergedComponents.AutoForm}
-          <Comp resourceName={params.resource} mode="edit" id={params.id} />
+      {:else if (renderedRoute === '/:resource/edit/:id' || renderedRoute === '/:parent/:parentId/:resource/edit/:id') && renderedHasRouteResource}
+        {#key `${renderedParams.resource}-${renderedParams.id}`}
+          {@const Comp = renderedResourcePages?.edit ?? mergedComponents.AutoForm}
+          <Comp resourceName={renderedParams.resource} mode="edit" id={renderedParams.id} />
         {/key}
-      {:else if (route === '/:resource/show/:id' || route === '/:parent/:parentId/:resource/show/:id') && hasRouteResource}
-        {#key `${params.resource}-${params.id}`}
-          {@const Comp = currentResourcePages?.show ?? mergedComponents.ShowPage}
-          <Comp resourceName={params.resource} id={params.id} />
+      {:else if (renderedRoute === '/:resource/show/:id' || renderedRoute === '/:parent/:parentId/:resource/show/:id') && renderedHasRouteResource}
+        {#key `${renderedParams.resource}-${renderedParams.id}`}
+          {@const Comp = renderedResourcePages?.show ?? mergedComponents.ShowPage}
+          <Comp resourceName={renderedParams.resource} id={renderedParams.id} />
         {/key}
-      {:else if (route === '/:resource/clone/:id' || route === '/:parent/:parentId/:resource/clone/:id') && hasRouteResource}
-        {#key `${params.resource}-clone-${params.id}`}
-          {@const Comp = currentResourcePages?.clone ?? mergedComponents.AutoForm}
-          <Comp resourceName={params.resource} mode="clone" id={params.id} />
+      {:else if (renderedRoute === '/:resource/clone/:id' || renderedRoute === '/:parent/:parentId/:resource/clone/:id') && renderedHasRouteResource}
+        {#key `${renderedParams.resource}-clone-${renderedParams.id}`}
+          {@const Comp = renderedResourcePages?.clone ?? mergedComponents.AutoForm}
+          <Comp resourceName={renderedParams.resource} mode="clone" id={renderedParams.id} />
         {/key}
       {:else}
         {@const ErrorComp = mergedComponents.ErrorPage || ErrorPage}
@@ -481,6 +579,8 @@
       {/if}
       </div>
       {/key}
+        {/if}
+      </div>
     </Layout>
   {:else}
     <div class="flex h-screen items-center justify-center">

--- a/packages/ui/src/components/admin-app-auth-navigation.test-page.svelte
+++ b/packages/ui/src/components/admin-app-auth-navigation.test-page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  let { resourceName }: { resourceName: string } = $props();
+
+  onMount(() => {
+    window.dispatchEvent(new CustomEvent('svadmin:test-page-mounted'));
+  });
+</script>
+
+<section aria-label="Posts page" data-resource={resourceName}>Posts page</section>

--- a/packages/ui/src/components/admin-app-auth-navigation.test.svelte.ts
+++ b/packages/ui/src/components/admin-app-auth-navigation.test.svelte.ts
@@ -1,0 +1,277 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthProvider, CheckResult, DataProvider, ResourceDefinition, RouterProvider } from '@svadmin/core';
+import { resetContext } from '@svadmin/core';
+import AdminApp from './AdminApp.svelte';
+import TestPage from './admin-app-auth-navigation.test-page.svelte';
+
+function createDataProvider(): DataProvider {
+  return {
+    getList: async () => ({ data: [], total: 0 }),
+    getOne: async () => ({ data: { id: 'test' } }),
+    create: async () => ({ data: { id: 'test' } }),
+    update: async () => ({ data: { id: 'test' } }),
+    deleteOne: async () => ({ data: { id: 'test' } }),
+    getApiUrl: () => 'https://example.test',
+  } as DataProvider;
+}
+
+function deferredCheck() {
+  let resolve!: (result: CheckResult) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<CheckResult>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function deferredNavigation() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function createTestRouter(go: RouterProvider['go']): RouterProvider {
+  return {
+    go,
+    back: () => {},
+    parse: () => {
+      const pathname = window.location.hash.replace(/^#/, '').split('?')[0] || '/';
+      const segments = pathname.split('/').filter(Boolean);
+      return {
+        resource: segments[0],
+        action: segments[1],
+        id: segments[2],
+        params: {},
+        pathname,
+      };
+    },
+    formatLink: (path) => `#${path.replace(/^#/, '')}`,
+  };
+}
+
+const resources: ResourceDefinition[] = [{
+  name: 'posts',
+  label: 'Posts',
+  fields: [],
+}];
+
+let pageMountedListener: (() => void) | undefined;
+
+function createAuthProvider(check: AuthProvider['check']): AuthProvider {
+  return {
+    login: async () => ({ success: true }),
+    logout: async () => ({ success: true }),
+    check,
+    getIdentity: async () => ({ id: 'admin', name: 'Admin' }),
+  };
+}
+
+beforeEach(() => {
+  window.location.hash = '#/';
+  Object.defineProperty(Element.prototype, 'animate', {
+    configurable: true,
+    value: () => ({
+      cancel: () => {},
+      finished: Promise.resolve(),
+    }),
+  });
+  resetContext();
+});
+
+afterEach(() => {
+  if (pageMountedListener) {
+    window.removeEventListener('svadmin:test-page-mounted', pageMountedListener);
+    pageMountedListener = undefined;
+  }
+  cleanup();
+  resetContext();
+  vi.restoreAllMocks();
+});
+
+describe('AdminApp authenticated navigation', () => {
+  it('blocks the layout until the initial auth check completes', async () => {
+    const initialCheck = deferredCheck();
+
+    const view = render(AdminApp, {
+      dataProvider: createDataProvider(),
+      authProvider: createAuthProvider(() => initialCheck.promise),
+      resources,
+    });
+
+    expect(view.queryByRole('complementary', { name: 'Sidebar navigation' })).toBeNull();
+    expect(view.getByText('Loading...')).not.toBeNull();
+
+    initialCheck.resolve({ authenticated: true });
+    await waitFor(() => expect(view.getByRole('complementary', { name: 'Sidebar navigation' })).not.toBeNull());
+  });
+
+  it('keeps the authenticated layout mounted while a route recheck is pending', async () => {
+    const recheck = deferredCheck();
+    const pageMounted = vi.fn();
+    pageMountedListener = pageMounted;
+    window.addEventListener('svadmin:test-page-mounted', pageMountedListener);
+    const check = vi.fn<AuthProvider['check']>()
+      .mockResolvedValueOnce({ authenticated: true })
+      .mockImplementation(() => recheck.promise);
+
+    const view = render(AdminApp, {
+      dataProvider: createDataProvider(),
+      authProvider: createAuthProvider(check),
+      resources,
+      resourcePages: { posts: { list: TestPage } },
+    });
+
+    const postsLink = await waitFor(() => view.getByRole('link', { name: 'Posts' }));
+    expect(view.queryByRole('complementary', { name: 'Sidebar navigation' })).not.toBeNull();
+
+    await fireEvent.click(postsLink);
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+
+    expect(view.queryByRole('complementary', { name: 'Sidebar navigation' })).not.toBeNull();
+    expect(view.queryByRole('region', { name: 'Posts page' })).toBeNull();
+    expect(pageMounted).not.toHaveBeenCalled();
+    expect(window.location.hash).toBe('#/');
+
+    recheck.resolve({ authenticated: true });
+    await waitFor(() => expect(view.getByRole('region', { name: 'Posts page' })).not.toBeNull());
+    expect(pageMounted).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks the layout again when the auth provider changes', async () => {
+    const replacementCheck = deferredCheck();
+    const dataProvider = createDataProvider();
+    const initialAuthProvider = createAuthProvider(async () => ({ authenticated: true }));
+    const replacementAuthProvider = createAuthProvider(() => replacementCheck.promise);
+    const view = render(AdminApp, {
+      dataProvider,
+      authProvider: initialAuthProvider,
+      resources,
+    });
+
+    await waitFor(() => expect(view.getByRole('complementary', { name: 'Sidebar navigation' })).not.toBeNull());
+
+    await view.rerender({
+      dataProvider,
+      authProvider: replacementAuthProvider,
+      resources,
+    });
+
+    expect(view.queryByRole('complementary', { name: 'Sidebar navigation' })).toBeNull();
+    expect(view.getByText('Loading...')).not.toBeNull();
+
+    replacementCheck.resolve({ authenticated: true });
+    await waitFor(() => expect(view.getByRole('complementary', { name: 'Sidebar navigation' })).not.toBeNull());
+  });
+
+  it('does not mount a protected standalone page before an external route recheck completes', async () => {
+    const recheck = deferredCheck();
+    const check = vi.fn<AuthProvider['check']>()
+      .mockResolvedValueOnce({ authenticated: true })
+      .mockImplementation(() => recheck.promise);
+    const view = render(AdminApp, {
+      dataProvider: createDataProvider(),
+      authProvider: createAuthProvider(check),
+      resources,
+    });
+
+    await waitFor(() => expect(view.getByRole('complementary', { name: 'Sidebar navigation' })).not.toBeNull());
+
+    window.location.hash = '#/2fa';
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+
+    expect(view.queryByRole('complementary', { name: 'Sidebar navigation' })).not.toBeNull();
+    expect(view.container.querySelector('[data-svadmin-content-page="auth-2fa"]')).toBeNull();
+    expect(view.getByText('Loading...')).not.toBeNull();
+
+    recheck.resolve({ authenticated: true });
+    await waitFor(() => expect(view.container.querySelector('[data-svadmin-content-page="auth-2fa"]')).not.toBeNull());
+  });
+
+  it('does not let a stale async router commit overwrite a replacement auth provider', async () => {
+    const navigation = deferredNavigation();
+    const routerGo = vi.fn<RouterProvider['go']>(() => navigation.promise);
+    const router = createTestRouter(routerGo);
+    const dataProvider = createDataProvider();
+    const initialAuthProvider = createAuthProvider(async () => ({ authenticated: true }));
+    const replacementAuthProvider = createAuthProvider(async () => ({ authenticated: true }));
+    const view = render(AdminApp, {
+      dataProvider,
+      authProvider: initialAuthProvider,
+      routerProvider: router,
+      resources,
+    });
+
+    const postsLink = await waitFor(() => view.getByRole('link', { name: 'Posts' }));
+    await fireEvent.click(postsLink);
+    await waitFor(() => expect(routerGo).toHaveBeenCalledTimes(1));
+
+    await view.rerender({
+      dataProvider,
+      authProvider: replacementAuthProvider,
+      routerProvider: router,
+      resources,
+    });
+    await waitFor(() => expect(view.getByRole('complementary', { name: 'Sidebar navigation' })).not.toBeNull());
+
+    navigation.resolve();
+    await navigation.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(view.queryByRole('complementary', { name: 'Sidebar navigation' })).not.toBeNull();
+    expect(view.queryByText('Loading...')).toBeNull();
+  });
+
+  it('removes the layout and redirects when a route recheck expires', async () => {
+    const recheck = deferredCheck();
+    const check = vi.fn<AuthProvider['check']>()
+      .mockResolvedValueOnce({ authenticated: true })
+      .mockImplementation(() => recheck.promise);
+
+    const view = render(AdminApp, {
+      dataProvider: createDataProvider(),
+      authProvider: createAuthProvider(check),
+      resources,
+      resourcePages: { posts: { list: TestPage } },
+    });
+
+    const postsLink = await waitFor(() => view.getByRole('link', { name: 'Posts' }));
+    await fireEvent.click(postsLink);
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+
+    recheck.resolve({ authenticated: false, redirectTo: '/login' });
+
+    await waitFor(() => expect(window.location.hash).toBe('#/login'));
+    expect(view.queryByRole('complementary', { name: 'Sidebar navigation' })).toBeNull();
+    expect(view.queryByRole('region', { name: 'Posts page' })).toBeNull();
+  });
+
+  it('removes the layout and redirects when a route recheck fails', async () => {
+    const recheck = deferredCheck();
+    const check = vi.fn<AuthProvider['check']>()
+      .mockResolvedValueOnce({ authenticated: true })
+      .mockImplementation(() => recheck.promise);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const view = render(AdminApp, {
+      dataProvider: createDataProvider(),
+      authProvider: createAuthProvider(check),
+      resources,
+      resourcePages: { posts: { list: TestPage } },
+    });
+
+    const postsLink = await waitFor(() => view.getByRole('link', { name: 'Posts' }));
+    await fireEvent.click(postsLink);
+    await waitFor(() => expect(check).toHaveBeenCalledTimes(2));
+
+    recheck.reject(new Error('session check failed'));
+
+    await waitFor(() => expect(window.location.hash).toBe('#/login'));
+    expect(view.queryByRole('complementary', { name: 'Sidebar navigation' })).toBeNull();
+    expect(view.queryByRole('region', { name: 'Posts page' })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- keep the authenticated layout mounted while route-level auth rechecks are pending
- show a loading state inside the content area without mounting either the previous or destination page during recheck
- preserve full-screen blocking for initial authentication and AuthProvider replacement
- support async/cancelled RouterProvider navigation and reject stale commits after path/provider changes
- gate protected standalone routes such as `/2fa` until their auth recheck completes

## Root cause

`AdminApp` reset `authChecked` on every protected route change. Its top-level loading branch therefore unmounted the entire layout for each authenticated navigation, producing a visible white-screen refresh across sidebar routes.

## Verification

- focused auth navigation regression tests: 7/7 passing
- focused core router tests: 5/5 passing
- full Playwright E2E: 11/11 passing
- `bun run typecheck`: 0 errors / 0 warnings
- `bun run lint`: passing
- `bun run --cwd packages/ui build`: passing
- Svelte autofixer: no issues
- `git diff --check`: passing
- independent read-only review: PASS