### PR TITLE
fix(release): sync create-svadmin ranges for 0.42.2/0.36.3

### DIFF
--- a/packages/create-svadmin/scaffold-manifest.json
+++ b/packages/create-svadmin/scaffold-manifest.json
@@ -10,8 +10,8 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@svadmin/core": "^0.36.2",
-    "@svadmin/ui": "^0.42.1",
+    "@svadmin/core": "^0.36.3",
+    "@svadmin/ui": "^0.42.2",
     "@tanstack/svelte-query": "^6.1.38",
     "highlight.js": "^11.11.1",
     "@lucide/svelte": "^1.31.0"


### PR DESCRIPTION
## Problem

The Release Please PR for `@svadmin/ui 0.42.2` and `@svadmin/core 0.36.3` was merged, but CI rejected the release because the canonical `create-svadmin` scaffold still referenced the previous package ranges.

## Fix

Update `packages/create-svadmin/scaffold-manifest.json` to:

- `@svadmin/core: ^0.36.3`
- `@svadmin/ui: ^0.42.2`

This keeps generated projects aligned with the workspace versions and allows the release compatibility gate to pass.

## Verification

- `bun test scripts/check-create-svadmin-compat.test.ts scripts/release-workflow-contract.test.ts` (10/10)
- `bun run lint`
- `bun run build:packages`
- `bun run test` (620/620 core tests; Vitest suites pass)
- `bun run typecheck` (0 errors, 0 warnings)
- `git diff --check`

Related: #251
